### PR TITLE
feat: auto-backup with daily rotation (#6)

### DIFF
--- a/src/main/backup.test.ts
+++ b/src/main/backup.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, existsSync, statSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+// Mock electron's `app.getPath('userData')` so backup.ts works in node tests.
+let userDataDir: string
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (key: string) => {
+      if (key === 'userData') return userDataDir
+      throw new Error(`Unexpected getPath key: ${key}`)
+    }
+  }
+}))
+
+beforeEach(() => {
+  userDataDir = mkdtempSync(join(tmpdir(), 'tt-backup-'))
+})
+
+afterEach(() => {
+  rmSync(userDataDir, { recursive: true, force: true })
+  vi.resetModules()
+})
+
+async function loadBackup(): Promise<typeof import('./backup')> {
+  // Re-import per test so the mocked electron is fresh.
+  return await import('./backup')
+}
+
+function makeFile(path: string, content = 'x'): void {
+  writeFileSync(path, content)
+}
+
+describe('createBackupSync', () => {
+  it('returns null when source DB does not exist', async () => {
+    const { createBackupSync } = await loadBackup()
+    const missing = join(userDataDir, 'nope.sqlite')
+    expect(createBackupSync(missing, 'pre-migration', 0)).toBeNull()
+  })
+
+  it('copies file to backups dir with pre-migration naming', async () => {
+    const { createBackupSync, getBackupsDir } = await loadBackup()
+    const src = join(userDataDir, 'src.sqlite')
+    makeFile(src, 'data')
+    const target = createBackupSync(src, 'pre-migration', 3)
+    expect(target).not.toBeNull()
+    expect(existsSync(target!)).toBe(true)
+    expect(target!).toContain('backup-pre-migration-v3-')
+    expect(target!.startsWith(getBackupsDir())).toBe(true)
+  })
+})
+
+describe('listBackups', () => {
+  it('classifies daily / manual / pre-migration / legacy', async () => {
+    const { listBackups, getBackupsDir } = await loadBackup()
+    const dir = getBackupsDir()
+    makeFile(join(dir, 'backup-daily-2026-04-20.sqlite'))
+    makeFile(join(dir, 'backup-daily-2026-04-21.sqlite'))
+    makeFile(join(dir, 'backup-manual-2026-04-22T10-00-00-000Z.sqlite'))
+    makeFile(join(dir, 'backup-pre-migration-v0-2026-04-23T00-00-00-000Z.sqlite'))
+    makeFile(join(dir, 'pre-migration-v0-old-format.sqlite')) // legacy
+    makeFile(join(dir, 'unrelated.txt'))
+
+    const list = listBackups()
+    const reasons = list.map((b) => b.reason).sort()
+    expect(reasons).toEqual([
+      'daily',
+      'daily',
+      'manual',
+      'pre-migration',
+      'pre-migration'
+    ])
+    // Newest first
+    const dailies = list.filter((b) => b.reason === 'daily')
+    expect(dailies[0].filename).toContain('2026-04-21')
+  })
+
+  it('returns empty array for empty backups dir', async () => {
+    const { listBackups } = await loadBackup()
+    expect(listBackups()).toEqual([])
+  })
+})
+
+describe('rotateDailyBackups', () => {
+  it('keeps last N daily backups, deletes older', async () => {
+    const { rotateDailyBackups, listBackups, getBackupsDir } = await loadBackup()
+    const dir = getBackupsDir()
+    // 10 daily backups
+    for (let i = 1; i <= 10; i++) {
+      const day = String(i).padStart(2, '0')
+      makeFile(join(dir, `backup-daily-2026-04-${day}.sqlite`))
+    }
+    const deleted = rotateDailyBackups(7)
+    expect(deleted).toHaveLength(3)
+    const remaining = listBackups().filter((b) => b.reason === 'daily')
+    expect(remaining).toHaveLength(7)
+    // The 7 newest (04 to 10) should remain — the oldest 3 (01-03) deleted.
+    expect(remaining.map((b) => b.filename).sort()).toEqual([
+      'backup-daily-2026-04-04.sqlite',
+      'backup-daily-2026-04-05.sqlite',
+      'backup-daily-2026-04-06.sqlite',
+      'backup-daily-2026-04-07.sqlite',
+      'backup-daily-2026-04-08.sqlite',
+      'backup-daily-2026-04-09.sqlite',
+      'backup-daily-2026-04-10.sqlite'
+    ])
+  })
+
+  it('never deletes manual or pre-migration backups', async () => {
+    const { rotateDailyBackups, listBackups, getBackupsDir } = await loadBackup()
+    const dir = getBackupsDir()
+    makeFile(join(dir, 'backup-manual-2026-01-01T00-00-00-000Z.sqlite'))
+    makeFile(join(dir, 'backup-pre-migration-v0-2026-01-01T00-00-00-000Z.sqlite'))
+    for (let i = 1; i <= 10; i++) {
+      const day = String(i).padStart(2, '0')
+      makeFile(join(dir, `backup-daily-2026-04-${day}.sqlite`))
+    }
+    rotateDailyBackups(2)
+    const list = listBackups()
+    expect(list.filter((b) => b.reason === 'manual')).toHaveLength(1)
+    expect(list.filter((b) => b.reason === 'pre-migration')).toHaveLength(1)
+    expect(list.filter((b) => b.reason === 'daily')).toHaveLength(2)
+  })
+})
+
+describe('restoreBackup', () => {
+  it('throws when backup file does not exist', async () => {
+    const { restoreBackup } = await loadBackup()
+    expect(() =>
+      restoreBackup(join(userDataDir, 'missing.sqlite'), join(userDataDir, 'db.sqlite'))
+    ).toThrow(/not found/i)
+  })
+
+  it('overwrites current DB and creates a safety copy', async () => {
+    const { restoreBackup, listBackups } = await loadBackup()
+    const currentDb = join(userDataDir, 'current.sqlite')
+    const backup = join(userDataDir, 'backup.sqlite')
+    makeFile(currentDb, 'CURRENT')
+    makeFile(backup, 'BACKUP')
+
+    const { safetyBackupPath } = restoreBackup(backup, currentDb)
+
+    expect(existsSync(safetyBackupPath)).toBe(true)
+    expect(safetyBackupPath).toContain('backup-pre-restore-')
+    // Current DB now holds backup contents
+    const current = require('fs').readFileSync(currentDb, 'utf-8')
+    expect(current).toBe('BACKUP')
+    // Safety copy holds the prior contents
+    const safety = require('fs').readFileSync(safetyBackupPath, 'utf-8')
+    expect(safety).toBe('CURRENT')
+    // Safety is listed (mtime-based, not classified as daily)
+    const list = listBackups()
+    expect(list.some((b) => b.filename.startsWith('backup-pre-restore-'))).toBe(false)
+    // Note: 'pre-restore' isn't classified by our listBackups schema, that's
+    // intentional — pre-restore safety copies are diagnostic, not user-facing.
+    // We just sanity-check the file size > 0.
+    expect(statSync(safetyBackupPath).size).toBeGreaterThan(0)
+  })
+})

