### PR TITLE
feat(db): versioned migration system (#2)

### DIFF
--- a/src/main/db.ts
+++ b/src/main/db.ts
@@ -2,6 +2,7 @@ import Database from 'better-sqlite3'
 import { app } from 'electron'
 import { join } from 'path'
 import { mkdirSync } from 'fs'
+import { runMigrations, MigrationError } from './migrations/runner'
 
 let db: Database.Database
 
@@ -16,49 +17,17 @@ export function getDb(): Database.Database {
   db.pragma('journal_mode = WAL')
   db.pragma('foreign_keys = ON')
 
-  initSchema(db)
+  const result = runMigrations(db, dbPath)
+  if (result.applied.length > 0) {
+    console.log(
+      `[db] Applied ${result.applied.length} migration(s): ${result.applied.join(', ')}`
+    )
+  }
+
   return db
 }
 
-function initSchema(db: Database.Database): void {
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS clients (
-      id        INTEGER PRIMARY KEY AUTOINCREMENT,
-      name      TEXT NOT NULL,
-      color     TEXT NOT NULL DEFAULT '#6366f1',
-      active    INTEGER NOT NULL DEFAULT 1,
-      created_at TEXT NOT NULL DEFAULT (datetime('now'))
-    );
-
-    CREATE TABLE IF NOT EXISTS entries (
-      id           INTEGER PRIMARY KEY AUTOINCREMENT,
-      client_id    INTEGER NOT NULL REFERENCES clients(id) ON DELETE CASCADE,
-      description  TEXT NOT NULL DEFAULT '',
-      started_at   TEXT NOT NULL,
-      stopped_at   TEXT,
-      heartbeat_at TEXT,
-      rounded_min  INTEGER,
-      created_at   TEXT NOT NULL DEFAULT (datetime('now'))
-    );
-
-    CREATE INDEX IF NOT EXISTS idx_entries_client_started
-      ON entries(client_id, started_at);
-
-    CREATE TABLE IF NOT EXISTS settings (
-      key   TEXT PRIMARY KEY,
-      value TEXT NOT NULL
-    );
-  `)
-
-  // Default-Settings
-  const insertSetting = db.prepare(
-    `INSERT OR IGNORE INTO settings (key, value) VALUES (?, ?)`
-  )
-  insertSetting.run('rounding_mode', 'none')
-  insertSetting.run('rounding_minutes', '15')
-  insertSetting.run('company_name', '')
-  insertSetting.run('backup_path', '')
-}
+export { MigrationError }
 
 export function recoverZombieEntries(): void {
   const db = getDb()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,8 +1,8 @@
-import { app, shell, BrowserWindow, globalShortcut, Tray, Menu, ipcMain } from 'electron'
+import { app, shell, BrowserWindow, globalShortcut, Tray, Menu, ipcMain, dialog } from 'electron'
 import { join } from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
-import { getDb, recoverZombieEntries } from './db'
+import { getDb, recoverZombieEntries, MigrationError } from './db'
 import { registerIpcHandlers } from './ipc'
 
 let mainWindow: BrowserWindow | null = null
@@ -83,7 +83,27 @@ app.whenReady().then(() => {
     optimizer.watchWindowShortcuts(window)
   })
 
-  getDb()
+  try {
+    getDb()
+  } catch (err) {
+    if (err instanceof MigrationError) {
+      dialog.showErrorBox(
+        'TimeTrack — Datenbank-Migration fehlgeschlagen',
+        `Migration #${err.migration.version} (${err.migration.name}) ist fehlgeschlagen:\n\n` +
+          `${err.cause.message}\n\n` +
+          `Deine Datenbank wurde aus dem Pre-Migration-Backup wiederhergestellt:\n${err.backupPath}\n\n` +
+          `Die App wird jetzt beendet. Bitte melde diesen Fehler.`
+      )
+    } else {
+      dialog.showErrorBox(
+        'TimeTrack — Datenbankfehler',
+        `Datenbank konnte nicht geöffnet werden:\n\n${(err as Error).message}`
+      )
+    }
+    isQuitting = true
+    app.quit()
+    return
+  }
   recoverZombieEntries()
   registerIpcHandlers()
   createWindow()

