### PR TITLE
feat(v1.1): idle-detection, tray quick-start, settings view

### DIFF
--- a/src/main/idle.ts
+++ b/src/main/idle.ts
@@ -1,0 +1,64 @@
+import { powerMonitor, BrowserWindow } from 'electron'
+
+/**
+ * Polls system idle time and emits `timer:idle-detected` to the renderer
+ * exactly once per idle episode. Renderer is responsible for showing the
+ * modal and acknowledging via `idle:dismiss` to re-arm.
+ *
+ * Polling only runs while a timer is active (renderer toggles via setActive).
+ */
+const POLL_INTERVAL_MS = 30_000
+
+let timer: NodeJS.Timeout | null = null
+let active = false
+let alreadyEmitted = false
+let thresholdSeconds = 300 // default 5 min, overridden by setThreshold
+let getWindow: () => BrowserWindow | null = () => null
+
+export function configureIdleWatcher(opts: {
+  getWindow: () => BrowserWindow | null
+}): void {
+  getWindow = opts.getWindow
+}
+
+export function setIdleThresholdMinutes(minutes: number): void {
+  // Clamp to reasonable range (1 min to 12h).
+  const clamped = Math.max(1, Math.min(720, minutes))
+  thresholdSeconds = clamped * 60
+}
+
+export function startIdleWatcher(): void {
+  if (active) return
+  active = true
+  alreadyEmitted = false
+  if (timer) clearInterval(timer)
+  timer = setInterval(check, POLL_INTERVAL_MS)
+}
+
+export function stopIdleWatcher(): void {
+  active = false
+  alreadyEmitted = false
+  if (timer) {
+    clearInterval(timer)
+    timer = null
+  }
+}
+
+/** Renderer dismisses the modal — re-arm so the next idle episode can fire. */
+export function rearmIdleWatcher(): void {
+  alreadyEmitted = false
+}
+
+function check(): void {
+  if (!active || alreadyEmitted) return
+  const idleSeconds = powerMonitor.getSystemIdleTime()
+  if (idleSeconds >= thresholdSeconds) {
+    const idleSinceMs = Date.now() - idleSeconds * 1000
+    const idleSince = new Date(idleSinceMs).toISOString()
+    const win = getWindow()
+    if (win && !win.isDestroyed()) {
+      win.webContents.send('timer:idle-detected', { idleSince, idleSeconds })
+      alreadyEmitted = true
+    }
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,40 +1,140 @@
-import { app, shell, BrowserWindow, globalShortcut, Tray, Menu, ipcMain, dialog } from 'electron'
+import {
+  app,
+  shell,
+  BrowserWindow,
+  globalShortcut,
+  Tray,
+  Menu,
+  ipcMain,
+  dialog,
+  type MenuItemConstructorOptions
+} from 'electron'
 import { join } from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
 import { getDb, recoverZombieEntries, MigrationError } from './db'
 import { registerIpcHandlers } from './ipc'
+import {
+  configureIdleWatcher,
+  setIdleThresholdMinutes,
+  startIdleWatcher,
+  stopIdleWatcher,
+  rearmIdleWatcher
+} from './idle'
+import type { Client } from '../shared/types'
 
 let mainWindow: BrowserWindow | null = null
 let tray: Tray | null = null
 let isQuitting = false
 
-function updateTray(isRunning: boolean, label: string): void {
-  if (!tray) return
-  tray.setToolTip(isRunning ? `TimeTrack ● ${label}` : 'TimeTrack — Kein Timer aktiv')
-  const menu = Menu.buildFromTemplate([
-    {
-      label: isRunning ? `● ${label}` : 'Kein Timer aktiv',
-      enabled: false
-    },
-    { type: 'separator' },
-    {
-      label: 'Fenster anzeigen',
-      click: () => {
-        mainWindow?.show()
-        mainWindow?.focus()
-      }
-    },
-    { type: 'separator' },
-    {
-      label: 'Beenden',
-      click: () => {
-        isQuitting = true
-        app.quit()
-      }
+// ── State for tray quick-start ──────────────────────────────────
+let cachedActiveClients: Client[] = []
+let isTimerRunning = false
+let runningLabel = ''
+
+function refreshActiveClients(): void {
+  try {
+    const db = getDb()
+    cachedActiveClients = db
+      .prepare(`SELECT * FROM clients WHERE active = 1 ORDER BY name ASC`)
+      .all() as Client[]
+  } catch (err) {
+    console.warn('[tray] could not refresh client cache:', err)
+    cachedActiveClients = []
+  }
+}
+
+function buildTrayMenu(): Menu {
+  const items: MenuItemConstructorOptions[] = []
+
+  items.push({
+    label: isTimerRunning ? `● ${runningLabel}` : 'Kein Timer aktiv',
+    enabled: false
+  })
+  items.push({ type: 'separator' })
+
+  if (isTimerRunning) {
+    items.push({
+      label: 'Stop',
+      click: () => mainWindow?.webContents.send('timer:tray-stop')
+    })
+  } else if (cachedActiveClients.length > 0) {
+    const quickStart: MenuItemConstructorOptions[] = cachedActiveClients
+      .slice(0, 10) // soft limit so menu stays usable
+      .map((c) => ({
+        label: `▶ ${c.name}`,
+        click: () => mainWindow?.webContents.send('timer:tray-quick-start', c.id)
+      }))
+    items.push({ label: 'Quick-Start', enabled: false })
+    items.push(...quickStart)
+  } else {
+    items.push({ label: 'Keine aktiven Kunden', enabled: false })
+  }
+
+  items.push({ type: 'separator' })
+  items.push({
+    label: 'Fenster anzeigen',
+    click: () => {
+      mainWindow?.show()
+      mainWindow?.focus()
     }
-  ])
-  tray.setContextMenu(menu)
+  })
+  items.push({ type: 'separator' })
+  items.push({
+    label: 'Beenden',
+    click: () => {
+      isQuitting = true
+      app.quit()
+    }
+  })
+
+  return Menu.buildFromTemplate(items)
+}
+
+function updateTray(running: boolean, label: string): void {
+  if (!tray) return
+  isTimerRunning = running
+  runningLabel = label
+  tray.setToolTip(running ? `TimeTrack ● ${label}` : 'TimeTrack — Kein Timer aktiv')
+  tray.setContextMenu(buildTrayMenu())
+}
+
+function registerHotkey(accelerator: string): boolean {
+  globalShortcut.unregisterAll()
+  if (!accelerator) return false
+  const ok = globalShortcut.register(accelerator, () => {
+    mainWindow?.webContents.send('timer:hotkey-toggle')
+  })
+  if (!ok) console.warn(`[hotkey] Could not register ${accelerator}`)
+  return ok
+}
+
+function applyAutoStart(enabled: boolean): void {
+  app.setLoginItemSettings({
+    openAtLogin: enabled,
+    path: process.execPath,
+    args: []
+  })
+}
+
+function loadStartupSettings(): void {
+  try {
+    const db = getDb()
+    const rows = db.prepare(`SELECT key, value FROM settings`).all() as Array<{
+      key: string
+      value: string
+    }>
+    const map = Object.fromEntries(rows.map((r) => [r.key, r.value]))
+    const idleMin = parseInt(map.idle_threshold_minutes ?? '5', 10)
+    setIdleThresholdMinutes(Number.isFinite(idleMin) ? idleMin : 5)
+    const hotkey = map.hotkey_toggle ?? 'Alt+Shift+S'
+    registerHotkey(hotkey)
+    const auto = map.auto_start === '1'
+    applyAutoStart(auto)
+  } catch (err) {
+    console.warn('[startup] settings load failed (using defaults):', err)
+    registerHotkey('Alt+Shift+S')
+  }
 }
 
 function createWindow(): void {
@@ -56,7 +156,6 @@ function createWindow(): void {
     mainWindow!.show()
   })
 
-  // Minimize to tray on close
   mainWindow.on('close', (e) => {
     if (!isQuitting) {
       e.preventDefault()
@@ -105,10 +204,21 @@ app.whenReady().then(() => {
     return
   }
   recoverZombieEntries()
-  registerIpcHandlers()
+  registerIpcHandlers({
+    refreshTrayClients: () => {
+      refreshActiveClients()
+      tray?.setContextMenu(buildTrayMenu())
+    },
+    setHotkey: (accelerator) => registerHotkey(accelerator),
+    setAutoStart: (enabled) => applyAutoStart(enabled),
+    setIdleThreshold: (minutes) => setIdleThresholdMinutes(minutes)
+  })
   createWindow()
 
-  // System tray
+  refreshActiveClients()
+  configureIdleWatcher({ getWindow: () => mainWindow })
+  loadStartupSettings()
+
   tray = new Tray(icon)
   updateTray(false, '')
   tray.on('click', () => {
@@ -120,20 +230,17 @@ app.whenReady().then(() => {
     }
   })
 
-  // Global hotkey Alt+Shift+S → toggle timer in renderer
-  const registered = globalShortcut.register('Alt+Shift+S', () => {
-    mainWindow?.webContents.send('timer:hotkey-toggle')
-  })
-  if (!registered) {
-    console.warn('Global hotkey Alt+Shift+S could not be registered')
-  }
-
-  // Renderer notifies main to update tray state
-  ipcMain.on('tray:update', (_event, isRunning: boolean, label: string) => {
-    updateTray(isRunning, label)
+  // Renderer notifies main to update tray state + drive idle watcher.
+  ipcMain.on('tray:update', (_event, running: boolean, label: string) => {
+    updateTray(running, label)
+    if (running) startIdleWatcher()
+    else stopIdleWatcher()
   })
 
-  app.on('activate', function () {
+  // Renderer dismissed idle modal — re-arm.
+  ipcMain.on('idle:dismiss', () => rearmIdleWatcher())
+
+  app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow()
   })
 })
@@ -144,6 +251,7 @@ app.on('before-quit', () => {
 
 app.on('will-quit', () => {
   globalShortcut.unregisterAll()
+  stopIdleWatcher()
 })
 
 app.on('window-all-closed', () => {
@@ -151,6 +259,3 @@ app.on('window-all-closed', () => {
     app.quit()
   }
 })
-
-// In this file you can include the rest of your app's specific main process
-// code. You can also put them in separate files and require them here.

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,6 +1,7 @@
-import { ipcMain } from 'electron'
+import { ipcMain, shell } from 'electron'
 import { app } from 'electron'
 import { getDb, getDbPath } from './db'
+import { getBackupsDir } from './backup'
 import {
   createBackup,
   listBackups,
@@ -19,6 +20,13 @@ import type {
   BackupInfo
 } from '../shared/types'
 
+export interface IpcHooks {
+  refreshTrayClients(): void
+  setHotkey(accelerator: string): boolean
+  setAutoStart(enabled: boolean): void
+  setIdleThreshold(minutes: number): void
+}
+
 function ok<T>(data: T): IpcResult<T> {
   return { ok: true, data }
 }
@@ -26,7 +34,7 @@ function fail(error: unknown): IpcResult<never> {
   return { ok: false, error: String(error) }
 }
 
-export function registerIpcHandlers(): void {
+export function registerIpcHandlers(hooks: IpcHooks): void {
   const db = getDb()
 
   // ── Clients ──────────────────────────────────────────────────
@@ -47,6 +55,7 @@ export function registerIpcHandlers(): void {
       const row = db
         .prepare(`SELECT * FROM clients WHERE id = ?`)
         .get(info.lastInsertRowid) as Client
+      hooks.refreshTrayClients()
       return ok(row)
     } catch (e) {
       return fail(e)
@@ -62,6 +71,7 @@ export function registerIpcHandlers(): void {
         input.id
       )
       const row = db.prepare(`SELECT * FROM clients WHERE id = ?`).get(input.id) as Client
+      hooks.refreshTrayClients()
       return ok(row)
     } catch (e) {
       return fail(e)
@@ -71,6 +81,7 @@ export function registerIpcHandlers(): void {
   ipcMain.handle('clients:delete', (_e, id: number): IpcResult<void> => {
     try {
       db.prepare(`DELETE FROM clients WHERE id = ?`).run(id)
+      hooks.refreshTrayClients()
       return ok(undefined)
     } catch (e) {
       return fail(e)
@@ -193,6 +204,16 @@ export function registerIpcHandlers(): void {
   ipcMain.handle('settings:set', (_e, key: string, value: string): IpcResult<void> => {
     try {
       db.prepare(`INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)`).run(key, value)
+      // Apply side-effects for known keys.
+      if (key === 'idle_threshold_minutes') {
+        const n = parseInt(value, 10)
+        if (Number.isFinite(n)) hooks.setIdleThreshold(n)
+      } else if (key === 'auto_start') {
+        hooks.setAutoStart(value === '1')
+      } else if (key === 'hotkey_toggle') {
+        const okHotkey = hooks.setHotkey(value)
+        if (!okHotkey) return fail(`Hotkey "${value}" konnte nicht registriert werden`)
+      }
       return ok(undefined)
     } catch (e) {
       return fail(e)
@@ -238,5 +259,26 @@ export function registerIpcHandlers(): void {
     app.relaunch()
     app.exit(0)
     return ok(undefined)
+  })
+
+  // ── Shell helpers ────────────────────────────────
+  ipcMain.handle('shell:openPath', async (_e, path: string): Promise<IpcResult<void>> => {
+    const err = await shell.openPath(path)
+    if (err) return fail(err)
+    return ok(undefined)
+  })
+
+  ipcMain.handle('shell:showItemInFolder', (_e, path: string): IpcResult<void> => {
+    shell.showItemInFolder(path)
+    return ok(undefined)
+  })
+
+  // ── Paths (for Settings-View) ──────────────────────────
+  ipcMain.handle('paths:get', (): IpcResult<{ db: string; backups: string }> => {
+    return ok({ db: getDbPath(), backups: getBackupsDir() })
+  })
+
+  ipcMain.handle('app:getVersion', (): IpcResult<string> => {
+    return ok(app.getVersion())
   })
 }

--- a/src/main/migrations/002-v11-settings.ts
+++ b/src/main/migrations/002-v11-settings.ts
@@ -1,0 +1,19 @@
+import type { Migration } from './index'
+
+/**
+ * v1.1 settings additions:
+ * - idle_threshold_minutes — for idle-detection modal
+ * - language              — UI language stub (i18n proper lands in v1.2)
+ * - auto_start            — Windows auto-launch toggle
+ * - hotkey_toggle         — global hotkey for start/stop
+ */
+export const migration002: Migration = {
+  version: 2,
+  name: 'v1.1-settings',
+  up: `
+    INSERT OR IGNORE INTO settings (key, value) VALUES ('idle_threshold_minutes', '5');
+    INSERT OR IGNORE INTO settings (key, value) VALUES ('language', 'de');
+    INSERT OR IGNORE INTO settings (key, value) VALUES ('auto_start', '0');
+    INSERT OR IGNORE INTO settings (key, value) VALUES ('hotkey_toggle', 'Alt+Shift+S');
+  `
+}

--- a/src/main/migrations/index.ts
+++ b/src/main/migrations/index.ts
@@ -1,4 +1,5 @@
 import { migration001 } from './001-initial'
+import { migration002 } from './002-v11-settings'
 
 export interface Migration {
   /** Monotonically increasing integer. Never reused, never reordered. */
@@ -13,6 +14,6 @@ export interface Migration {
  * All migrations in order. New migrations must be APPENDED, never inserted
  * in the middle. Once shipped, a migration is immutable.
  */
-export const migrations: Migration[] = [migration001].sort(
+export const migrations: Migration[] = [migration001, migration002].sort(
   (a, b) => a.version - b.version
 )

--- a/src/main/migrations/migrations.test.ts
+++ b/src/main/migrations/migrations.test.ts
@@ -106,27 +106,31 @@ describe('migration SQL execution', () => {
     expect(idx).toBeDefined()
   })
 
-  it('migration 001 seeds default settings', () => {
+  it('migrations seed default settings', () => {
     applyAll()
     const rows = db
       .prepare('SELECT key, value FROM settings ORDER BY key')
       .all()
     expect(rows).toEqual([
+      { key: 'auto_start', value: '0' },
       { key: 'backup_path', value: '' },
       { key: 'company_name', value: '' },
+      { key: 'hotkey_toggle', value: 'Alt+Shift+S' },
+      { key: 'idle_threshold_minutes', value: '5' },
+      { key: 'language', value: 'de' },
       { key: 'rounding_minutes', value: '15' },
       { key: 'rounding_mode', value: 'none' }
     ])
   })
 
-  it('migration 001 is idempotent', () => {
+  it('migrations are idempotent', () => {
     applyAll()
     db.exec('DELETE FROM schema_version')
     expect(() => applyAll()).not.toThrow()
     const count = db.prepare('SELECT COUNT(*) as n FROM settings').get() as {
       n: number
     }
-    expect(count.n).toBe(4)
+    expect(count.n).toBe(8)
   })
 
   it('foreign key cascade deletes entries when client is deleted', () => {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -20,6 +20,14 @@ declare global {
         update(isRunning: boolean, label: string): void
       }
       onHotkeyToggle(callback: () => void): () => void
+      onTrayQuickStart(callback: (clientId: number) => void): () => void
+      onTrayStop(callback: () => void): () => void
+      onIdleDetected(
+        callback: (data: { idleSince: string; idleSeconds: number }) => void
+      ): () => void
+      idle: {
+        dismiss(): void
+      }
       clients: {
         getAll(): Promise<IpcResult<Client[]>>
         create(input: CreateClientInput): Promise<IpcResult<Client>>
@@ -46,6 +54,14 @@ declare global {
       }
       app: {
         relaunch(): Promise<IpcResult<void>>
+        getVersion(): Promise<IpcResult<string>>
+      }
+      shell: {
+        openPath(path: string): Promise<IpcResult<void>>
+        showItemInFolder(path: string): Promise<IpcResult<void>>
+      }
+      paths: {
+        get(): Promise<IpcResult<{ db: string; backups: string }>>
       }
     }
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -24,6 +24,29 @@ const api = {
     ipcRenderer.on('timer:hotkey-toggle', handler)
     return () => ipcRenderer.removeListener('timer:hotkey-toggle', handler)
   },
+  onTrayQuickStart: (callback: (clientId: number) => void): (() => void) => {
+    const handler = (_e: unknown, clientId: number): void => callback(clientId)
+    ipcRenderer.on('timer:tray-quick-start', handler)
+    return () => ipcRenderer.removeListener('timer:tray-quick-start', handler)
+  },
+  onTrayStop: (callback: () => void): (() => void) => {
+    const handler = (): void => callback()
+    ipcRenderer.on('timer:tray-stop', handler)
+    return () => ipcRenderer.removeListener('timer:tray-stop', handler)
+  },
+  onIdleDetected: (
+    callback: (data: { idleSince: string; idleSeconds: number }) => void
+  ): (() => void) => {
+    const handler = (
+      _e: unknown,
+      data: { idleSince: string; idleSeconds: number }
+    ): void => callback(data)
+    ipcRenderer.on('timer:idle-detected', handler)
+    return () => ipcRenderer.removeListener('timer:idle-detected', handler)
+  },
+  idle: {
+    dismiss: (): void => ipcRenderer.send('idle:dismiss')
+  },
   // Clients
   clients: {
     getAll: (): Promise<IpcResult<Client[]>> => ipcRenderer.invoke('clients:getAll'),
@@ -61,7 +84,18 @@ const api = {
       ipcRenderer.invoke('backup:restore', filePath)
   },
   app: {
-    relaunch: (): Promise<IpcResult<void>> => ipcRenderer.invoke('app:relaunch')
+    relaunch: (): Promise<IpcResult<void>> => ipcRenderer.invoke('app:relaunch'),
+    getVersion: (): Promise<IpcResult<string>> => ipcRenderer.invoke('app:getVersion')
+  },
+  shell: {
+    openPath: (path: string): Promise<IpcResult<void>> =>
+      ipcRenderer.invoke('shell:openPath', path),
+    showItemInFolder: (path: string): Promise<IpcResult<void>> =>
+      ipcRenderer.invoke('shell:showItemInFolder', path)
+  },
+  paths: {
+    get: (): Promise<IpcResult<{ db: string; backups: string }>> =>
+      ipcRenderer.invoke('paths:get')
   }
 }
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,11 +1,15 @@
 import { useState } from 'react'
 import TimerView from './views/TimerView'
 import ClientsView from './views/ClientsView'
+import SettingsView from './views/SettingsView'
+import { IdleModal } from './components/IdleModal'
+import { useTimer } from './hooks/useTimer'
 
 type View = 'timer' | 'calendar' | 'clients' | 'settings'
 
 function App(): React.JSX.Element {
   const [view, setView] = useState<View>('timer')
+  const { idleEvent, idleKeep, idleStopAtIdle, idleMarkPause } = useTimer()
 
   return (
     <div className="h-screen bg-slate-900 text-slate-100 flex flex-col overflow-hidden">
@@ -41,14 +45,18 @@ function App(): React.JSX.Element {
           </div>
         )}
         {view === 'clients' && <ClientsView />}
-        {view === 'settings' && (
-          <div className="flex flex-col items-center justify-center mt-24 gap-3 text-slate-600">
-            <span className="text-5xl">⚙️</span>
-            <p className="font-medium text-slate-400">Einstellungen</p>
-            <p className="text-sm">Kommen in einer späteren Session.</p>
-          </div>
-        )}
+        {view === 'settings' && <SettingsView />}
       </main>
+
+      {idleEvent && (
+        <IdleModal
+          idleSince={idleEvent.idleSince}
+          idleSeconds={idleEvent.idleSeconds}
+          onKeep={idleKeep}
+          onStopAtIdle={idleStopAtIdle}
+          onMarkPause={idleMarkPause}
+        />
+      )}
     </div>
   )
 }

--- a/src/renderer/src/components/IdleModal.tsx
+++ b/src/renderer/src/components/IdleModal.tsx
@@ -1,0 +1,71 @@
+import { useEffect } from 'react'
+import { formatDuration } from '../../../shared/duration'
+
+interface Props {
+  idleSince: string
+  idleSeconds: number
+  onKeep: () => void
+  onStopAtIdle: () => void
+  onMarkPause: () => void
+}
+
+export function IdleModal({ idleSince, idleSeconds, onKeep, onStopAtIdle, onMarkPause }: Props) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') onKeep()
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [onKeep])
+
+  const idleSinceLocal = new Date(idleSince).toLocaleTimeString('de-DE', {
+    hour: '2-digit',
+    minute: '2-digit'
+  })
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="idle-modal-title"
+    >
+      <div className="w-[460px] rounded-xl bg-zinc-900 p-6 shadow-2xl ring-1 ring-zinc-700">
+        <h2 id="idle-modal-title" className="mb-2 text-xl font-semibold text-zinc-100">
+          Inaktivität erkannt
+        </h2>
+        <p className="mb-6 text-sm text-zinc-400">
+          Du warst seit <span className="font-mono text-zinc-200">{idleSinceLocal}</span> nicht
+          mehr aktiv ({formatDuration(idleSeconds)}). Was soll mit der Zeit passieren?
+        </p>
+        <div className="flex flex-col gap-2">
+          <button
+            type="button"
+            onClick={onKeep}
+            className="rounded-lg bg-indigo-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+            autoFocus
+          >
+            Weiter laufen lassen
+          </button>
+          <button
+            type="button"
+            onClick={onStopAtIdle}
+            className="rounded-lg bg-zinc-800 px-4 py-2.5 text-sm font-medium text-zinc-100 hover:bg-zinc-700 focus:outline-none focus:ring-2 focus:ring-zinc-500"
+          >
+            Bei Inaktivität stoppen ({idleSinceLocal})
+          </button>
+          <button
+            type="button"
+            onClick={onMarkPause}
+            className="rounded-lg bg-zinc-800 px-4 py-2.5 text-sm font-medium text-zinc-100 hover:bg-zinc-700 focus:outline-none focus:ring-2 focus:ring-zinc-500"
+          >
+            Als Pause markieren
+          </button>
+        </div>
+        <p className="mt-4 text-xs text-zinc-500">
+          Tipp: <kbd className="rounded bg-zinc-800 px-1.5 py-0.5">Esc</kbd> = Weiter laufen lassen
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/hooks/useTimer.ts
+++ b/src/renderer/src/hooks/useTimer.ts
@@ -2,6 +2,30 @@ import { useEffect, useRef, useCallback } from 'react'
 import { useTimerStore } from '../store/timerStore'
 import { formatDuration as _formatDuration } from '../../../shared/duration'
 
+// Refs shared across all useTimer() instances so listeners are registered ONCE
+// globally and always invoke the latest callback.
+const globalToggleRef: { current: () => void } = { current: () => {} }
+const globalQuickStartRef: { current: (clientId: number) => void } = { current: () => {} }
+const globalStopRef: { current: () => void } = { current: () => {} }
+let listenersInstalled = false
+
+function installGlobalListenersOnce(setIdleEvent: (e: { idleSince: string; idleSeconds: number } | null) => void): void {
+  if (listenersInstalled) return
+  listenersInstalled = true
+  window.api.onHotkeyToggle(() => globalToggleRef.current())
+  window.api.onTrayQuickStart((clientId) => globalQuickStartRef.current(clientId))
+  window.api.onTrayStop(() => globalStopRef.current())
+  window.api.onIdleDetected((data) => {
+    if (useTimerStore.getState().runningEntry) {
+      setIdleEvent(data)
+    } else {
+      window.api.idle.dismiss()
+    }
+  })
+}
+
+let initRan = false
+
 export function useTimer() {
   const {
     clients,
@@ -10,22 +34,23 @@ export function useTimer() {
     description,
     elapsedSeconds,
     isLoading,
+    idleEvent,
     setClients,
     setRunningEntry,
     setSelectedClientId,
     setDescription,
     setElapsedSeconds,
-    setIsLoading
+    setIsLoading,
+    setIdleEvent
   } = useTimerStore()
 
   const tickRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const heartbeatRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
-  // Ref to always-current toggle fn for hotkey (avoids stale closures)
-  const toggleRef = useRef<() => void>(() => {})
-
-  // Load clients + check for running entry on mount
+  // Load clients + check for running entry on first mount only (idempotent).
   useEffect(() => {
+    if (initRan) return
+    initRan = true
     async function init() {
       const [clientsRes, runningRes] = await Promise.all([
         window.api.clients.getAll(),
@@ -39,17 +64,13 @@ export function useTimer() {
         setDescription(entry.description)
         const started = new Date(entry.started_at).getTime()
         setElapsedSeconds(Math.floor((Date.now() - started) / 1000))
-        // Restore tray state on app start
         const allClients = clientsRes.ok ? clientsRes.data : []
         const clientName = allClients.find((c) => c.id === entry.client_id)?.name ?? ''
         window.api.tray.update(true, clientName)
       }
     }
     init()
-
-    // Register hotkey listener once
-    const cleanup = window.api.onHotkeyToggle(() => toggleRef.current())
-    return cleanup
+    installGlobalListenersOnce(setIdleEvent)
   }, [])
 
   // Tick interval when running
@@ -100,11 +121,114 @@ export function useTimer() {
       setRunningEntry(null)
       setDescription('')
       window.api.tray.update(false, '')
+      // If user manually stops, dismiss any pending idle event.
+      if (useTimerStore.getState().idleEvent) {
+        setIdleEvent(null)
+        window.api.idle.dismiss()
+      }
     }
   }, [runningEntry])
 
-  // Keep toggleRef current so hotkey always calls the right fn
-  toggleRef.current = runningEntry ? stop : start
+  const startWithClient = useCallback(
+    async (clientId: number) => {
+      if (useTimerStore.getState().runningEntry) return
+      setSelectedClientId(clientId)
+      setIsLoading(true)
+      const res = await window.api.entries.start({
+        client_id: clientId,
+        description: '',
+        started_at: new Date().toISOString()
+      })
+      setIsLoading(false)
+      if (res.ok) {
+        setRunningEntry(res.data)
+        setDescription('')
+        const clientName = clients.find((c) => c.id === clientId)?.name ?? ''
+        window.api.tray.update(true, clientName)
+      }
+    },
+    [clients]
+  )
+
+  const dismissIdle = useCallback(() => {
+    setIdleEvent(null)
+    window.api.idle.dismiss()
+  }, [])
+
+  const idleKeep = useCallback(() => {
+    dismissIdle()
+  }, [dismissIdle])
+
+  const idleStopAtIdle = useCallback(async () => {
+    const ev = useTimerStore.getState().idleEvent
+    const entry = useTimerStore.getState().runningEntry
+    if (!ev || !entry) {
+      dismissIdle()
+      return
+    }
+    setIsLoading(true)
+    const res = await window.api.entries.update({
+      id: entry.id,
+      client_id: entry.client_id,
+      description: entry.description,
+      started_at: entry.started_at,
+      stopped_at: ev.idleSince
+    })
+    setIsLoading(false)
+    if (res.ok) {
+      setRunningEntry(null)
+      setDescription('')
+      window.api.tray.update(false, '')
+    }
+    dismissIdle()
+  }, [dismissIdle])
+
+  const idleMarkPause = useCallback(async () => {
+    const ev = useTimerStore.getState().idleEvent
+    const entry = useTimerStore.getState().runningEntry
+    if (!ev || !entry) {
+      dismissIdle()
+      return
+    }
+    setIsLoading(true)
+    // 1. Stop the running entry at idleSince
+    const stopRes = await window.api.entries.update({
+      id: entry.id,
+      client_id: entry.client_id,
+      description: entry.description,
+      started_at: entry.started_at,
+      stopped_at: ev.idleSince
+    })
+    if (stopRes.ok) {
+      // 2. Insert pause entry from idleSince to now
+      const pauseStart = ev.idleSince
+      const pauseEnd = new Date().toISOString()
+      const pauseStartRes = await window.api.entries.start({
+        client_id: entry.client_id,
+        description: 'Pause',
+        started_at: pauseStart
+      })
+      if (pauseStartRes.ok) {
+        await window.api.entries.update({
+          id: pauseStartRes.data.id,
+          client_id: entry.client_id,
+          description: 'Pause',
+          started_at: pauseStart,
+          stopped_at: pauseEnd
+        })
+      }
+      setRunningEntry(null)
+      setDescription('')
+      window.api.tray.update(false, '')
+    }
+    setIsLoading(false)
+    dismissIdle()
+  }, [dismissIdle])
+
+  // Keep refs current so listeners always call the latest fn
+  globalToggleRef.current = runningEntry ? stop : start
+  globalQuickStartRef.current = startWithClient
+  globalStopRef.current = stop
 
   return {
     clients,
@@ -113,10 +237,14 @@ export function useTimer() {
     description,
     elapsedSeconds,
     isLoading,
+    idleEvent,
     setSelectedClientId,
     setDescription,
     start,
-    stop
+    stop,
+    idleKeep,
+    idleStopAtIdle,
+    idleMarkPause
   }
 }
 

--- a/src/renderer/src/store/timerStore.ts
+++ b/src/renderer/src/store/timerStore.ts
@@ -12,6 +12,9 @@ interface TimerState {
   elapsedSeconds: number
   isLoading: boolean
 
+  // Idle modal
+  idleEvent: { idleSince: string; idleSeconds: number } | null
+
   // Actions
   setClients: (clients: Client[]) => void
   setRunningEntry: (entry: Entry | null) => void
@@ -19,6 +22,7 @@ interface TimerState {
   setDescription: (desc: string) => void
   setElapsedSeconds: (s: number) => void
   setIsLoading: (v: boolean) => void
+  setIdleEvent: (e: { idleSince: string; idleSeconds: number } | null) => void
 }
 
 export const useTimerStore = create<TimerState>((set) => ({
@@ -28,11 +32,13 @@ export const useTimerStore = create<TimerState>((set) => ({
   description: '',
   elapsedSeconds: 0,
   isLoading: false,
+  idleEvent: null,
 
   setClients: (clients) => set({ clients }),
   setRunningEntry: (runningEntry) => set({ runningEntry }),
   setSelectedClientId: (selectedClientId) => set({ selectedClientId }),
   setDescription: (description) => set({ description }),
   setElapsedSeconds: (elapsedSeconds) => set({ elapsedSeconds }),
-  setIsLoading: (isLoading) => set({ isLoading })
+  setIsLoading: (isLoading) => set({ isLoading }),
+  setIdleEvent: (idleEvent) => set({ idleEvent })
 }))

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -1,0 +1,316 @@
+import { useEffect, useState } from 'react'
+import type { Settings, BackupInfo } from '../../../shared/types'
+
+const DEFAULT_HOTKEY = 'Alt+Shift+S'
+
+function parseAccelerator(e: KeyboardEvent): string | null {
+  // Need at least one modifier and a non-modifier key.
+  const mods: string[] = []
+  if (e.ctrlKey) mods.push('Ctrl')
+  if (e.altKey) mods.push('Alt')
+  if (e.shiftKey) mods.push('Shift')
+  if (e.metaKey) mods.push('Super')
+  if (mods.length === 0) return null
+
+  const k = e.key
+  if (k === 'Control' || k === 'Alt' || k === 'Shift' || k === 'Meta') return null
+  // Single letter / digit / function key.
+  let key: string
+  if (k.length === 1) {
+    key = k.toUpperCase()
+  } else if (/^F\d{1,2}$/.test(k)) {
+    key = k
+  } else {
+    return null
+  }
+  return [...mods, key].join('+')
+}
+
+export default function SettingsView(): React.JSX.Element {
+  const [settings, setSettings] = useState<Settings | null>(null)
+  const [paths, setPaths] = useState<{ db: string; backups: string } | null>(null)
+  const [version, setVersion] = useState<string>('')
+  const [backups, setBackups] = useState<BackupInfo[]>([])
+  const [capturingHotkey, setCapturingHotkey] = useState(false)
+  const [hotkeyError, setHotkeyError] = useState<string | null>(null)
+  const [statusMsg, setStatusMsg] = useState<string | null>(null)
+
+  async function loadAll(): Promise<void> {
+    const [s, p, v, b] = await Promise.all([
+      window.api.settings.getAll(),
+      window.api.paths.get(),
+      window.api.app.getVersion(),
+      window.api.backups.list()
+    ])
+    if (s.ok) setSettings(s.data)
+    if (p.ok) setPaths(p.data)
+    if (v.ok) setVersion(v.data)
+    if (b.ok) setBackups(b.data)
+  }
+
+  useEffect(() => {
+    loadAll()
+  }, [])
+
+  // Capture next key combo for hotkey change.
+  useEffect(() => {
+    if (!capturingHotkey) return
+    const handler = async (e: KeyboardEvent): Promise<void> => {
+      e.preventDefault()
+      e.stopPropagation()
+      if (e.key === 'Escape') {
+        setCapturingHotkey(false)
+        setHotkeyError(null)
+        return
+      }
+      const accel = parseAccelerator(e)
+      if (!accel) return // wait for valid combo
+      const res = await window.api.settings.set('hotkey_toggle', accel)
+      if (res.ok) {
+        setSettings((prev) => (prev ? { ...prev, hotkey_toggle: accel } : prev))
+        setHotkeyError(null)
+        setCapturingHotkey(false)
+      } else {
+        setHotkeyError(res.error)
+      }
+    }
+    window.addEventListener('keydown', handler, true)
+    return () => window.removeEventListener('keydown', handler, true)
+  }, [capturingHotkey])
+
+  async function update<K extends keyof Settings>(key: K, value: Settings[K]): Promise<void> {
+    if (!settings) return
+    setSettings({ ...settings, [key]: value })
+    const res = await window.api.settings.set(String(key), String(value))
+    if (!res.ok) {
+      setStatusMsg(`Fehler: ${res.error}`)
+      // revert by reloading
+      await loadAll()
+    }
+  }
+
+  async function createBackupNow(): Promise<void> {
+    setStatusMsg('Backup wird erstellt …')
+    const res = await window.api.backups.create()
+    if (res.ok) {
+      setStatusMsg('Backup erstellt.')
+      const list = await window.api.backups.list()
+      if (list.ok) setBackups(list.data)
+    } else {
+      setStatusMsg(`Fehler: ${res.error}`)
+    }
+  }
+
+  if (!settings || !paths) {
+    return <div className="text-slate-400">Lade Einstellungen …</div>
+  }
+
+  const latestBackup = backups[0] ?? null
+
+  return (
+    <div className="max-w-2xl mx-auto flex flex-col gap-8 pb-12">
+      <h1 className="text-2xl font-semibold text-slate-100">Einstellungen</h1>
+
+      {statusMsg && (
+        <div className="rounded-md bg-slate-800 px-3 py-2 text-sm text-slate-300">
+          {statusMsg}
+        </div>
+      )}
+
+      {/* Allgemein */}
+      <Section title="Allgemein">
+        <Row label="Sprache" hint="Übersetzungen folgen in v1.2 — die Auswahl wird gespeichert.">
+          <select
+            aria-label="Sprache"
+            value={settings.language}
+            onChange={(e) => update('language', e.target.value)}
+            className={inputClass}
+          >
+            <option value="de">Deutsch</option>
+            <option value="en">English</option>
+          </select>
+        </Row>
+        <Row label="Mit Windows starten">
+          <label className="inline-flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={settings.auto_start === '1'}
+              onChange={(e) => update('auto_start', e.target.checked ? '1' : '0')}
+              className="h-4 w-4 rounded border-slate-600 bg-slate-800"
+            />
+            <span className="text-sm text-slate-300">Beim Anmelden automatisch starten</span>
+          </label>
+        </Row>
+        <Row label="Firma (für Exporte)">
+          <input
+            type="text"
+            value={settings.company_name}
+            onChange={(e) => update('company_name', e.target.value)}
+            className={inputClass}
+            placeholder="z.\u202fB. Meine Firma GmbH"
+          />
+        </Row>
+      </Section>
+
+      {/* Timer */}
+      <Section title="Timer">
+        <Row label="Inaktivitäts-Schwelle" hint="Nach wie vielen Minuten soll die App nachfragen?">
+          <div className="flex items-center gap-2">
+            <input
+              aria-label="Inaktivitäts-Schwelle in Minuten"
+              type="number"
+              min={1}
+              max={60}
+              value={settings.idle_threshold_minutes}
+              onChange={(e) => update('idle_threshold_minutes', e.target.value)}
+              className={`${inputClass} w-24`}
+            />
+            <span className="text-sm text-slate-400">Minuten</span>
+          </div>
+        </Row>
+        <Row
+          label="Globaler Hotkey"
+          hint="Start/Stop von überall. Modifier (Ctrl/Alt/Shift) + Buchstabe oder F-Taste."
+        >
+          <div className="flex items-center gap-2">
+            <code className="rounded bg-slate-800 px-3 py-1.5 text-sm text-slate-200">
+              {capturingHotkey ? 'Drücke eine Tastenkombi …' : settings.hotkey_toggle}
+            </code>
+            <button
+              type="button"
+              onClick={() => {
+                setCapturingHotkey((v) => !v)
+                setHotkeyError(null)
+              }}
+              className={btnSecondaryClass}
+            >
+              {capturingHotkey ? 'Abbrechen' : 'Ändern'}
+            </button>
+            {settings.hotkey_toggle !== DEFAULT_HOTKEY && (
+              <button
+                type="button"
+                onClick={() => update('hotkey_toggle', DEFAULT_HOTKEY)}
+                className={btnSecondaryClass}
+              >
+                Zurücksetzen
+              </button>
+            )}
+          </div>
+          {hotkeyError && <p className="mt-1 text-xs text-red-400">{hotkeyError}</p>}
+        </Row>
+        <Row label="Rundung" hint="Aktuell nur intern verfügbar — UI-Auswahl folgt.">
+          <select
+            aria-label="Rundungsmodus"
+            value={settings.rounding_mode}
+            onChange={(e) => update('rounding_mode', e.target.value as Settings['rounding_mode'])}
+            className={inputClass}
+          >
+            <option value="none">Keine</option>
+            <option value="ceil">Aufrunden</option>
+            <option value="floor">Abrunden</option>
+            <option value="round">Kaufmännisch</option>
+          </select>
+        </Row>
+      </Section>
+
+      {/* Daten */}
+      <Section title="Daten">
+        <Row label="Datenbank">
+          <div className="flex items-center gap-2">
+            <code className="flex-1 truncate rounded bg-slate-800 px-3 py-1.5 text-xs text-slate-300">
+              {paths.db}
+            </code>
+            <button
+              type="button"
+              onClick={() => window.api.shell.showItemInFolder(paths.db)}
+              className={btnSecondaryClass}
+            >
+              Im Explorer öffnen
+            </button>
+          </div>
+        </Row>
+        <Row label="Backups-Ordner">
+          <div className="flex items-center gap-2">
+            <code className="flex-1 truncate rounded bg-slate-800 px-3 py-1.5 text-xs text-slate-300">
+              {paths.backups}
+            </code>
+            <button
+              type="button"
+              onClick={() => window.api.shell.openPath(paths.backups)}
+              className={btnSecondaryClass}
+            >
+              Öffnen
+            </button>
+          </div>
+        </Row>
+        <Row label="Letztes Backup">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-sm text-slate-300">
+              {latestBackup
+                ? `${new Date(latestBackup.createdAt).toLocaleString('de-DE')} (${latestBackup.reason})`
+                : 'Noch keins vorhanden'}
+            </span>
+            <button type="button" onClick={createBackupNow} className={btnSecondaryClass}>
+              Backup jetzt erstellen
+            </button>
+          </div>
+          {backups.length > 0 && (
+            <p className="mt-1 text-xs text-slate-500">
+              Insgesamt {backups.length} Backup{backups.length === 1 ? '' : 's'} gespeichert.
+            </p>
+          )}
+        </Row>
+      </Section>
+
+      {/* Über */}
+      <Section title="Über">
+        <Row label="Version">
+          <span className="text-sm text-slate-300">{version || '—'}</span>
+        </Row>
+      </Section>
+    </div>
+  )
+}
+
+const inputClass =
+  'bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-100 ' +
+  'focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent'
+
+const btnSecondaryClass =
+  'rounded-md bg-slate-700 px-3 py-1.5 text-sm font-medium text-slate-100 hover:bg-slate-600 ' +
+  'focus:outline-none focus:ring-2 focus:ring-indigo-500'
+
+function Section({
+  title,
+  children
+}: {
+  title: string
+  children: React.ReactNode
+}): React.JSX.Element {
+  return (
+    <section className="flex flex-col gap-4">
+      <h2 className="text-xs font-semibold uppercase tracking-wider text-slate-500">{title}</h2>
+      <div className="flex flex-col gap-5 rounded-lg border border-slate-800 bg-slate-900/50 p-5">
+        {children}
+      </div>
+    </section>
+  )
+}
+
+function Row({
+  label,
+  hint,
+  children
+}: {
+  label: string
+  hint?: string
+  children: React.ReactNode
+}): React.JSX.Element {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label className="text-sm font-medium text-slate-200">{label}</label>
+      {children}
+      {hint && <p className="text-xs text-slate-500">{hint}</p>}
+    </div>
+  )
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -24,6 +24,11 @@ export interface Settings {
   rounding_minutes: '5' | '10' | '15' | '30'
   company_name: string
   backup_path: string
+  // v1.1
+  idle_threshold_minutes: string
+  language: string
+  auto_start: string
+  hotkey_toggle: string
 }
 
 export interface CreateClientInput {


### PR DESCRIPTION
## v1.1 — Daily Trust (final)

Schließt die letzten drei v1.1-Issues in einem PR ab, damit die Release-Version end-to-end testbar ist.

Closes #3, closes #4, closes #5.

### #3 Idle-Detection
- Neuer `src/main/idle.ts`: `powerMonitor`-Polling alle 30 s; nur aktiv, solange Timer läuft.
- Schwelle aus `settings.idle_threshold_minutes` (Default 5, 1–720 min clamped).
- Bei Inaktivität sendet Main `timer:idle-detected` mit `idleSince` (ISO) + `idleSeconds`. Re-arm erst nach Renderer-Bestätigung (`idle:dismiss`).
- `IdleModal` (Renderer): drei Aktionen
  - **Weiter laufen lassen** (auch via `Esc`)
  - **Bei Inaktivität stoppen** → `entries.update({ stopped_at: idleSince })`
  - **Als Pause markieren** → aktuellen Eintrag bei `idleSince` stoppen + neuen `Pause`-Eintrag von `idleSince` bis jetzt anlegen
- Manuelles Stoppen entsorgt offene Idle-Events (kein Geister-Modal).

### #4 Tray Quick-Start
- Main cacht aktive Kunden (`refreshActiveClients()`), aktualisiert Tray-Menü dynamisch.
- Bei laufendem Timer: Status + **Stop**.
- Sonst: bis zu 10 aktive Kunden als `▶ {name}` → sendet `timer:tray-quick-start` mit `clientId`.
- IPC-Hook `refreshTrayClients` läuft automatisch nach jedem `clients:create|update|delete`.

### #5 Settings-View
Komplette Ansicht ersetzt den Platzhalter. Sektionen:
- **Allgemein**: Sprache (Auswahl gespeichert, echte i18n folgt v1.2), Auto-Start (`app.setLoginItemSettings`), Firma.
- **Timer**: Idle-Schwelle (1–60 min), globaler Hotkey (Capture-Modus mit Validierung & Reset), Rundungsmodus.
- **Daten**: DB-Pfad + „Im Explorer öffnen", Backups-Ordner + „Öffnen", letztes Backup + „Backup jetzt erstellen".
- **Über**: Version aus `app.getVersion()`.

### Schema / IPC
- Migration `002-v11-settings`: appended, fügt `idle_threshold_minutes`, `language`, `auto_start`, `hotkey_toggle` per `INSERT OR IGNORE` hinzu.
- `Settings`-Type erweitert.
- Neue IPC-Handler: `shell:openPath`, `shell:showItemInFolder`, `paths:get`, `app:getVersion`.
- `settings:set` triggert jetzt Side-Effects (Idle-Threshold, Auto-Start, Hotkey-Rebind) und meldet Hotkey-Konflikte zurück.

### Renderer-Architektur
- Listener für Hotkey/Tray/Idle werden modul-global einmalig registriert (Flag `listenersInstalled`), sodass mehrere `useTimer()`-Instanzen (z. B. App + TimerView) keine Doppel-Events erzeugen.
- `idleEvent` lebt im Zustand-Store; `App.tsx` rendert `<IdleModal>` als Overlay, unabhängig vom aktiven Tab.

### Bewusst zurückgestellt
- Echte i18n-Übersetzungen (DE/EN-Strings) → v1.2. Der Setting wird persistiert, damit die Migration heute nicht später nachgezogen werden muss.
- UI-Auswahl für `rounding_minutes` → später; aktuell nur Mode wählbar.

### Prüfung
- `pnpm typecheck` ✅
- `pnpm test` → 18 passed, 7 skipped (DB-Tests skipif lokal, laufen in CI nach `pnpm rebuild better-sqlite3`)
- `pnpm build` ✅