--- a/src/main/backup.ts
+++ b/src/main/backup.ts
@@ -1,0 +1,193 @@
+import type Database from 'better-sqlite3'
+import { app } from 'electron'
+import { join } from 'path'
+import {
+  mkdirSync,
+  existsSync,
+  copyFileSync,
+  readdirSync,
+  statSync,
+  unlinkSync
+} from 'fs'
+
+export type BackupReason = 'daily' | 'manual' | 'pre-migration'
+
+export interface BackupInfo {
+  filename: string
+  fullPath: string
+  reason: BackupReason
+  /** ISO timestamp from filename (daily) or file mtime (others). */
+  createdAt: string
+  sizeBytes: number
+}
+
+const DAILY_RETENTION = 7
+
+/**
+ * Naming scheme:
+ *   daily         -> backup-daily-YYYY-MM-DD.sqlite
+ *   manual        -> backup-manual-YYYY-MM-DDTHH-mm-ss-sssZ.sqlite
+ *   pre-migration -> backup-pre-migration-v{from}-YYYY-MM-DDTHH-mm-ss-sssZ.sqlite
+ *
+ * Rotation only deletes `daily` backups; manual + pre-migration are kept forever.
+ */
+
+export function getBackupsDir(): string {
+  const dir = join(app.getPath('userData'), 'backups')
+  mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+function isoTimestamp(): string {
+  return new Date().toISOString().replace(/[:.]/g, '-')
+}
+
+function todayDate(): string {
+  return new Date().toISOString().slice(0, 10) // YYYY-MM-DD
+}
+
+function buildFilename(reason: BackupReason, fromVersion?: number): string {
+  switch (reason) {
+    case 'daily':
+      return `backup-daily-${todayDate()}.sqlite`
+    case 'manual':
+      return `backup-manual-${isoTimestamp()}.sqlite`
+    case 'pre-migration':
+      return `backup-pre-migration-v${fromVersion ?? 0}-${isoTimestamp()}.sqlite`
+  }
+}
+
+function classify(filename: string): BackupReason | null {
+  if (filename.startsWith('backup-daily-')) return 'daily'
+  if (filename.startsWith('backup-manual-')) return 'manual'
+  if (filename.startsWith('backup-pre-migration-')) return 'pre-migration'
+  // Legacy v1.1.0 pre-migration filename.
+  if (filename.startsWith('pre-migration-')) return 'pre-migration'
+  return null
+}
+
+/**
+ * Create a backup using better-sqlite3's atomic backup API.
+ * Safe even with concurrent writers (uses SQLite's online backup).
+ */
+export async function createBackup(
+  db: Database.Database,
+  reason: BackupReason,
+  fromVersion?: number
+): Promise<string> {
+  const dir = getBackupsDir()
+  const targetPath = join(dir, buildFilename(reason, fromVersion))
+  // db.backup() returns a Promise that resolves with progress info.
+  await db.backup(targetPath)
+  console.log(`[backup] Created (${reason}): ${targetPath}`)
+  return targetPath
+}
+
+/**
+ * Synchronous backup variant for the migration runner, which runs before the
+ * better-sqlite3 backup API can be used safely (we want a hard file copy of
+ * the on-disk state, not a live snapshot).
+ */
+export function createBackupSync(
+  dbPath: string,
+  reason: BackupReason,
+  fromVersion?: number
+): string | null {
+  if (!existsSync(dbPath)) return null
+  const dir = getBackupsDir()
+  const targetPath = join(dir, buildFilename(reason, fromVersion))
+  copyFileSync(dbPath, targetPath)
+  console.log(`[backup] Created sync (${reason}): ${targetPath}`)
+  return targetPath
+}
+
+export function listBackups(): BackupInfo[] {
+  const dir = getBackupsDir()
+  const entries = readdirSync(dir)
+  const result: BackupInfo[] = []
+  for (const filename of entries) {
+    if (!filename.endsWith('.sqlite')) continue
+    const reason = classify(filename)
+    if (!reason) continue
+    const fullPath = join(dir, filename)
+    const stat = statSync(fullPath)
+    let createdAt: string
+    if (reason === 'daily') {
+      const m = filename.match(/(\d{4}-\d{2}-\d{2})/)
+      createdAt = m ? `${m[1]}T00:00:00.000Z` : stat.mtime.toISOString()
+    } else {
+      createdAt = stat.mtime.toISOString()
+    }
+    result.push({
+      filename,
+      fullPath,
+      reason,
+      createdAt,
+      sizeBytes: stat.size
+    })
+  }
+  return result.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1))
+}
+
+/**
+ * Keep only the last N daily backups. Manual + pre-migration are never deleted.
+ */
+export function rotateDailyBackups(retain = DAILY_RETENTION): string[] {
+  const dailies = listBackups().filter((b) => b.reason === 'daily')
+  // listBackups returns newest first; entries beyond `retain` are old.
+  const toDelete = dailies.slice(retain)
+  for (const b of toDelete) {
+    try {
+      unlinkSync(b.fullPath)
+      console.log(`[backup] Rotated out: ${b.filename}`)
+    } catch (err) {
+      console.warn(`[backup] Could not delete ${b.filename}:`, err)
+    }
+  }
+  return toDelete.map((b) => b.filename)
+}
+
+/**
+ * Create today's daily backup if it doesn't already exist.
+ * Failures are logged but never thrown — backup must not block app start.
+ */
+export async function runDailyBackupIfNeeded(db: Database.Database): Promise<void> {
+  try {
+    const today = todayDate()
+    const existing = listBackups().find(
+      (b) => b.reason === 'daily' && b.filename.includes(today)
+    )
+    if (existing) return
+    await createBackup(db, 'daily')
+    rotateDailyBackups()
+  } catch (err) {
+    console.warn('[backup] Daily backup failed (non-fatal):', err)
+  }
+}
+
+/**
+ * Restore a backup file over the current DB. Caller is responsible for closing
+ * the existing DB handle and prompting the user to restart the app.
+ *
+ * Before overwriting, a safety copy of the current DB is created so the user
+ * can roll back if the chosen backup turns out to be worse than the current
+ * state.
+ */
+export function restoreBackup(
+  backupPath: string,
+  currentDbPath: string
+): { safetyBackupPath: string } {
+  if (!existsSync(backupPath)) {
+    throw new Error(`Backup file not found: ${backupPath}`)
+  }
+  // Safety copy of the current DB before destruction.
+  const dir = getBackupsDir()
+  const safetyName = `backup-pre-restore-${isoTimestamp()}.sqlite`
+  const safetyBackupPath = join(dir, safetyName)
+  if (existsSync(currentDbPath)) {
+    copyFileSync(currentDbPath, safetyBackupPath)
+  }
+  copyFileSync(backupPath, currentDbPath)
+  console.log(`[backup] Restored ${backupPath} -> ${currentDbPath}`)
+  return { safetyBackupPath }
+}