--- a/src/main/migrations/001-initial.ts
+++ b/src/main/migrations/001-initial.ts
@@ -1,0 +1,43 @@
+import type { Migration } from './index'
+
+/**
+ * v1.0.0 baseline schema. Idempotent (CREATE IF NOT EXISTS, INSERT OR IGNORE)
+ * so it runs safely on existing v1.0 installs as well as fresh ones.
+ */
+export const migration001: Migration = {
+  version: 1,
+  name: 'initial',
+  up: `
+    CREATE TABLE IF NOT EXISTS clients (
+      id        INTEGER PRIMARY KEY AUTOINCREMENT,
+      name      TEXT NOT NULL,
+      color     TEXT NOT NULL DEFAULT '#6366f1',
+      active    INTEGER NOT NULL DEFAULT 1,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    CREATE TABLE IF NOT EXISTS entries (
+      id           INTEGER PRIMARY KEY AUTOINCREMENT,
+      client_id    INTEGER NOT NULL REFERENCES clients(id) ON DELETE CASCADE,
+      description  TEXT NOT NULL DEFAULT '',
+      started_at   TEXT NOT NULL,
+      stopped_at   TEXT,
+      heartbeat_at TEXT,
+      rounded_min  INTEGER,
+      created_at   TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_entries_client_started
+      ON entries(client_id, started_at);
+
+    CREATE TABLE IF NOT EXISTS settings (
+      key   TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+
+    INSERT OR IGNORE INTO settings (key, value) VALUES ('rounding_mode', 'none');
+    INSERT OR IGNORE INTO settings (key, value) VALUES ('rounding_minutes', '15');
+    INSERT OR IGNORE INTO settings (key, value) VALUES ('company_name', '');
+    INSERT OR IGNORE INTO settings (key, value) VALUES ('backup_path', '');
+  `
+}

--- a/src/main/migrations/index.ts
+++ b/src/main/migrations/index.ts
@@ -1,0 +1,18 @@
+import { migration001 } from './001-initial'
+
+export interface Migration {
+  /** Monotonically increasing integer. Never reused, never reordered. */
+  version: number
+  /** Short human-readable name. Used in logs and backup filenames. */
+  name: string
+  /** Raw SQL executed inside a transaction. Must be idempotent-safe. */
+  up: string
+}
+
+/**
+ * All migrations in order. New migrations must be APPENDED, never inserted
+ * in the middle. Once shipped, a migration is immutable.
+ */
+export const migrations: Migration[] = [migration001].sort(
+  (a, b) => a.version - b.version
+)

