### PR TITLE
docs: sync CHANGELOG/README/ROADMAP with v1.1.x + v1.2-v1.5 backlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,71 @@
 
 All notable changes to TimeTrack are documented here.
 
+## [1.1.2] — 2026-04-24
+
+### Fixed
+
+- **Installer crash on first launch** — The Windows installer in v1.1.0 and v1.1.1
+  shipped a `better-sqlite3` binary compiled for Node.js (ABI 127) instead of
+  Electron (ABI 140). The app crashed at startup with a `NODE_MODULE_VERSION`
+  mismatch. The release workflow now uses `@electron/rebuild`, which handles
+  pnpm's symlinked `node_modules` correctly and rebuilds against the bundled
+  Electron version before packaging.
+
+## [1.1.1] — 2026-04-24
+
+### Fixed
+
+- Attempted fix for the v1.1.0 native-module mismatch using
+  `electron-builder install-app-deps` — turned out not to work reliably with
+  pnpm. Superseded by v1.1.2.
+
+## [1.1.0] — 2026-04-24
+
+### Added
+
+- **Idle-Detection** — When the system is idle longer than the configured
+  threshold (default 5 minutes), a modal asks what to do with the time:
+  *Weiter laufen lassen*, *Bei Inaktivität stoppen*, or *Als Pause markieren*.
+  Driven by `powerMonitor.getSystemIdleTime()` in the main process.
+- **Tray Quick-Start** — Right-click the tray icon to start a timer for any
+  client directly, without opening the window. The menu rebuilds dynamically
+  from the active-clients list and shows a *Stop* entry while a timer runs.
+- **Settings-View** — New *Einstellungen* tab with sections *Allgemein*,
+  *Timer*, *Daten* and *Über*. Configure language, auto-start, idle threshold,
+  global hotkey (with capture UI), and inspect data paths and backups.
+- **Auto-Backup** — A daily SQLite backup runs at app startup, kept rolling
+  for the last 7 days under `%AppData%\TimeTrack\backups\`. Manual backups,
+  pre-migration backups and restore are exposed in the Settings view. Manual
+  and pre-migration backups are never auto-rotated.
+- **DB Migrations** — Versioned migration system (`src/main/migrations/`) with
+  a `schema_version` table, transactional apply, and an automatic
+  pre-migration backup. v1.1 ships migration `002` which seeds the new
+  settings keys (`idle_threshold_minutes`, `language`, `auto_start`,
+  `hotkey_toggle`).
+- **Vitest setup** — First automated tests: shared `duration` helpers,
+  migration system (10 tests), and backup rotation/restore (8 tests). Two
+  Vitest projects (`node`, `jsdom`) so renderer hooks can use the DOM.
+- **Automated Windows Release** — `.github/workflows/release.yml` builds the
+  NSIS installer on Windows, runs the test suite, rebuilds native modules
+  for the Electron ABI, and publishes a GitHub Release with the installer
+  attached when a `v*` tag is pushed.
+
+### Changed
+
+- Hotkey is now configurable via the Settings view; failed re-binds revert
+  the change and surface an inline error.
+- The tray tooltip and context menu update on every `tray:update` IPC so the
+  Quick-Start menu always reflects the current client list.
+
+### For contributors
+
+- Native-module rebuild for tests: CI runs `pnpm rebuild better-sqlite3`
+  against Node 22 before `pnpm test`, then `pnpm exec electron-rebuild` against
+  Electron before `electron-builder`.
+- Vitest `testTimeout` and `hookTimeout` raised to 30 s — the Windows runner
+  needs the headroom for the first cold-start `better-sqlite3` call.
+
 ## [1.0.0] — 2026-04-23
 
 First public release. Windows NSIS installer.

--- a/README.md
+++ b/README.md
@@ -6,16 +6,21 @@ A personal Windows desktop time-tracking app for freelancers. Lightweight Toggl 
 
 - **Timer** — Start/stop with client selection and description. Crash-safe via heartbeat.
 - **Kunden-Verwaltung** — Create, edit, archive, and delete clients with color coding.
-- **Global Hotkey** — `Alt+Shift+S` starts/stops the timer from anywhere.
-- **Tray Icon** — Live status in the system tray. Minimize-to-tray on close.
+- **Global Hotkey** — `Alt+Shift+S` (configurable) starts/stops the timer from anywhere.
+- **Tray Icon + Quick-Start** — Right-click the tray to start a client timer without opening the window.
+- **Idle-Detection** — When the system is idle past your threshold, the app asks whether to keep, stop, or mark as break.
+- **Settings-View** — Language, auto-start, idle threshold, hotkey, and data paths in one place.
+- **Auto-Backup** — Rolling 7-day SQLite backups under `%AppData%\TimeTrack\backups\`. Manual backup + restore from Settings.
+- **DB Migrations** — Versioned schema with pre-migration backup, so updates never lose data.
+- **Auto-Update Releases** — Pushing a `v*` tag builds the Windows installer and publishes a GitHub Release automatically.
 - **Local SQLite** — All data stays on your machine under `%AppData%\TimeTrack\`.
 
 ### Coming soon
 
-- Kalender-Modus (monthly overview)
-- PDF Stundennachweis export
-- Mini-Modus always-on-top widget
-- electron-builder Windows installer
+- Kalender-Modus (monthly overview) — see [v1.2 issues](https://github.com/skoedr/time-tracking/labels/v1.2)
+- PDF Stundennachweis export — see [v1.3 issues](https://github.com/skoedr/time-tracking/labels/v1.3)
+- Mini-Modus always-on-top widget — see [v1.4 issues](https://github.com/skoedr/time-tracking/labels/v1.4)
+- Auto-Update + Onboarding — see [v1.5 issues](https://github.com/skoedr/time-tracking/labels/v1.5)
 
 ## Tech Stack
 
@@ -43,8 +48,34 @@ pnpm dev
 # Type check
 pnpm typecheck
 
+# Run tests
+pnpm test
+
 # Build Windows installer
 pnpm build:win
+```
+
+## Releases
+
+Releases are built automatically by `.github/workflows/release.yml` when a `v*` tag
+is pushed to `main`. The workflow rebuilds `better-sqlite3` against the Electron
+ABI via `@electron/rebuild`, packages an NSIS installer, and publishes a GitHub
+Release with the `.exe`, `.blockmap`, and `latest.yml` attached.
+
+- Download the latest installer:
+  [github.com/skoedr/time-tracking/releases/latest](https://github.com/skoedr/time-tracking/releases/latest)
+- Roadmap and per-version planning: see [ROADMAP.md](ROADMAP.md) and the
+  [open issues](https://github.com/skoedr/time-tracking/issues) grouped by `v1.x` labels.
+
+To cut a new release locally:
+
+```bash
+# 1. Bump version in package.json + add CHANGELOG entry
+# 2. Tag and push
+git tag v1.x.y
+git push origin v1.x.y
+# 3. The Release workflow does the rest. The release is created as a draft —
+#    publish it from the GitHub UI (or `gh release edit vX.Y.Z --draft=false`).
 ```
 
 ## Project Structure
@@ -52,18 +83,23 @@ pnpm build:win
 ```
 src/
   main/          # Electron main process
-    index.ts     # App entry, tray, global hotkey
-    db.ts        # SQLite schema + crash recovery
-    ipc.ts       # All IPC handlers
+    index.ts     # App entry, tray (with Quick-Start), global hotkey
+    db.ts        # SQLite open + WAL setup
+    ipc.ts       # All IPC handlers (clients, entries, settings, shell, paths)
+    idle.ts      # powerMonitor-based idle watcher
+    backup.ts    # Daily/manual/pre-migration backups + restore
+    migrations/  # Versioned schema migrations + runner
   preload/
     index.ts     # Context Bridge (window.api)
     index.d.ts   # TypeScript types for renderer
   renderer/src/
-    views/       # React page components
+    views/       # React page components (incl. SettingsView)
+    components/  # IdleModal etc.
     hooks/       # useTimer logic hook
     store/       # Zustand stores
   shared/
     types.ts     # Shared TypeScript interfaces
+    duration.ts  # Time-formatting helpers
 ```
 
 ## Data Storage

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,27 +11,30 @@ geschlossenen Schleife. Keine Tabs, keine Browser, kein zweites Programm nötig.
 
 ---
 
-## v1.1 — Daily Trust (Schmerzstellen lösen)
+## v1.1 — Daily Trust (Schmerzstellen lösen) ✅ ausgeliefert v1.1.0–v1.1.2 (2026-04-24)
 
 **Thema:** Was den Freelancer Geld kostet, wenn die App es nicht macht.
 
-- **Idle Detection** — PC >5 Min inaktiv? Modal "Timer noch laufen lassen, bei XY:XX
+- ✅ **Idle Detection** — PC >5 Min inaktiv? Modal "Timer noch laufen lassen, bei XY:XX
   stoppen, oder als Pause markieren?". Verhindert die größte Datenverluststelle:
   Mittagspause vergessen.
-- **Tray Quick-Start** — aktive Kunden direkt im Tray-Kontextmenü als Buttons. 1 Klick
+- ✅ **Tray Quick-Start** — aktive Kunden direkt im Tray-Kontextmenü als Buttons. 1 Klick
   → Timer läuft. Heute braucht es: Tray → Fenster anzeigen → Kunde wählen → Start. 4 Klicks.
-- **Settings-View** — Hotkey ändern, DB-Pfad anzeigen + öffnen, Idle-Schwelle einstellen,
-  Sprache (DE/EN), "Beim Windows-Start automatisch starten" Toggle.
-- **Auto-Backup** — rollierend 7 Tage SQLite-Snapshots in `%AppData%\TimeTrack\backups\`.
+- ✅ **Settings-View** — Hotkey ändern, DB-Pfad anzeigen + öffnen, Idle-Schwelle einstellen,
+  Sprache (DE/EN — i18n-Strings folgen in v1.2), "Beim Windows-Start automatisch starten" Toggle.
+- ✅ **Auto-Backup** — rollierend 7 Tage SQLite-Snapshots in `%AppData%\TimeTrack\backups\`.
   Wiederherstellung über Settings.
-- **DB-Migrationen** — `migrations/`-Ordner mit nummerierten `.sql`-Dateien, ausgeführt
+- ✅ **DB-Migrationen** — `migrations/`-Ordner mit TypeScript-Migration-Modulen, ausgeführt
   beim App-Start nach Schema-Version. Pflicht bevor v1.2 neue Spalten hinzufügt.
+- ✅ **Bonus:** Vitest-Setup mit ersten Tests + automatisierter Windows-Release-Workflow.
 
-**Ship-Kriterium:** Du kannst dem Tool über einen ganzen Arbeitstag ohne Babysitting trauen.
+**Ship-Kriterium:** Du kannst dem Tool über einen ganzen Arbeitstag ohne Babysitting trauen. ✅
 
 ---
 
 ## v1.2 — Calendar & Edit (das Original-Backlog)
+
+📂 [Issues mit Label `v1.2`](https://github.com/skoedr/time-tracking/labels/v1.2)
 
 **Thema:** Was war, wann war es, und kann ich es korrigieren?
 
@@ -50,6 +53,8 @@ geschlossenen Schleife. Keine Tabs, keine Browser, kein zweites Programm nötig.
 ---
 
 ## v1.3 — PDF Export & Reporting (das Geld-verdienen-Feature)
+
+📂 [Issues mit Label `v1.3`](https://github.com/skoedr/time-tracking/labels/v1.3)
 
 **Thema:** Daten → fertige Rechnungs-Anlage in 30 Sekunden.
 
@@ -70,6 +75,8 @@ geschlossenen Schleife. Keine Tabs, keine Browser, kein zweites Programm nötig.
 
 ## v1.4 — Mini Mode & Flow
 
+📂 [Issues mit Label `v1.4`](https://github.com/skoedr/time-tracking/labels/v1.4)
+
 **Thema:** App soll im Workflow verschwinden, nicht stören.
 
 - **Mini-Widget** — Always-on-top, **200×40px horizontal** (Toggl-Style), zeigt Zeit + Kunde +
@@ -85,6 +92,8 @@ geschlossenen Schleife. Keine Tabs, keine Browser, kein zweites Programm nötig.
 ---
 
 ## v1.5 — Trust at Scale
+
+📂 [Issues mit Label `v1.5`](https://github.com/skoedr/time-tracking/labels/v1.5)
 
 **Thema:** Wenn jemand außer dir das Tool nutzt, soll es nicht peinlich sein.
 


### PR DESCRIPTION
Documentation catch-up after the v1.1.0 → v1.1.1 → v1.1.2 release sequence and the v1.2/v1.3/v1.4/v1.5 issue triage. No code changes.

## CHANGELOG.md
- New entries for **v1.1.2**, **v1.1.1**, **v1.1.0** (preserves existing v1.0.0 entry verbatim).
- v1.1.0: idle-detection, tray quick-start, settings view, auto-backup, DB migrations, vitest, release workflow.
- v1.1.1 / v1.1.2: documents the `NODE_MODULE_VERSION` mismatch and the `@electron/rebuild` fix.

## README.md
- `Features` rewritten — idle detection, quick-start, settings, auto-backup, migrations, automated releases are no longer `Coming soon`.
- `Coming soon` now points at the v1.2 / v1.3 / v1.4 / v1.5 issue labels.
- `Project Structure` reflects `idle.ts`, `backup.ts`, `migrations/`, `components/`, `shared/duration.ts`.
- New `Releases` section: download link + `git tag → push → workflow → publish draft` flow.
- `pnpm test` listed under Development commands.

## ROADMAP.md
- v1.1 heading marked ✅ ausgeliefert v1.1.0–v1.1.2 with each bullet ticked; ship-criterion ticked.
- Each of v1.2 / v1.3 / v1.4 / v1.5 gets a 📂 link to its GitHub issue label so the plan ↔ tracker bridge is one click.

## Not changed
- `DESIGN.md` — still accurate, no v1.1 visual changes affect it.
- No `ARCHITECTURE.md` / `CONTRIBUTING.md` / `CLAUDE.md` / `VERSION` files exist; nothing to sync.
- v1.0.0 changelog entry is untouched.