--- a/src/main/db.ts
+++ b/src/main/db.ts
@@ -3,28 +3,37 @@ import { app } from 'electron'
 import { join } from 'path'
 import { mkdirSync } from 'fs'
 import { runMigrations, MigrationError } from './migrations/runner'
+import { runDailyBackupIfNeeded } from './backup'
 
 let db: Database.Database
+let _dbPath: string
 
 export function getDb(): Database.Database {
   if (db) return db
 
   const userDataPath = app.getPath('userData')
   mkdirSync(userDataPath, { recursive: true })
-  const dbPath = join(userDataPath, 'timetrack.sqlite')
+  _dbPath = join(userDataPath, 'timetrack.sqlite')
 
-  db = new Database(dbPath)
+  db = new Database(_dbPath)
   db.pragma('journal_mode = WAL')
   db.pragma('foreign_keys = ON')
 
-  const result = runMigrations(db, dbPath)
+  const result = runMigrations(db, _dbPath)
   if (result.applied.length > 0) {
     console.log(
       `[db] Applied ${result.applied.length} migration(s): ${result.applied.join(', ')}`
     )
   }
 
+  // Daily backup is fire-and-forget — must not block startup or throw.
+  void runDailyBackupIfNeeded(db)
+
   return db
+}
+
+export function getDbPath(): string {
+  return _dbPath
 }
 
 export { MigrationError }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,5 +1,11 @@
 import { ipcMain } from 'electron'
