### PR TITLE
fix(release): v1.1.2 — @electron/rebuild für korrekte Native-ABI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Test
         run: pnpm test
 
-      - name: Rebuild native modules for Electron (packaging runtime)
-        run: pnpm exec electron-builder install-app-deps
+      - name: Rebuild better-sqlite3 for Electron ABI
+        run: pnpm exec electron-rebuild -f -w better-sqlite3
 
       - name: Build installer (NSIS)
         env:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "time-tracking",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Schlanker Desktop-Zeiterfasser für Windows — Toggl-Track-Style, lokal, ohne Cloud.",
   "main": "./out/main/index.js",
   "author": "skoedr",
@@ -34,6 +34,7 @@
     "@electron-toolkit/eslint-config-prettier": "^3.0.0",
     "@electron-toolkit/eslint-config-ts": "^3.1.0",
     "@electron-toolkit/tsconfig": "^2.0.0",
+    "@electron/rebuild": "^4.0.4",
     "@tailwindcss/vite": "^4.2.4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@electron-toolkit/tsconfig':
         specifier: ^2.0.0
         version: 2.0.0(@types/node@22.19.17)
+      '@electron/rebuild':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0))


### PR DESCRIPTION
v1.1.1 hatte denselben NODE_MODULE_VERSION-Mismatch wie v1.1.0. Ursache: `electron-builder install-app-deps` arbeitet mit pnpms Symlink-Layout nicht zuverlässig und überschreibt die zuvor gegen Node 22 kompilierte better-sqlite3-Binary nicht.

Fix: `@electron/rebuild` (offizielles Tool) als devDependency hinzugefügt und im Workflow nach den Tests ausgeführt — handhabt pnpm korrekt.