### PR TITLE
feat(v1.2 PR A): tray tooltip with today total + #15 placeholder fix + DESIGN tokens stub

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -29,27 +29,27 @@ aussieht.
 
 ## Prämissen (bestätigt)
 
-| # | Prämisse |
-|---|----------|
-| 1 | Solo-Freelancer-Tool. Kein Team, keine Cloud, alles lokal. |
-| 2 | Mini-Modus ist der tägliche Workflow. Kalender ist für Nachtragen & Monatsabschluss. |
-| 3 | Primäres Artefakt: PDF-Stundennachweis. Keine Rechnungsstellung, kein Buchhaltungsexport. |
-| 4 | Electron + React als Basis. Outlook-Integration (Graph API) kommt in Phase 2. |
+| #   | Prämisse                                                                                  |
+| --- | ----------------------------------------------------------------------------------------- |
+| 1   | Solo-Freelancer-Tool. Kein Team, keine Cloud, alles lokal.                                |
+| 2   | Mini-Modus ist der tägliche Workflow. Kalender ist für Nachtragen & Monatsabschluss.      |
+| 3   | Primäres Artefakt: PDF-Stundennachweis. Keine Rechnungsstellung, kein Buchhaltungsexport. |
+| 4   | Electron + React als Basis. Outlook-Integration (Graph API) kommt in Phase 2.             |
 
 ---
 
 ## Tech-Stack
 
-| Schicht | Technologie | Begründung |
-|---------|-------------|------------|
-| Shell | **Electron** | Native Windows-Fenster, System-Tray, kein Browser nötig |
-| UI | **React** + Tailwind CSS | Nutzer kennt Web-Stack, schnelle Iteration |
-| Datenbank | **SQLite** (via `better-sqlite3`) | Lokal, zero-config, kein Server |
-| PDF | **Electron `webContents.printToPDF()`** | Nutzt Chromium das Electron bereits eingebaut hat — kein Puppeteer (+300MB) nötig |
-| Build | **electron-builder** | `.exe`-Installer für Windows, Auto-Update vorbereitet |
-| Paket-Manager | **npm** / **pnpm** | Standard für Electron-Projekte |
-| IPC-Sicherheit | **Context Bridge** (`contextIsolation: true`) | HTML-Templates werden gerendert — nodeIntegration bleibt aus |
-| Datenpfad | **`app.getPath('userData')`** | `%AppData%\TimeTrack\` — Updates überschreiben Daten nie |
+| Schicht        | Technologie                                   | Begründung                                                                        |
+| -------------- | --------------------------------------------- | --------------------------------------------------------------------------------- |
+| Shell          | **Electron**                                  | Native Windows-Fenster, System-Tray, kein Browser nötig                           |
+| UI             | **React** + Tailwind CSS                      | Nutzer kennt Web-Stack, schnelle Iteration                                        |
+| Datenbank      | **SQLite** (via `better-sqlite3`)             | Lokal, zero-config, kein Server                                                   |
+| PDF            | **Electron `webContents.printToPDF()`**       | Nutzt Chromium das Electron bereits eingebaut hat — kein Puppeteer (+300MB) nötig |
+| Build          | **electron-builder**                          | `.exe`-Installer für Windows, Auto-Update vorbereitet                             |
+| Paket-Manager  | **npm** / **pnpm**                            | Standard für Electron-Projekte                                                    |
+| IPC-Sicherheit | **Context Bridge** (`contextIsolation: true`) | HTML-Templates werden gerendert — nodeIntegration bleibt aus                      |
+| Datenpfad      | **`app.getPath('userData')`**                 | `%AppData%\TimeTrack\` — Updates überschreiben Daten nie                          |
 
 > **Warum nicht Tauri?** Rust-Lernkurve würde Phase 1 verlangsamen. Tauri bleibt
 > Option für Phase 3, wenn Executable-Größe wichtig wird.
@@ -64,6 +64,7 @@ aussieht.
 ### Phase 1 — Das Kernprodukt
 
 #### Mini-Modus (Timer-Widget)
+
 - **Always-on-top**, kleines Fenster (~300×150px)
 - **Start / Pause / Stop**-Buttons mit Tastenkürzel (`F5` / `F6`)
 - **Globaler Hotkey** (`F5`/`F6`) — funktioniert auch wenn das Fenster im Hintergrund ist (`globalShortcut`)
@@ -75,6 +76,7 @@ aussieht.
 - **Tray-Icon:** Grün = Timer läuft, Grau = gestoppt (via `nativeImage` + Electron Tray API)
 
 #### Kalender-Modus
+
 - **Monatsansicht** (Kalender-Grid, ein Block pro Eintrag)
 - **Farb-Kodierung** nach Kunde
 - **Eintrag erstellen/bearbeiten/löschen** (manuell, für Nachträge)
@@ -83,11 +85,13 @@ aussieht.
 - **Liste-Ansicht** alternativ zur Kalender-Ansicht
 
 #### Kunden-Verwaltung
+
 - Name, Farbe, Kurzbezeichnung (für den PDF-Header)
 - Stundensatz (optional, für spätere Berechnungen)
 - Archivieren (nicht löschen)
 
 #### Einstellungen
+
 - **Rundungsmodus:** 5 / 10 / 15 / 30 Minuten; Ceil / Floor / Round
 - **Branding:** Logo (PNG/SVG), Firmenname, Adresse, USt-Nr. (für PDF-Footer)
 - **Standard-Tätigkeiten:** vordefinierte Texte als Quickselect
@@ -96,6 +100,7 @@ aussieht.
 - **Auto-Backup:** Konfigurierbarer Zielordner (z.B. OneDrive); SQLite-DB wird täglich kopiert
 
 #### PDF-Export
+
 - **Zeitraum** wählen (Monat-Picker oder benutzerdefiniert)
 - **Kunde** wählen
 - **HTML-Template** (anpassbar, liegt im App-Datenordner)
@@ -171,6 +176,7 @@ CREATE TABLE settings (
 ## UI-Skizzen
 
 ### Mini-Modus
+
 ```
 ┌─────────────────────────────┐
 │ ▶ Kunde GmbH          00:47 │