-import { getDb } from './db'
+import { app } from 'electron'
+import { getDb, getDbPath } from './db'
+import {
+  createBackup,
+  listBackups,
+  restoreBackup as restoreBackupFile
+} from './backup'
 import type {
   Client,
   Entry,
@@ -9,7 +15,8 @@ import type {
   UpdateEntryInput,
   MonthQuery,
   Settings,
-  IpcResult
+  IpcResult,
+  BackupInfo
 } from '../shared/types'
 
 function ok<T>(data: T): IpcResult<T> {
@@ -190,5 +197,46 @@ export function registerIpcHandlers(): void {
     } catch (e) {
       return fail(e)
     }
+  })
+
+  // ── Backups ───────────────────────────────────
+  ipcMain.handle('backup:list', (): IpcResult<BackupInfo[]> => {
+    try {
+      return ok(listBackups())
+    } catch (e) {
+      return fail(e)
+    }
+  })
+
+  ipcMain.handle('backup:create', async (): Promise<IpcResult<string>> => {
+    try {
+      const path = await createBackup(db, 'manual')
+      return ok(path)
+    } catch (e) {
+      return fail(e)
+    }
+  })
+
+  ipcMain.handle(
+    'backup:restore',
+    (_e, filePath: string): IpcResult<{ safetyBackupPath: string }> => {
+      try {
+        // Close the live DB so the file can be replaced. App must restart
+        // afterwards; the renderer is expected to call app.relaunch via a
+        // separate IPC or a manual user action.
+        const dbPath = getDbPath()
+        db.close()
+        const result = restoreBackupFile(filePath, dbPath)
+        return ok(result)
+      } catch (e) {
+        return fail(e)
+      }
+    }
+  )
+
+  ipcMain.handle('app:relaunch', (): IpcResult<void> => {
+    app.relaunch()
+    app.exit(0)
+    return ok(undefined)
   })
 }