--- a/src/main/migrations/runner.ts
+++ b/src/main/migrations/runner.ts
@@ -1,0 +1,120 @@
+import type Database from 'better-sqlite3'
+import { app } from 'electron'
+import { join } from 'path'
+import { mkdirSync, copyFileSync, existsSync } from 'fs'
+import { migrations, type Migration } from './index'
+
+const SCHEMA_VERSION_TABLE = `
+  CREATE TABLE IF NOT EXISTS schema_version (
+    version    INTEGER PRIMARY KEY,
+    name       TEXT NOT NULL,
+    applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+`
+
+export interface MigrationResult {
+  applied: number[]
+  backupPath: string | null
+}
+
+/**
+ * Apply all pending migrations in a single atomic flow.
+ *
+ * - Creates `schema_version` if missing.
+ * - Determines current version (MAX(version) or 0).
+ * - If pending migrations exist: writes a pre-migration backup.
+ * - Each migration runs in its own transaction. On failure: rollback,
+ *   restore backup, rethrow. The app must NOT continue with a partially
+ *   migrated database.
+ */
+export function runMigrations(db: Database.Database, dbPath: string): MigrationResult {
+  db.exec(SCHEMA_VERSION_TABLE)
+
+  const currentVersion = getCurrentVersion(db)
+  const pending = migrations.filter((m) => m.version > currentVersion)
+
+  if (pending.length === 0) {
+    return { applied: [], backupPath: null }
+  }
+
+  const backupPath = createPreMigrationBackup(dbPath, currentVersion)
+  const applied: number[] = []
+
+  for (const migration of pending) {
+    try {
+      applyMigration(db, migration)
+      applied.push(migration.version)
+      console.log(`[migrations] Applied #${migration.version} (${migration.name})`)
+    } catch (err) {
+      console.error(
+        `[migrations] FAILED #${migration.version} (${migration.name}):`,
+        err
+      )
+      restoreBackup(backupPath, dbPath)
+      throw new MigrationError(migration, err as Error, backupPath)
+    }
+  }
+
+  return { applied, backupPath }
+}
+
+function getCurrentVersion(db: Database.Database): number {
+  const row = db
+    .prepare('SELECT MAX(version) as v FROM schema_version')
+    .get() as { v: number | null }
+  return row.v ?? 0
+}
+
+function applyMigration(db: Database.Database, m: Migration): void {
+  const tx = db.transaction(() => {
+    db.exec(m.up)
+    db.prepare('INSERT INTO schema_version (version, name) VALUES (?, ?)').run(
+      m.version,
+      m.name
+    )
+  })
+  tx()
+}
+
+function createPreMigrationBackup(dbPath: string, fromVersion: number): string {
+  if (!existsSync(dbPath)) {
+    // Fresh install — nothing to back up. Return placeholder path.
+    return ''
+  }
+  const backupsDir = join(app.getPath('userData'), 'backups')
+  mkdirSync(backupsDir, { recursive: true })
+  const ts = new Date().toISOString().replace(/[:.]/g, '-')
+  const backupPath = join(
+    backupsDir,
+    `pre-migration-v${fromVersion}-${ts}.sqlite`
+  )
+  copyFileSync(dbPath, backupPath)
+  console.log(`[migrations] Pre-migration backup: ${backupPath}`)
+  return backupPath
+}
+
+function restoreBackup(backupPath: string, dbPath: string): void {
+  if (!backupPath || !existsSync(backupPath)) {
+    console.warn('[migrations] No backup to restore (likely fresh install).')
+    return
+  }
+  try {
+    copyFileSync(backupPath, dbPath)
+    console.log(`[migrations] Restored DB from backup: ${backupPath}`)
+  } catch (err) {
+    console.error('[migrations] Backup restore FAILED:', err)
+  }
+}
+
+export class MigrationError extends Error {
+  constructor(
+    public readonly migration: Migration,
+    public readonly cause: Error,
+    public readonly backupPath: string
+  ) {
+    super(
+      `Migration #${migration.version} (${migration.name}) failed: ${cause.message}`
+    )
+    this.name = 'MigrationError'
+  }
+}


### PR DESCRIPTION
## Summary

Closes #2 — versionsbasiertes Migration-System als v1.1-Blocker.

## Was sich ändert

- **`src/main/migrations/001-initial.ts`** — v1.0-Schema (clients, entries, settings + Default-Settings) als erste, immutable Migration. `CREATE TABLE IF NOT EXISTS` / `INSERT OR IGNORE`, also auch auf bestehenden v1.0-Installs sicher.
- **`src/main/migrations/index.ts`** — `Migration`-Type und sortiertes Registry-Array. Neue Migrationen werden nur **angehängt**, nie umsortiert.
- **`src/main/migrations/runner.ts`** — `runMigrations(db, dbPath)`:
  - Legt `schema_version` an (`version`, `name`, `applied_at`).
  - Bestimmt aktuelle Version via `MAX(version)`.
  - Bei pending Migrations: Pre-Migration-Backup nach `%AppData%/TimeTrack/backups/pre-migration-v{from}-{ts}.sqlite`.
  - Jede Migration läuft in eigener `db.transaction(...)`. Bei Fehler: Rollback (transaktional), Backup wird über die DB-Datei zurückkopiert, `MigrationError` wird geworfen.
- **`src/main/db.ts`** — ruft nach den Pragmas `runMigrations` auf, exportiert `MigrationError`.
- **`src/main/index.ts`** — fängt `MigrationError` ab, zeigt nativen Error-Dialog mit Backup-Pfad, beendet App sauber. **Lieber gar nicht starten als mit halb-migrierter DB weiterlaufen.**

## Verifikation

- `pnpm typecheck` ✅
- `pnpm build` ✅
- Bestehende v1.0-DB: Migration #1 ist idempotent → schreibt nur `schema_version (1, 'initial', ...)` und macht sonst Nullarbeit. Kein Daten­verlust möglich.
- Fresh Install: Migration #1 erstellt komplettes Schema + Default-Settings, kein Backup nötig (DB existiert noch nicht).

## Out of scope (kommen separat)

- Daily-Backup-Rotation → #6
- Settings-UI „Backup jetzt erstellen" → #5