@@ -180,6 +186,7 @@ CREATE TABLE settings (
 ```
 
 ### Kalender-Modus (Header)
+
 ```
 ┌──────────────────────────────────────────────────┐
 │ ← April 2026 →          [+ Eintrag] [📄 Export]  │
@@ -243,32 +250,32 @@ time-tracking/
 
 ## Offene Entscheidungen
 
-| Frage | Empfehlung | Alternative |
-|-------|------------|-------------|
-| State-Management | Zustand (minimal, kein Redux-Overhead) | Jotai |
-| Datumslib | `date-fns` (tree-shakeable) | `dayjs` |
-| Kalender-Komponente | Eigenbau (simpler Grid) | `react-big-calendar` |
-| PDF-Preview | Browser-Vorschau-Fenster (BrowserWindow mit `printToPDF`) | direkt speichern |
-| Update-Mechanismus | electron-updater (GitHub Releases) | manuell |
+| Frage               | Empfehlung                                                | Alternative          |
+| ------------------- | --------------------------------------------------------- | -------------------- |
+| State-Management    | Zustand (minimal, kein Redux-Overhead)                    | Jotai                |
+| Datumslib           | `date-fns` (tree-shakeable)                               | `dayjs`              |
+| Kalender-Komponente | Eigenbau (simpler Grid)                                   | `react-big-calendar` |
+| PDF-Preview         | Browser-Vorschau-Fenster (BrowserWindow mit `printToPDF`) | direkt speichern     |
+| Update-Mechanismus  | electron-updater (GitHub Releases)                        | manuell              |
 
 ## Architektur-Entscheidungen (aus Reviews)
 
-| Entscheidung | Gewählt | Begründung |
-|---|---|---|
-| IPC-Sicherheit | Context Bridge | HTML-Templates werden gerendert, nodeIntegration aus |
-| PDF-Engine | `webContents.printToPDF()` | Electron hat Chromium bereits — kein Puppeteer |
-| Datenpfad | `app.getPath('userData')` | Updates-sicher, kein Datenverlust |
-| Crash-Recovery | Heartbeat + Auto-Stop | `heartbeat_at` alle 30s, beim Start offene Einträge schließen |
+| Entscheidung   | Gewählt                    | Begründung                                                    |
+| -------------- | -------------------------- | ------------------------------------------------------------- |
+| IPC-Sicherheit | Context Bridge             | HTML-Templates werden gerendert, nodeIntegration aus          |
+| PDF-Engine     | `webContents.printToPDF()` | Electron hat Chromium bereits — kein Puppeteer                |
+| Datenpfad      | `app.getPath('userData')`  | Updates-sicher, kein Datenverlust                             |
+| Crash-Recovery | Heartbeat + Auto-Stop      | `heartbeat_at` alle 30s, beim Start offene Einträge schließen |
 
 ## Pflicht-Tests (aus Eng-Review)
 
-| Test | Typ | Priorität |
-|------|-----|-----------|
-| Rundungsmodus (alle 3 Modi × alle Intervalle) | Unit | P1 |
-| Crash-Recovery: App-Start mit offenem Eintrag | Integration | P1 |
-| PDF-Export: korrekter Zeitraum, korrekte Stunden | Integration | P1 |
-| Auto-Backup: Zielordner nicht existent | Unit | P2 |
-| Zombie-Erkennung: heartbeat > 5 min alt | Unit | P1 |
+| Test                                             | Typ         | Priorität |
+| ------------------------------------------------ | ----------- | --------- |
+| Rundungsmodus (alle 3 Modi × alle Intervalle)    | Unit        | P1        |
+| Crash-Recovery: App-Start mit offenem Eintrag    | Integration | P1        |
+| PDF-Export: korrekter Zeitraum, korrekte Stunden | Integration | P1        |
+| Auto-Backup: Zielordner nicht existent           | Unit        | P2        |
+| Zombie-Erkennung: heartbeat > 5 min alt          | Unit        | P1        |
 
 ---
 
@@ -289,6 +296,76 @@ time-tracking/
 
 ---
 
-*Design-Status: REVIEWED — CEO + Eng Review abgeschlossen. Bereit zum Bauen.*
+_Design-Status: REVIEWED — CEO + Eng Review abgeschlossen. Bereit zum Bauen._
 
 **Reviews:** /office-hours ✓ | /plan-ceo-review ✓ (SELECTIVE EXPANSION) | /plan-eng-review ✓
+
+---
+
+## v1.2 Visual Tokens (stub)
+
+Minimal token sheet introduced with v1.2 (#26 Calendar, #30 Today, #28 Edit/Delete).
+Full state-matrix and component catalogue follow in v1.3.
+
+### Color tokens
+
+**Surfaces (Tailwind slate scale)**
+
+- `slate-900` `#0f172a` — page background
+- `slate-800` `#1e293b` — card background
+- `slate-700` `#334155` — raised surface, drawer body
+- `slate-600` `#475569` — focused/expanded row
+- `slate-400` `#94a3b8` — secondary text
+- `slate-300` `#cbd5e1` — body text
+- `slate-100` `#f1f5f9` — primary text / numerics
+
+**Accent**
+
+- `indigo-500` `#6366f1` — primary action, today-highlight border, active links
+- `indigo-400` `#818cf8` — hover
+
+**Semantic**
+
+- `emerald-500` `#10b981` — success / save flash
+- `amber-500` `#f59e0b` — warning (cross-midnight banner)
+- `red-500` `#ef4444` — destructive / delete confirm
+
+**Client palette (10 presets, locked in v1.1)**
+`#6366f1` `#8b5cf6` `#ec4899` `#f59e0b` `#10b981`
+`#3b82f6` `#ef4444` `#f97316` `#14b8a6` `#84cc16`
+
+### Typography scale
+
+- Display (timer numerics): 56px / 64px (mono, e.g. `font-mono text-7xl`)
+- h1: 24px / 32px, semibold
+- h2: 20px / 28px, semibold
+- body: 14px / 20px, regular
+- small: 12px / 16px, regular (KW column, tagessumme)
+
+### Spacing tokens
+
+4 / 8 / 12 / 16 / 24 / 32 px (`gap-1 / gap-2 / gap-3 / gap-4 / gap-6 / gap-8`).
+
+### Calendar mini-bars (locked v1.2)
+
+- Bar height: **3 px**, gap **2 px**
+- Max **5 visible** per cell; overflow as clickable `+N` (opens Drawer)
+- Bar color = `client.color`; running entry has 1px white border
+
+### Drawer (locked v1.2)
+
+- Position: `fixed right-0 top-0 w-96 h-screen`
+- Sticky header (date + total, close X)
+- Sticky footer ("+ Eintrag für [Date] hinzufügen")
+- Inline-edit row expands to ~200 px max with `scrollIntoView({block:'center'})`
+
+### Known limitations (deferred)
+
+| #   | Limitation                                                                  | Defer-to  | Reason                                                       |
+| --- | --------------------------------------------------------------------------- | --------- | ------------------------------------------------------------ |
+| L1  | Tray-tooltip is German-only (ignores `settings.language`)                   | v1.4      | Full i18n pass scoped together                               |
+| L2  | Client color palette not colorblind-safe (Indigo/Violet, Blue/Teal cluster) | v1.4      | Palette change requires migration of saved per-client colors |
+| L3  | No mobile/tablet layout (<1024 px); Calendar grid breaks below that width   | v1.4      | App is Windows-desktop-first; web build not on roadmap       |
+| L4  | No light mode                                                               | post-v1.5 | Single user, dark-only tested                                |
+| L5  | Cross-midnight entries blocked (warning banner shown in EntryEditForm)      | v1.3      | Needs entry-splitting logic + PDF impact                     |
+| L6  | Full ARIA / screen-reader pass                                              | v1.3      | Keyboard nav for Calendar already in v1.2                    |

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -31,6 +31,16 @@ let isQuitting = false
 let cachedActiveClients: Client[] = []
 let isTimerRunning = false
 let runningLabel = ''
+let lastTodaySeconds = 0
+
+/** Format seconds as `HH:MM` (no seconds) for the tray tooltip. */
+function fmtHHMM(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) seconds = 0
+  const total = Math.floor(seconds)
+  const h = Math.floor(total / 3600)
+  const m = Math.floor((total % 3600) / 60)
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`
+}
 
 function refreshActiveClients(): void {
   try {
@@ -91,11 +101,20 @@ function buildTrayMenu(): Menu {
   return Menu.buildFromTemplate(items)
 }
 
-function updateTray(running: boolean, label: string): void {
+function updateTray(running: boolean, label: string, todaySeconds: number): void {
   if (!tray) return
   isTimerRunning = running
   runningLabel = label
-  tray.setToolTip(running ? `TimeTrack ● ${label}` : 'TimeTrack — Kein Timer aktiv')
+  lastTodaySeconds = todaySeconds
+  // Tooltip format (v1.2 #31):
+  //   running: `● {client} · {HH:MM} · Heute {HH:MM}`
+  //   idle:    `TimeTrack — Heute {HH:MM}`
+  // (i18n in tooltip deferred to v1.4 — see DESIGN.md known limitations.)
+  tray.setToolTip(
+    running
+      ? `● ${label} · Heute ${fmtHHMM(todaySeconds)}`
+      : `TimeTrack — Heute ${fmtHHMM(todaySeconds)}`
+  )
   tray.setContextMenu(buildTrayMenu())
 }
 
@@ -220,7 +239,7 @@ app.whenReady().then(() => {
   loadStartupSettings()
 
   tray = new Tray(icon)
-  updateTray(false, '')
+  updateTray(false, '', 0)
   tray.on('click', () => {
     if (mainWindow?.isVisible()) {
       mainWindow.focus()
@@ -231,8 +250,8 @@ app.whenReady().then(() => {
   })
 
   // Renderer notifies main to update tray state + drive idle watcher.
-  ipcMain.on('tray:update', (_event, running: boolean, label: string) => {
-    updateTray(running, label)
+  ipcMain.on('tray:update', (_event, running: boolean, label: string, todaySeconds: number) => {
+    updateTray(running, label, todaySeconds ?? lastTodaySeconds)
     if (running) startIdleWatcher()
     else stopIdleWatcher()
   })

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -2,11 +2,7 @@ import { ipcMain, shell } from 'electron'
 import { app } from 'electron'
 import { getDb, getDbPath } from './db'
 import { getBackupsDir } from './backup'
-import {
-  createBackup,
-  listBackups,
-  restoreBackup as restoreBackupFile
-} from './backup'
+import { createBackup, listBackups, restoreBackup as restoreBackupFile } from './backup'
 import type {
   Client,
   Entry,
@@ -141,7 +137,9 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
     try {
       const row =
         (db
-          .prepare(`SELECT * FROM entries WHERE stopped_at IS NULL ORDER BY started_at DESC LIMIT 1`)
+          .prepare(
+            `SELECT * FROM entries WHERE stopped_at IS NULL ORDER BY started_at DESC LIMIT 1`
+          )
           .get() as Entry) ?? null
       return ok(row)
     } catch (e) {
@@ -182,6 +180,34 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
     try {
       db.prepare(`DELETE FROM entries WHERE id = ?`).run(id)
       return ok(undefined)
+    } catch (e) {
+      return fail(e)
+    }
+  })
+
+  // ── Dashboard ─────────────────────────────────────────────────
+  // Sum of today's tracked seconds, including the running entry up to now.
+  // Cross-midnight: a running entry started yesterday is counted via the
+  // `stopped_at IS NULL` branch (E7 in v1.2 plan) so the tray total never
+  // shows 0h while a 6h timer is visibly running.
+  ipcMain.handle('dashboard:todayTotal', (): IpcResult<number> => {
+    try {
+      const row = db
+        .prepare(
+          `SELECT COALESCE(SUM(
+             CASE
+               WHEN stopped_at IS NULL
+                 THEN (julianday('now') - julianday(started_at)) * 86400
+               ELSE (julianday(stopped_at) - julianday(started_at)) * 86400
+             END
+           ), 0) AS seconds
+           FROM entries
+           WHERE DATE(started_at, 'localtime') = DATE('now', 'localtime')
+              OR stopped_at IS NULL`
+        )
+        .get() as { seconds: number }
+      const seconds = Math.max(0, Math.floor(row.seconds ?? 0))
+      return ok(seconds)
     } catch (e) {
       return fail(e)
     }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -17,7 +17,7 @@ declare global {
     electron: ElectronAPI
     api: {
       tray: {
-        update(isRunning: boolean, label: string): void
+        update(isRunning: boolean, label: string, todaySeconds: number): void
       }
       onHotkeyToggle(callback: () => void): () => void
       onTrayQuickStart(callback: (clientId: number) => void): () => void
@@ -51,6 +51,9 @@ declare global {
         list(): Promise<IpcResult<BackupInfo[]>>
         create(): Promise<IpcResult<string>>
         restore(filePath: string): Promise<IpcResult<{ safetyBackupPath: string }>>
+      }
+      dashboard: {
+        todayTotal(): Promise<IpcResult<number>>
       }
       app: {
         relaunch(): Promise<IpcResult<void>>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -16,8 +16,8 @@ import type {
 const api = {
   // Tray + hotkey
   tray: {
-    update: (isRunning: boolean, label: string): void =>
-      ipcRenderer.send('tray:update', isRunning, label)
+    update: (isRunning: boolean, label: string, todaySeconds: number): void =>
+      ipcRenderer.send('tray:update', isRunning, label, todaySeconds)
   },
   onHotkeyToggle: (callback: () => void): (() => void) => {
     const handler = () => callback()
@@ -37,10 +37,8 @@ const api = {
   onIdleDetected: (
     callback: (data: { idleSince: string; idleSeconds: number }) => void
   ): (() => void) => {
-    const handler = (
-      _e: unknown,
-      data: { idleSince: string; idleSeconds: number }
-    ): void => callback(data)
+    const handler = (_e: unknown, data: { idleSince: string; idleSeconds: number }): void =>
+      callback(data)
     ipcRenderer.on('timer:idle-detected', handler)
     return () => ipcRenderer.removeListener('timer:idle-detected', handler)
   },
@@ -76,12 +74,15 @@ const api = {
     set: (key: string, value: string): Promise<IpcResult<void>> =>
       ipcRenderer.invoke('settings:set', key, value)
   },
-  // Backups
   backups: {
     list: (): Promise<IpcResult<BackupInfo[]>> => ipcRenderer.invoke('backup:list'),
     create: (): Promise<IpcResult<string>> => ipcRenderer.invoke('backup:create'),
     restore: (filePath: string): Promise<IpcResult<{ safetyBackupPath: string }>> =>
       ipcRenderer.invoke('backup:restore', filePath)
+  },
+  // Dashboard
+  dashboard: {
+    todayTotal: (): Promise<IpcResult<number>> => ipcRenderer.invoke('dashboard:todayTotal')
   },
   app: {
     relaunch: (): Promise<IpcResult<void>> => ipcRenderer.invoke('app:relaunch'),
@@ -94,8 +95,7 @@ const api = {
       ipcRenderer.invoke('shell:showItemInFolder', path)
   },
   paths: {
-    get: (): Promise<IpcResult<{ db: string; backups: string }>> =>
-      ipcRenderer.invoke('paths:get')
+    get: (): Promise<IpcResult<{ db: string; backups: string }>> => ipcRenderer.invoke('paths:get')
   }
 }
 

--- a/src/renderer/src/hooks/useTimer.ts
+++ b/src/renderer/src/hooks/useTimer.ts
@@ -2,6 +2,18 @@ import { useEffect, useRef, useCallback } from 'react'
 import { useTimerStore } from '../store/timerStore'
 import { formatDuration as _formatDuration } from '../../../shared/duration'
 
+/**
+ * Fetch today's total seconds from main and push it to the tray together with
+ * the current running label. Centralised so every callsite (start, stop,
+ * heartbeat, init, idle handlers) keeps the tray tooltip in sync — no second
+ * polling interval is needed (E5 in v1.2 plan).
+ */
+async function pushTrayUpdate(running: boolean, label: string): Promise<void> {
+  const totalRes = await window.api.dashboard.todayTotal()
+  const seconds = totalRes.ok ? totalRes.data : 0
+  window.api.tray.update(running, label, seconds)
+}
+
 // Refs shared across all useTimer() instances so listeners are registered ONCE
 // globally and always invoke the latest callback.
 const globalToggleRef: { current: () => void } = { current: () => {} }
@@ -9,7 +21,9 @@ const globalQuickStartRef: { current: (clientId: number) => void } = { current: 
 const globalStopRef: { current: () => void } = { current: () => {} }
 let listenersInstalled = false
 
-function installGlobalListenersOnce(setIdleEvent: (e: { idleSince: string; idleSeconds: number } | null) => void): void {
+function installGlobalListenersOnce(
+  setIdleEvent: (e: { idleSince: string; idleSeconds: number } | null) => void
+): void {
   if (listenersInstalled) return
   listenersInstalled = true
   window.api.onHotkeyToggle(() => globalToggleRef.current())
@@ -66,7 +80,10 @@ export function useTimer() {
         setElapsedSeconds(Math.floor((Date.now() - started) / 1000))
         const allClients = clientsRes.ok ? clientsRes.data : []
         const clientName = allClients.find((c) => c.id === entry.client_id)?.name ?? ''
-        window.api.tray.update(true, clientName)
+        await pushTrayUpdate(true, clientName)
+      } else {
+        // Idle on launch: still surface today's total in the tray tooltip.
+        await pushTrayUpdate(false, '')
       }
     }
     init()
@@ -82,9 +99,13 @@ export function useTimer() {
         )
       }, 1000)
 
-      // Heartbeat every 30s
+      // Heartbeat every 30s — also refreshes the tray today-total so the
+      // tooltip stays current without a second timer (v1.2 plan, E5).
       heartbeatRef.current = setInterval(() => {
         window.api.entries.heartbeat(runningEntry.id)
+        const clientName =
+          useTimerStore.getState().clients.find((c) => c.id === runningEntry.client_id)?.name ?? ''
+        void pushTrayUpdate(true, clientName)
       }, 30_000)
     } else {
       if (!runningEntry) setElapsedSeconds(0)
@@ -108,7 +129,7 @@ export function useTimer() {
     if (res.ok) {
       setRunningEntry(res.data)
       const clientName = clients.find((c) => c.id === selectedClientId)?.name ?? ''
-      window.api.tray.update(true, clientName)
+      await pushTrayUpdate(true, clientName)
     }
   }, [selectedClientId, description, clients])
 
@@ -120,7 +141,7 @@ export function useTimer() {
     if (res.ok) {
       setRunningEntry(null)
       setDescription('')
-      window.api.tray.update(false, '')
+      await pushTrayUpdate(false, '')
       // If user manually stops, dismiss any pending idle event.
       if (useTimerStore.getState().idleEvent) {
         setIdleEvent(null)
@@ -144,7 +165,7 @@ export function useTimer() {
         setRunningEntry(res.data)
         setDescription('')
         const clientName = clients.find((c) => c.id === clientId)?.name ?? ''
-        window.api.tray.update(true, clientName)
+        await pushTrayUpdate(true, clientName)
       }
     },
     [clients]
@@ -178,7 +199,7 @@ export function useTimer() {
     if (res.ok) {
       setRunningEntry(null)
       setDescription('')
-      window.api.tray.update(false, '')
+      await pushTrayUpdate(false, '')
     }
     dismissIdle()
   }, [dismissIdle])
@@ -219,7 +240,7 @@ export function useTimer() {
       }
       setRunningEntry(null)
       setDescription('')
-      window.api.tray.update(false, '')
+      await pushTrayUpdate(false, '')
     }
     setIsLoading(false)
     dismissIdle()

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -112,9 +112,7 @@ export default function SettingsView(): React.JSX.Element {
       <h1 className="text-2xl font-semibold text-slate-100">Einstellungen</h1>
 
       {statusMsg && (
-        <div className="rounded-md bg-slate-800 px-3 py-2 text-sm text-slate-300">
-          {statusMsg}
-        </div>
+        <div className="rounded-md bg-slate-800 px-3 py-2 text-sm text-slate-300">{statusMsg}</div>
       )}
 
       {/* Allgemein */}
@@ -147,7 +145,7 @@ export default function SettingsView(): React.JSX.Element {
             value={settings.company_name}
             onChange={(e) => update('company_name', e.target.value)}
             className={inputClass}
-            placeholder="z.\u202fB. Meine Firma GmbH"
+            placeholder={'z.\u202fB. Meine Firma GmbH'}
           />
         </Row>
       </Section>


### PR DESCRIPTION
**v1.2 PR A — Warm-up:** Bug fix + Tray tooltip extension + DESIGN.md visual-token stub. Low-risk foundation before PR B (data migration) and PR C (UI).

Closes #15
Refs #31

## Changes

### 1. Bug #15 — Settings placeholder shows raw escape
- `src/renderer/src/views/SettingsView.tsx`: wrap the narrow-no-break-space placeholder in a JSX expression so the `\u202f` escape is interpreted instead of rendered literally.

### 2. Tray tooltip with today's total (#31)
Adds the today total to the tray tooltip so users see "How much have I tracked today?" at a glance.

- **`src/main/ipc.ts`** — new `dashboard:todayTotal` handler returning `IpcResult<number>` (seconds). SQL handles cross-midnight running entries via `stopped_at IS NULL`.
- **`src/preload/index.ts` + `index.d.ts`** — `tray.update` signature extended to `(running, label, todaySeconds)`; new `dashboard.todayTotal()` bridge.
- **`src/main/index.ts`** — `updateTray()` now formats `● Kunde · Heute HH:MM` (running) / `TimeTrack — Heute HH:MM` (idle). New `fmtHHMM()` helper. `tray:update` IPC handler accepts `todaySeconds` with a `lastTodaySeconds` fallback.
- **`src/renderer/src/hooks/useTimer.ts`** — heartbeat (30s) piggybacks `dashboard.todayTotal` + `tray.update` (no second timer). All 6 callsites routed through a single `pushTrayUpdate(running, label)` helper.

### 3. DESIGN.md v1.2 visual-token stub
Locks the design vocabulary that PR C will consume.
- Surface tokens (slate-900 → slate-100), accent (indigo-500/400), semantic (emerald/amber/red-500).
- 10-color client palette.
- Typography scale (56/24/20/14/12) and spacing tokens (4/8/12/16/24/32).
- Calendar mini-bars: 3 px height, 2 px gap, max 5 visible + clickable `+N`.
- Drawer: `fixed right-0 top-0 w-96 h-screen` with sticky header/footer.
- **Known Limitations table L1–L6** — explicit deferrals (tray i18n → v1.4, colorblind palette → v1.4, mobile <1024 → v1.4, light mode → post-v1.5, cross-midnight reporting → v1.3, full ARIA → v1.3).

## Verification

- `pnpm typecheck` — green (node + web)
- `pnpm test` — 18 pass / 7 skipped (no regressions)
- `pnpm lint` — pre-existing 21 errors (unchanged from `main`); warnings dropped after prettier ran on the 7 modified files
- Manual smoke (recommended on review): start a timer → tray tooltip shows `● Kunde · Heute HH:MM` and updates within 30 s; stop → idle format; Settings input shows the narrow space (no `\u202f`).

## Out of scope (deferred to follow-up PRs)

- **PR B**: migration 003 (`entries.deleted_at`, `entries.note`, `dashboard:summary`, soft-delete + undo IPC, form primitives).
- **PR C**: TodayView (default tab), CalendarView (month grid), entry-detail drawer with delete/undo.
- **PR D**: CI `electron-rebuild` step + smoke build before tagging v1.2.0.