--- a/src/main/migrations/runner.ts
+++ b/src/main/migrations/runner.ts
@@ -1,8 +1,7 @@
 import type Database from 'better-sqlite3'
-import { app } from 'electron'
-import { join } from 'path'
-import { mkdirSync, copyFileSync, existsSync } from 'fs'
+import { existsSync, copyFileSync } from 'fs'
 import { migrations, type Migration } from './index'
+import { createBackupSync } from '../backup'
 
 const SCHEMA_VERSION_TABLE = `
   CREATE TABLE IF NOT EXISTS schema_version (
@@ -37,7 +36,7 @@ export function runMigrations(db: Database.Database, dbPath: string): MigrationR
     return { applied: [], backupPath: null }
   }
 
-  const backupPath = createPreMigrationBackup(dbPath, currentVersion)
+  const backupPath = createBackupSync(dbPath, 'pre-migration', currentVersion) ?? ''
   const applied: number[] = []
 
   for (const migration of pending) {
@@ -74,23 +73,6 @@ function applyMigration(db: Database.Database, m: Migration): void {
     )
   })
   tx()
-}
-
-function createPreMigrationBackup(dbPath: string, fromVersion: number): string {
-  if (!existsSync(dbPath)) {
-    // Fresh install — nothing to back up. Return placeholder path.
-    return ''
-  }
-  const backupsDir = join(app.getPath('userData'), 'backups')
-  mkdirSync(backupsDir, { recursive: true })
-  const ts = new Date().toISOString().replace(/[:.]/g, '-')
-  const backupPath = join(
-    backupsDir,
-    `pre-migration-v${fromVersion}-${ts}.sqlite`
-  )
-  copyFileSync(dbPath, backupPath)
-  console.log(`[migrations] Pre-migration backup: ${backupPath}`)
-  return backupPath
 }
 
 function restoreBackup(backupPath: string, dbPath: string): void {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -8,7 +8,8 @@ import type {
   UpdateEntryInput,
   MonthQuery,
   Settings,
-  IpcResult
+  IpcResult,
+  BackupInfo
 } from '../shared/types'
 
 declare global {
@@ -37,6 +38,14 @@ declare global {
       settings: {
         getAll(): Promise<IpcResult<Settings>>
         set(key: string, value: string): Promise<IpcResult<void>>
+      }
+      backups: {
+        list(): Promise<IpcResult<BackupInfo[]>>
+        create(): Promise<IpcResult<string>>
+        restore(filePath: string): Promise<IpcResult<{ safetyBackupPath: string }>>
+      }
+      app: {
+        relaunch(): Promise<IpcResult<void>>
       }
     }
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -9,7 +9,8 @@ import type {
   UpdateEntryInput,
   MonthQuery,
   Settings,
-  IpcResult
+  IpcResult,
+  BackupInfo
 } from '../shared/types'
 
 const api = {
@@ -51,6 +52,16 @@ const api = {
     getAll: (): Promise<IpcResult<Settings>> => ipcRenderer.invoke('settings:getAll'),
     set: (key: string, value: string): Promise<IpcResult<void>> =>
       ipcRenderer.invoke('settings:set', key, value)
+  },
+  // Backups
+  backups: {
+    list: (): Promise<IpcResult<BackupInfo[]>> => ipcRenderer.invoke('backup:list'),
+    create: (): Promise<IpcResult<string>> => ipcRenderer.invoke('backup:create'),
+    restore: (filePath: string): Promise<IpcResult<{ safetyBackupPath: string }>> =>
+      ipcRenderer.invoke('backup:restore', filePath)
+  },
+  app: {
+    relaunch: (): Promise<IpcResult<void>> => ipcRenderer.invoke('app:relaunch')
   }
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -58,3 +58,13 @@ export interface MonthQuery {
 }
 
 export type IpcResult<T> = { ok: true; data: T } | { ok: false; error: string }
+
+export type BackupReason = 'daily' | 'manual' | 'pre-migration'
+
+export interface BackupInfo {
+  filename: string
+  fullPath: string
+  reason: BackupReason
+  createdAt: string
+  sizeBytes: number
+}


### PR DESCRIPTION
## Summary

Closes #6 — automatische tägliche SQLite-Backups mit Rotation.

## Was sich ändert

- **`src/main/backup.ts`** — Zentrales Backup-Modul:
  - `createBackup(db, reason)` — atomar via better-sqlite3 `.backup()`-API (sicher auch bei laufenden Schreibvorgängen).
  - `createBackupSync(dbPath, reason)` — File-Copy-Variante für den Migration-Runner (DB ist da gerade frisch geöffnet, atomare Online-Backup wäre Overkill).
  - `listBackups()` — gibt sortierte `BackupInfo[]` zurück (newest first), klassifiziert über Filename-Präfix.
  - `rotateDailyBackups(retain=7)` — löscht ausschließlich `daily`-Backups jenseits der 7-Tage-Grenze. **Manual und pre-migration werden nie gelöscht.**
  - `runDailyBackupIfNeeded(db)` — beim App-Start: legt heutiges Backup an, wenn noch keines für YYYY-MM-DD existiert. **Fehlschläge sind silent log, blockieren App-Start nicht.**
  - `restoreBackup(backupPath, dbPath)` — überschreibt aktuelle DB, legt vorher eine `backup-pre-restore-*` Sicherheitskopie an.
- **`src/main/migrations/runner.ts`** — nutzt jetzt `createBackupSync` aus dem zentralen Modul (single source of truth, alte Inline-Backup-Logik entfernt). Filename-Schema vereinheitlicht auf `backup-pre-migration-v{n}-{ts}.sqlite`. Legacy-Filename `pre-migration-*` wird in `listBackups()` weiterhin erkannt.
- **`src/main/db.ts`** — ruft `void runDailyBackupIfNeeded(db)` nach erfolgreichen Migrationen. Exportiert `getDbPath()` für die Restore-IPC.
- **`src/main/ipc.ts`** — drei neue Handler: `backup:list`, `backup:create` (manual), `backup:restore` (schließt DB, ruft `restoreBackup`). Plus `app:relaunch` für den Restart-Flow nach Restore.
- **`src/preload/index.ts` + `index.d.ts`** — `window.api.backups.{list,create,restore}` und `window.api.app.relaunch`.
- **`src/shared/types.ts`** — `BackupReason`, `BackupInfo`.

## Tests

- **`src/main/backup.test.ts`** — 8 Tests, alle laufen unter Node (electron-Modul wird gemockt):
  - `createBackupSync` Null bei fehlender Source, korrekte Filename-Konvention
  - `listBackups` Klassifizierung (daily/manual/pre-migration/legacy), Sortierung
  - `rotateDailyBackups` schneidet auf N, lässt manual + pre-migration in Ruhe
  - `restoreBackup` wirft bei fehlender Source, überschreibt korrekt, legt Safety-Copy an

Lokal: 18 passed | 7 skipped (DB-Suite skippt unter Node-ABI-Mismatch wie gehabt).

## Acceptance Criteria

- [x] `createBackup(reason)` Funktion in `src/main/backup.ts`
- [x] Daily-Backup automatisch beim App-Start
- [x] Rotation behält 7 tägliche, alle pre-migration, alle manual
- [x] `restoreBackup(filePath)` mit Safety-Backup der aktuellen DB
- [x] Backup-Liste-IPC für #5 (Settings-View)
- [x] Fehlschlag silent log, App startet trotzdem (`runDailyBackupIfNeeded` fängt alles)

## Out of scope

- Settings-UI mit Backup-Liste / „Backup jetzt erstellen"-Button → #5
