### PR TITLE
fix(release): v1.1.1 — rebuild better-sqlite3 für Electron ABI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Test
         run: pnpm test
 
+      - name: Rebuild native modules for Electron (packaging runtime)
+        run: pnpm exec electron-builder install-app-deps
+
       - name: Build installer (NSIS)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "time-tracking",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Schlanker Desktop-Zeiterfasser für Windows — Toggl-Track-Style, lokal, ohne Cloud.",
   "main": "./out/main/index.js",
   "author": "skoedr",


### PR DESCRIPTION
v1.1.0 Installer crashte beim Start mit `NODE_MODULE_VERSION 127 vs 140`. Ursache: `pnpm rebuild better-sqlite3` (für Tests gegen Node 22) lief nach dem postinstall, sodass die Node-ABI-Binary in den Build ging.

Fix: nach den Tests `electron-builder install-app-deps` ausführen, das rebuildet against Electron 39 (ABI 140) bevor `build:win` packaged.