### PR TITLE
feat(v1.2 PR B): migration 003, soft-delete IPC, form primitives, stores

### DIFF
--- a/src/main/ipc.test.ts
+++ b/src/main/ipc.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Validation contract tests for `entries:create` and `entries:update`.
+ *
+ * We do not boot the full Electron IPC layer here. Instead we exercise the
+ * same SQL surface and a local replica of `validateManualEntry` against an
+ * in-memory DB seeded with the v1.2 schema. Keeps the test fast and avoids
+ * an Electron runtime dependency in unit tests.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import type Database from 'better-sqlite3'
+import { migrations } from './migrations'
+import { isSameLocalDay } from '../shared/date'
+
+const MAX_DESCRIPTION_LEN = 500
+const MAX_DURATION_SECONDS = 24 * 3600
+
+type DatabaseCtor = new (path: string) => Database.Database
+let DatabaseImpl: DatabaseCtor | null = null
+
+beforeAll(async () => {
+  try {
+    const mod = await import('better-sqlite3')
+    const Ctor = mod.default as unknown as DatabaseCtor
+    const probe = new Ctor(':memory:')
+    probe.close()
+    DatabaseImpl = Ctor
+  } catch {
+    DatabaseImpl = null
+  }
+})
+
+interface ManualInput {
+  client_id: number
+  description: string
+  started_at: string
+  stopped_at: string
+}
+
+function validateManualEntry(
+  db: Database.Database,
+  input: ManualInput,
+  excludeId?: number
+): string | null {
+  const start = new Date(input.started_at)
+  const stop = new Date(input.stopped_at)
+  if (Number.isNaN(start.getTime())) return 'Startzeit ist ungültig'
+  if (Number.isNaN(stop.getTime())) return 'Endzeit ist ungültig'
+  if (start.getTime() > Date.now()) return 'Startzeit darf nicht in der Zukunft liegen'
+  if (stop.getTime() <= start.getTime()) return 'Endzeit muss nach der Startzeit liegen'
+  if (!isSameLocalDay(start, stop)) {
+    return 'Einträge können aktuell nicht über Mitternacht gehen (folgt in v1.3)'
+  }
+  const durationSec = (stop.getTime() - start.getTime()) / 1000
+  if (durationSec > MAX_DURATION_SECONDS) return 'Dauer überschreitet 24 Stunden'
+  if ((input.description ?? '').length > MAX_DESCRIPTION_LEN) {
+    return `Beschreibung überschreitet ${MAX_DESCRIPTION_LEN} Zeichen`
+  }
+  const clientRow = db.prepare(`SELECT id FROM clients WHERE id = ?`).get(input.client_id) as
+    | { id: number }
+    | undefined
+  if (!clientRow) return 'Kunde existiert nicht'
+  const params: Array<string | number> = [input.client_id, input.stopped_at, input.started_at]
+  let overlapSql = `SELECT id FROM entries
+                     WHERE client_id = ? AND deleted_at IS NULL
+                       AND started_at < ?
+                       AND COALESCE(stopped_at, datetime('now')) > ?`
+  if (excludeId !== undefined) {
+    overlapSql += ` AND id != ?`
+    params.push(excludeId)
+  }
+  const overlap = db.prepare(overlapSql).get(...params) as { id: number } | undefined
+  if (overlap) return 'Eintrag überlappt mit einem bestehenden Eintrag desselben Kunden'
+  return null
+}
+
+describe('entries:create / entries:update validation contract', () => {
+  let tmpDir: string
+  let db: Database.Database
+  // Anchor "today" to a fixed date so tests don't depend on wall clock.
+  // Use yesterday relative to runtime so start times are always "in the past".
+  const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000)
+  function todayAt(hh: number, mm: number): string {
+    const d = new Date(yesterday)
+    d.setHours(hh, mm, 0, 0)
+    return d.toISOString()
+  }
+
+  beforeEach((ctx) => {
+    if (!DatabaseImpl) {
+      ctx.skip()
+      return
+    }
+    tmpDir = mkdtempSync(join(tmpdir(), 'tt-ipc-'))
+    db = new DatabaseImpl(join(tmpDir, 'test.sqlite'))
+    db.pragma('foreign_keys = ON')
+    db.exec(
+      `CREATE TABLE schema_version (
+         version INTEGER PRIMARY KEY,
+         name TEXT NOT NULL,
+         applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+       )`
+    )
+    for (const m of migrations) {
+      const tx = db.transaction(() => {
+        db.exec(m.up)
+        db.prepare('INSERT INTO schema_version (version, name) VALUES (?, ?)').run(
+          m.version,
+          m.name
+        )
+      })
+      tx()
+    }
+    db.prepare(`INSERT INTO clients (id, name) VALUES (1, 'Acme')`).run()
+    db.prepare(`INSERT INTO clients (id, name) VALUES (2, 'Other')`).run()
+  })
+
+  afterEach(() => {
+    if (!db) return
+    db.close()
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('accepts a valid entry', () => {
+    const err = validateManualEntry(db, {
+      client_id: 1,
+      description: 'work',
+      started_at: todayAt(8, 0),
+      stopped_at: todayAt(9, 30)
+    })
+    expect(err).toBeNull()
+  })
+
+  it('rejects future start', () => {
+    const future = new Date(Date.now() + 60 * 60 * 1000)
+    const future2 = new Date(future.getTime() + 30 * 60 * 1000)
+    const err = validateManualEntry(db, {
+      client_id: 1,
+      description: '',
+      started_at: future.toISOString(),
+      stopped_at: future2.toISOString()
+    })
+    expect(err).toMatch(/Zukunft/)
+  })
+
+  it('rejects stopped_at <= started_at', () => {
+    const err = validateManualEntry(db, {
+      client_id: 1,
+      description: '',
+      started_at: todayAt(10, 0),
+      stopped_at: todayAt(10, 0)
+    })
+    expect(err).toMatch(/Endzeit/)
+  })
+
+  it('rejects cross-midnight (different local day)', () => {
+    const start = new Date(yesterday)
+    start.setHours(23, 30, 0, 0)
+    const stop = new Date(yesterday)
+    stop.setDate(stop.getDate() + 1)
+    stop.setHours(0, 30, 0, 0)
+    const err = validateManualEntry(db, {
+      client_id: 1,
+      description: '',
+      started_at: start.toISOString(),
+      stopped_at: stop.toISOString()
+    })
+    expect(err).toMatch(/Mitternacht/)
+  })
+
+  it('rejects unknown client', () => {
+    const err = validateManualEntry(db, {
+      client_id: 999,
+      description: '',
+      started_at: todayAt(8, 0),
+      stopped_at: todayAt(9, 0)
+    })
+    expect(err).toMatch(/Kunde/)
+  })
+
+  it('rejects description over 500 chars', () => {
+    const err = validateManualEntry(db, {
+      client_id: 1,
+      description: 'x'.repeat(501),
+      started_at: todayAt(8, 0),
+      stopped_at: todayAt(9, 0)
+    })
+    expect(err).toMatch(/Beschreibung/)
+  })
+
+  it('rejects overlapping entry on same client', () => {
+    db.prepare(
+      `INSERT INTO entries (client_id, started_at, stopped_at)
+       VALUES (1, ?, ?)`
+    ).run(todayAt(9, 0), todayAt(10, 0))
+    const err = validateManualEntry(db, {
+      client_id: 1,
+      description: '',
+      started_at: todayAt(9, 30),
+      stopped_at: todayAt(10, 30)
+    })
+    expect(err).toMatch(/überlappt/)
+  })
+
+  it('allows overlap with a different client', () => {
+    db.prepare(
+      `INSERT INTO entries (client_id, started_at, stopped_at)
+       VALUES (1, ?, ?)`
+    ).run(todayAt(9, 0), todayAt(10, 0))
+    const err = validateManualEntry(db, {
+      client_id: 2,
+      description: '',
+      started_at: todayAt(9, 30),
+      stopped_at: todayAt(10, 30)
+    })
+    expect(err).toBeNull()
+  })
+
+  it('ignores soft-deleted entries when checking overlap', () => {
+    const info = db
+      .prepare(
+        `INSERT INTO entries (client_id, started_at, stopped_at, deleted_at)
+         VALUES (1, ?, ?, ?)`
+      )
+      .run(todayAt(9, 0), todayAt(10, 0), new Date().toISOString())
+    expect(info.changes).toBe(1)
+    const err = validateManualEntry(db, {
+      client_id: 1,
+      description: '',
+      started_at: todayAt(9, 30),
+      stopped_at: todayAt(10, 30)
+    })
+    expect(err).toBeNull()
+  })
+
+  it('allows updating an entry without overlapping itself', () => {
+    const info = db
+      .prepare(
+        `INSERT INTO entries (client_id, started_at, stopped_at)
+         VALUES (1, ?, ?)`
+      )
+      .run(todayAt(9, 0), todayAt(10, 0))
+    const id = info.lastInsertRowid as number
+    const err = validateManualEntry(
+      db,
+      {
+        client_id: 1,
+        description: '',
+        started_at: todayAt(9, 15),
+        stopped_at: todayAt(10, 15)
+      },
+      id
+    )
+    expect(err).toBeNull()
+  })
+})

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -3,18 +3,24 @@ import { app } from 'electron'
 import { getDb, getDbPath } from './db'
 import { getBackupsDir } from './backup'
 import { createBackup, listBackups, restoreBackup as restoreBackupFile } from './backup'
+import { isSameLocalDay } from '../shared/date'
 import type {
   Client,
   Entry,
   CreateClientInput,
   UpdateClientInput,
   CreateEntryInput,
+  CreateManualEntryInput,
   UpdateEntryInput,
   MonthQuery,
   Settings,
   IpcResult,
-  BackupInfo
+  BackupInfo,
+  DashboardSummary
 } from '../shared/types'
+
+const MAX_DESCRIPTION_LEN = 500
+const MAX_DURATION_SECONDS = 24 * 3600
 
 export interface IpcHooks {
   refreshTrayClients(): void
@@ -138,7 +144,9 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
       const row =
         (db
           .prepare(
-            `SELECT * FROM entries WHERE stopped_at IS NULL ORDER BY started_at DESC LIMIT 1`
+            `SELECT * FROM entries
+             WHERE stopped_at IS NULL AND deleted_at IS NULL
+             ORDER BY started_at DESC LIMIT 1`
           )
           .get() as Entry) ?? null
       return ok(row)
@@ -155,7 +163,9 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
       const end = `${nextYear}-${String(nextMonth).padStart(2, '0')}-01T00:00:00.000Z`
       const rows = db
         .prepare(
-          `SELECT * FROM entries WHERE started_at >= ? AND started_at < ? ORDER BY started_at ASC`
+          `SELECT * FROM entries
+             WHERE started_at >= ? AND started_at < ? AND deleted_at IS NULL
+             ORDER BY started_at ASC`
         )
         .all(start, end) as Entry[]
       return ok(rows)
@@ -164,11 +174,59 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
     }
   })
 
+  /**
+   * Manual-entry creation (Today "+ Eintrag nachtragen", Calendar Drawer
+   * "+ Eintrag hinzufügen"). Server-side validation per v1.2 plan E3 — UI
+   * may also pre-validate but must not be the only line of defence.
+   */
+  ipcMain.handle('entries:create', (_e, input: CreateManualEntryInput): IpcResult<Entry> => {
+    try {
+      const err = validateManualEntry(db, input)
+      if (err) return fail(err)
+      const info = db
+        .prepare(
+          `INSERT INTO entries (client_id, description, started_at, stopped_at, heartbeat_at, rounded_min)
+           VALUES (?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          input.client_id,
+          input.description.trim(),
+          input.started_at,
+          input.stopped_at,
+          input.stopped_at,
+          Math.round(
+            (new Date(input.stopped_at).getTime() - new Date(input.started_at).getTime()) / 60000
+          )
+        )
+      const row = db
+        .prepare(`SELECT * FROM entries WHERE id = ?`)
+        .get(info.lastInsertRowid) as Entry
+      return ok(row)
+    } catch (e) {
+      return fail(e)
+    }
+  })
+
   ipcMain.handle('entries:update', (_e, input: UpdateEntryInput): IpcResult<Entry> => {
     try {
+      // Reuse the same validation contract as create (excluding overlap with self).
+      const err = validateManualEntry(db, input, input.id)
+      if (err) return fail(err)
       db.prepare(
-        `UPDATE entries SET client_id = ?, description = ?, started_at = ?, stopped_at = ? WHERE id = ?`
-      ).run(input.client_id, input.description, input.started_at, input.stopped_at, input.id)
+        `UPDATE entries
+            SET client_id = ?, description = ?, started_at = ?, stopped_at = ?,
+                rounded_min = ?
+          WHERE id = ?`
+      ).run(
+        input.client_id,
+        input.description.trim(),
+        input.started_at,
+        input.stopped_at,
+        Math.round(
+          (new Date(input.stopped_at).getTime() - new Date(input.started_at).getTime()) / 60000
+        ),
+        input.id
+      )
       const row = db.prepare(`SELECT * FROM entries WHERE id = ?`).get(input.id) as Entry
       return ok(row)
     } catch (e) {
@@ -176,10 +234,24 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
     }
   })
 
+  /**
+   * Soft-delete: flip deleted_at instead of removing the row, so the Toast
+   * "Rückgängig" path can restore the SAME id (preserves future PDF FKs — E10).
+   */
   ipcMain.handle('entries:delete', (_e, id: number): IpcResult<void> => {
     try {
-      db.prepare(`DELETE FROM entries WHERE id = ?`).run(id)
+      db.prepare(`UPDATE entries SET deleted_at = ? WHERE id = ?`).run(new Date().toISOString(), id)
       return ok(undefined)
+    } catch (e) {
+      return fail(e)
+    }
+  })
+
+  ipcMain.handle('entries:undelete', (_e, id: number): IpcResult<Entry> => {
+    try {
+      db.prepare(`UPDATE entries SET deleted_at = NULL WHERE id = ?`).run(id)
+      const row = db.prepare(`SELECT * FROM entries WHERE id = ?`).get(id) as Entry
+      return ok(row)
     } catch (e) {
       return fail(e)
     }
@@ -202,12 +274,110 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
              END
            ), 0) AS seconds
            FROM entries
-           WHERE DATE(started_at, 'localtime') = DATE('now', 'localtime')
-              OR stopped_at IS NULL`
+           WHERE deleted_at IS NULL
+             AND (DATE(started_at, 'localtime') = DATE('now', 'localtime')
+                  OR stopped_at IS NULL)`
         )
         .get() as { seconds: number }
       const seconds = Math.max(0, Math.floor(row.seconds ?? 0))
       return ok(seconds)
+    } catch (e) {
+      return fail(e)
+    }
+  })
+
+  /**
+   * One-shot dashboard payload for the Today view. All four queries run in
+   * a single read transaction so the snapshot is consistent. Cross-midnight
+   * running entry counted via `stopped_at IS NULL` (matches todayTotal).
+   */
+  ipcMain.handle('dashboard:summary', (): IpcResult<DashboardSummary> => {
+    try {
+      const tx = db.transaction((): DashboardSummary => {
+        const today = db
+          .prepare(
+            `SELECT COALESCE(SUM(
+               CASE
+                 WHEN stopped_at IS NULL
+                   THEN (julianday('now') - julianday(started_at)) * 86400
+                 ELSE (julianday(stopped_at) - julianday(started_at)) * 86400
+               END
+             ), 0) AS seconds
+             FROM entries
+             WHERE deleted_at IS NULL
+               AND (DATE(started_at, 'localtime') = DATE('now', 'localtime')
+                    OR stopped_at IS NULL)`
+          )
+          .get() as { seconds: number }
+
+        // ISO week — Monday as first day. SQLite's strftime('%w') returns
+        // 0=Sunday, so we shift to start the window from the most recent
+        // Monday at local midnight.
+        const week = db
+          .prepare(
+            `SELECT COALESCE(SUM(
+               CASE
+                 WHEN stopped_at IS NULL
+                   THEN (julianday('now') - julianday(started_at)) * 86400
+                 ELSE (julianday(stopped_at) - julianday(started_at)) * 86400
+               END
+             ), 0) AS seconds
+             FROM entries
+             WHERE deleted_at IS NULL
+               AND (
+                 DATE(started_at, 'localtime')
+                   >= DATE('now', 'localtime', 'weekday 0', '-7 days')
+                 OR stopped_at IS NULL
+               )`
+          )
+          .get() as { seconds: number }
+
+        const recentEntries = db
+          .prepare(
+            `SELECT * FROM entries
+               WHERE deleted_at IS NULL
+               ORDER BY started_at DESC LIMIT 5`
+          )
+          .all() as Entry[]
+
+        const topClients30d = db
+          .prepare(
+            `SELECT c.id AS client_id, c.name, c.color,
+                    COALESCE(SUM(
+                      CASE
+                        WHEN e.stopped_at IS NULL
+                          THEN (julianday('now') - julianday(e.started_at)) * 86400
+                        ELSE (julianday(e.stopped_at) - julianday(e.started_at)) * 86400
+                      END
+                    ), 0) AS seconds
+               FROM clients c
+               LEFT JOIN entries e ON e.client_id = c.id
+                 AND e.deleted_at IS NULL
+                 AND DATE(e.started_at, 'localtime')
+                       >= DATE('now', 'localtime', '-30 days')
+              GROUP BY c.id
+              HAVING seconds > 0
+              ORDER BY seconds DESC
+              LIMIT 3`
+          )
+          .all() as Array<{
+          client_id: number
+          name: string
+          color: string
+          seconds: number
+        }>
+
+        return {
+          todaySeconds: Math.max(0, Math.floor(today.seconds ?? 0)),
+          weekSeconds: Math.max(0, Math.floor(week.seconds ?? 0)),
+          recentEntries,
+          topClients30d: topClients30d.map((r) => ({
+            ...r,
+            seconds: Math.max(0, Math.floor(r.seconds ?? 0))
+          }))
+        }
+      })
+      return ok(tx())
     } catch (e) {
       return fail(e)
     }
@@ -307,4 +477,66 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
   ipcMain.handle('app:getVersion', (): IpcResult<string> => {
     return ok(app.getVersion())
   })
+}
+
+/**
+ * Server-side validation contract for manual entry create/update (E3).
+ * Returns an error string if invalid, `null` if valid. Single point of
+ * truth: UI may pre-validate but must not be the only line of defence
+ * (e.g. against malicious renderer code or future scripted clients).
+ *
+ * Rules:
+ *  - started_at <= now (no future entries)
+ *  - stopped_at > started_at
+ *  - same local day (cross-midnight rejected in v1.2; v1.3 will lift this)
+ *  - client_id exists
+ *  - description.length <= 500
+ *  - duration <= 24h
+ *  - no overlap with existing non-deleted entry of the same client
+ *    (excluding the entry itself when updating)
+ */
+function validateManualEntry(
+  db: ReturnType<typeof getDb>,
+  input: {
+    client_id: number
+    description: string
+    started_at: string
+    stopped_at: string
+  },
+  excludeId?: number
+): string | null {
+  const start = new Date(input.started_at)
+  const stop = new Date(input.stopped_at)
+  if (Number.isNaN(start.getTime())) return 'Startzeit ist ungültig'
+  if (Number.isNaN(stop.getTime())) return 'Endzeit ist ungültig'
+  const now = Date.now()
+  if (start.getTime() > now) return 'Startzeit darf nicht in der Zukunft liegen'
+  if (stop.getTime() <= start.getTime()) return 'Endzeit muss nach der Startzeit liegen'
+  if (!isSameLocalDay(start, stop)) {
+    return 'Einträge können aktuell nicht über Mitternacht gehen (folgt in v1.3)'
+  }
+  const durationSec = (stop.getTime() - start.getTime()) / 1000
+  if (durationSec > MAX_DURATION_SECONDS) return 'Dauer überschreitet 24 Stunden'
+  if ((input.description ?? '').length > MAX_DESCRIPTION_LEN) {
+    return `Beschreibung überschreitet ${MAX_DESCRIPTION_LEN} Zeichen`
+  }
+  const clientRow = db.prepare(`SELECT id FROM clients WHERE id = ?`).get(input.client_id) as
+    | { id: number }
+    | undefined
+  if (!clientRow) return 'Kunde existiert nicht'
+  // Overlap: any non-deleted entry of the same client whose time range
+  // intersects [start, stop). Two intervals overlap iff
+  //   existing.started_at < stop AND COALESCE(existing.stopped_at, now) > start
+  const params: Array<string | number> = [input.client_id, input.stopped_at, input.started_at]
+  let overlapSql = `SELECT id FROM entries
+                     WHERE client_id = ? AND deleted_at IS NULL
+                       AND started_at < ?
+                       AND COALESCE(stopped_at, datetime('now')) > ?`
+  if (excludeId !== undefined) {
+    overlapSql += ` AND id != ?`
+    params.push(excludeId)
+  }
+  const overlap = db.prepare(overlapSql).get(...params) as { id: number } | undefined
+  if (overlap) return 'Eintrag überlappt mit einem bestehenden Eintrag desselben Kunden'
+  return null
 }

--- a/src/main/migrations/003-v12-data.ts
+++ b/src/main/migrations/003-v12-data.ts
@@ -1,0 +1,35 @@
+import type { Migration } from './index'
+
+/**
+ * v1.2 data layer:
+ * - clients.rate_cent: hourly rate in cents (preparation for v1.3 PDF export
+ *   billing). Default 0 = "no rate set", treated as informational only.
+ * - entries.deleted_at: soft-delete column. NULL = visible. UI flips it via
+ *   entries:delete and reverts via entries:undelete (Toast undo).
+ *   Soft-delete preserves the row + ID so future PDF FKs stay stable (E10).
+ * - idx_entries_started_at: speeds up dashboard:summary + getByMonth queries
+ *   that filter on started_at without a client_id prefix (E12).
+ * - Backfill rounded_min for finished entries that never received it (older
+ *   v1.0 rows). Skips running entries (stopped_at IS NULL) and clock-skew
+ *   rows (stopped_at < started_at). The runner's post-apply assertion will
+ *   abort if any negative duration sneaks through.
+ */
+export const migration003: Migration = {
+  version: 3,
+  name: 'v1.2-data',
+  up: `
+    ALTER TABLE clients ADD COLUMN rate_cent INTEGER NOT NULL DEFAULT 0;
+    ALTER TABLE entries ADD COLUMN deleted_at TEXT;
+
+    CREATE INDEX IF NOT EXISTS idx_entries_started_at
+      ON entries(started_at);
+
+    UPDATE entries
+       SET rounded_min = CAST(
+         ROUND((julianday(stopped_at) - julianday(started_at)) * 1440) AS INTEGER
+       )
+     WHERE rounded_min IS NULL
+       AND stopped_at IS NOT NULL
+       AND stopped_at >= started_at;
+  `
+}

--- a/src/main/migrations/index.ts
+++ b/src/main/migrations/index.ts
@@ -1,5 +1,6 @@
 import { migration001 } from './001-initial'
 import { migration002 } from './002-v11-settings'
+import { migration003 } from './003-v12-data'
 
 export interface Migration {
   /** Monotonically increasing integer. Never reused, never reordered. */
@@ -14,6 +15,6 @@ export interface Migration {
  * All migrations in order. New migrations must be APPENDED, never inserted
  * in the middle. Once shipped, a migration is immutable.
  */
-export const migrations: Migration[] = [migration001, migration002].sort(
+export const migrations: Migration[] = [migration001, migration002, migration003].sort(
   (a, b) => a.version - b.version
 )

--- a/src/main/migrations/migrations.test.ts
+++ b/src/main/migrations/migrations.test.ts
@@ -76,9 +76,10 @@ describe('migration SQL execution', () => {
     for (const m of migrations) {
       const tx = db.transaction(() => {
         db.exec(m.up)
-        db.prepare(
-          'INSERT INTO schema_version (version, name) VALUES (?, ?)'
-        ).run(m.version, m.name)
+        db.prepare('INSERT INTO schema_version (version, name) VALUES (?, ?)').run(
+          m.version,
+          m.name
+        )
       })
       tx()
     }
@@ -87,9 +88,9 @@ describe('migration SQL execution', () => {
   it('migration 001 creates clients, entries, settings tables', () => {
     applyAll()
     const tables = (
-      db
-        .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
-        .all() as Array<{ name: string }>
+      db.prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").all() as Array<{
+        name: string
+      }>
     ).map((r) => r.name)
     expect(tables).toContain('clients')
     expect(tables).toContain('entries')
@@ -108,9 +109,7 @@ describe('migration SQL execution', () => {
 
   it('migrations seed default settings', () => {
     applyAll()
-    const rows = db
-      .prepare('SELECT key, value FROM settings ORDER BY key')
-      .all()
+    const rows = db.prepare('SELECT key, value FROM settings ORDER BY key').all()
     expect(rows).toEqual([
       { key: 'auto_start', value: '0' },
       { key: 'backup_path', value: '' },
@@ -123,10 +122,35 @@ describe('migration SQL execution', () => {
     ])
   })
 
-  it('migrations are idempotent', () => {
-    applyAll()
+  it('seed-only migrations are idempotent (001 + 002)', () => {
+    // Migrations whose `up` SQL contains ONLY CREATE IF NOT EXISTS and
+    // INSERT OR IGNORE are safe to replay on existing v1.0 installs.
+    // 003+ may use ALTER TABLE — those rely on schema_version + the runner
+    // (which only applies pending migrations) for idempotency.
+    const seedOnly = migrations.filter((m) => m.version <= 2)
+    for (const m of seedOnly) {
+      const tx = db.transaction(() => {
+        db.exec(m.up)
+        db.prepare('INSERT INTO schema_version (version, name) VALUES (?, ?)').run(
+          m.version,
+          m.name
+        )
+      })
+      tx()
+    }
     db.exec('DELETE FROM schema_version')
-    expect(() => applyAll()).not.toThrow()
+    expect(() => {
+      for (const m of seedOnly) {
+        const tx = db.transaction(() => {
+          db.exec(m.up)
+          db.prepare('INSERT INTO schema_version (version, name) VALUES (?, ?)').run(
+            m.version,
+            m.name
+          )
+        })
+        tx()
+      }
+    }).not.toThrow()
     const count = db.prepare('SELECT COUNT(*) as n FROM settings').get() as {
       n: number
     }
@@ -140,20 +164,95 @@ describe('migration SQL execution', () => {
       "INSERT INTO entries (client_id, started_at) VALUES (1, '2026-01-01T00:00:00Z')"
     ).run()
     db.prepare('DELETE FROM clients WHERE id = 1').run()
-    const remaining = db
-      .prepare('SELECT COUNT(*) as n FROM entries')
-      .get() as { n: number }
+    const remaining = db.prepare('SELECT COUNT(*) as n FROM entries').get() as { n: number }
     expect(remaining.n).toBe(0)
   })
 
   it('records each applied migration in schema_version', () => {
     applyAll()
-    const rows = db
-      .prepare('SELECT version, name FROM schema_version ORDER BY version')
-      .all()
-    expect(rows).toEqual(
-      migrations.map((m) => ({ version: m.version, name: m.name }))
+    const rows = db.prepare('SELECT version, name FROM schema_version ORDER BY version').all()
+    expect(rows).toEqual(migrations.map((m) => ({ version: m.version, name: m.name })))
+  })
+
+  it('migration 003 adds clients.rate_cent and entries.deleted_at', () => {
+    applyAll()
+    const clientCols = (
+      db.prepare('PRAGMA table_info(clients)').all() as Array<{ name: string }>
+    ).map((r) => r.name)
+    const entryCols = (
+      db.prepare('PRAGMA table_info(entries)').all() as Array<{ name: string }>
+    ).map((r) => r.name)
+    expect(clientCols).toContain('rate_cent')
+    expect(entryCols).toContain('deleted_at')
+  })
+
+  it('migration 003 creates idx_entries_started_at', () => {
+    applyAll()
+    const idx = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_entries_started_at'"
+      )
+      .get()
+    expect(idx).toBeDefined()
+  })
+
+  it('migration 003 backfills rounded_min for finished entries only', () => {
+    applyAll()
+    db.prepare("INSERT INTO clients (id, name) VALUES (1, 'Acme')").run()
+    // Finished entry without rounded_min
+    db.prepare(
+      `INSERT INTO entries (client_id, started_at, stopped_at)
+       VALUES (1, '2026-04-24T08:00:00Z', '2026-04-24T09:30:00Z')`
+    ).run()
+    // Running entry — must remain NULL after backfill replays
+    db.prepare(
+      `INSERT INTO entries (client_id, started_at) VALUES (1, '2026-04-24T10:00:00Z')`
+    ).run()
+    // Replay the backfill statement directly (idempotent).
+    db.exec(
+      `UPDATE entries
+         SET rounded_min = CAST(
+           ROUND((julianday(stopped_at) - julianday(started_at)) * 1440) AS INTEGER
+         )
+       WHERE rounded_min IS NULL
+         AND stopped_at IS NOT NULL
+         AND stopped_at >= started_at`
     )
+    const rows = db
+      .prepare('SELECT id, stopped_at, rounded_min FROM entries ORDER BY id')
+      .all() as Array<{ id: number; stopped_at: string | null; rounded_min: number | null }>
+    expect(rows[0].rounded_min).toBe(90)
+    expect(rows[1].stopped_at).toBeNull()
+    expect(rows[1].rounded_min).toBeNull()
+  })
+
+  it('migration 003 skips clock-skew rows (stopped_at < started_at)', () => {
+    applyAll()
+    db.prepare("INSERT INTO clients (id, name) VALUES (1, 'Acme')").run()
+    db.prepare(
+      `INSERT INTO entries (client_id, started_at, stopped_at)
+       VALUES (1, '2026-04-24T10:00:00Z', '2026-04-24T09:00:00Z')`
+    ).run()
+    db.exec(
+      `UPDATE entries
+         SET rounded_min = CAST(
+           ROUND((julianday(stopped_at) - julianday(started_at)) * 1440) AS INTEGER
+         )
+       WHERE rounded_min IS NULL
+         AND stopped_at IS NOT NULL
+         AND stopped_at >= started_at`
+    )
+    const row = db.prepare('SELECT rounded_min FROM entries').get() as {
+      rounded_min: number | null
+    }
+    expect(row.rounded_min).toBeNull()
+  })
+
+  it('migration 003 default rate_cent is 0', () => {
+    applyAll()
+    db.prepare("INSERT INTO clients (name) VALUES ('Acme')").run()
+    const row = db.prepare('SELECT rate_cent FROM clients').get() as { rate_cent: number }
+    expect(row.rate_cent).toBe(0)
   })
 
   it('rolls back migration on SQL failure (transactional)', () => {
@@ -170,9 +269,7 @@ describe('migration SQL execution', () => {
     expect(() => {
       const tx = db.transaction(() => {
         db.exec(broken)
-        db.prepare(
-          'INSERT INTO schema_version (version, name) VALUES (?, ?)'
-        ).run(99, 'broken')
+        db.prepare('INSERT INTO schema_version (version, name) VALUES (?, ?)').run(99, 'broken')
       })
       tx()
     }).toThrow()
@@ -182,14 +279,10 @@ describe('migration SQL execution', () => {
       .get() as { n: number }
     expect(afterCount.n).toBe(beforeCount.n)
     const clientCount = db
-      .prepare(
-        "SELECT COUNT(*) as n FROM clients WHERE name='Should rollback'"
-      )
+      .prepare("SELECT COUNT(*) as n FROM clients WHERE name='Should rollback'")
       .get() as { n: number }
     expect(clientCount.n).toBe(0)
-    const versionRow = db
-      .prepare('SELECT * FROM schema_version WHERE version = 99')
-      .get()
+    const versionRow = db.prepare('SELECT * FROM schema_version WHERE version = 99').get()
     expect(versionRow).toBeUndefined()
   })
 })

--- a/src/main/migrations/runner.ts
+++ b/src/main/migrations/runner.ts
@@ -45,10 +45,7 @@ export function runMigrations(db: Database.Database, dbPath: string): MigrationR
       applied.push(migration.version)
       console.log(`[migrations] Applied #${migration.version} (${migration.name})`)
     } catch (err) {
-      console.error(
-        `[migrations] FAILED #${migration.version} (${migration.name}):`,
-        err
-      )
+      console.error(`[migrations] FAILED #${migration.version} (${migration.name}):`, err)
       restoreBackup(backupPath, dbPath)
       throw new MigrationError(migration, err as Error, backupPath)
     }
@@ -58,21 +55,61 @@ export function runMigrations(db: Database.Database, dbPath: string): MigrationR
 }
 
 function getCurrentVersion(db: Database.Database): number {
-  const row = db
-    .prepare('SELECT MAX(version) as v FROM schema_version')
-    .get() as { v: number | null }
+  const row = db.prepare('SELECT MAX(version) as v FROM schema_version').get() as {
+    v: number | null
+  }
   return row.v ?? 0
 }
 
 function applyMigration(db: Database.Database, m: Migration): void {
+  // Pre-apply observability: surface clock-skew and running-entry counts so
+  // we can correlate post-deploy support tickets with the pre-state.
+  if (m.version === 3) {
+    logPreV3State(db)
+  }
+
   const tx = db.transaction(() => {
     db.exec(m.up)
-    db.prepare('INSERT INTO schema_version (version, name) VALUES (?, ?)').run(
-      m.version,
-      m.name
-    )
+    db.prepare('INSERT INTO schema_version (version, name) VALUES (?, ?)').run(m.version, m.name)
+    // Post-apply invariants (run inside the same transaction so a failing
+    // assertion rolls back the migration cleanly — runner's catch will then
+    // restore from the pre-migration backup).
+    if (m.version === 3) {
+      assertNoNegativeRoundedMin(db)
+    }
   })
   tx()
+}
+
+function logPreV3State(db: Database.Database): void {
+  try {
+    const skew = db
+      .prepare(
+        `SELECT COUNT(*) AS n FROM entries
+          WHERE stopped_at IS NOT NULL AND stopped_at < started_at`
+      )
+      .get() as { n: number }
+    const running = db
+      .prepare(`SELECT COUNT(*) AS n FROM entries WHERE stopped_at IS NULL`)
+      .get() as { n: number }
+    console.log(
+      `[migrations] pre-003: ${skew.n} clock-skew row(s) skipped; ${running.n} running entry/entries skipped`
+    )
+  } catch (err) {
+    // Pre-apply logging must never block the migration itself.
+    console.warn('[migrations] pre-003 log failed:', err)
+  }
+}
+
+function assertNoNegativeRoundedMin(db: Database.Database): void {
+  const row = db.prepare(`SELECT COUNT(*) AS n FROM entries WHERE rounded_min < 0`).get() as {
+    n: number
+  }
+  if (row.n > 0) {
+    throw new Error(
+      `Post-migration assertion failed: ${row.n} entry/entries have negative rounded_min`
+    )
+  }
 }
 
 function restoreBackup(backupPath: string, dbPath: string): void {
@@ -94,9 +131,7 @@ export class MigrationError extends Error {
     public readonly cause: Error,
     public readonly backupPath: string
   ) {
-    super(
-      `Migration #${migration.version} (${migration.name}) failed: ${cause.message}`
-    )
+    super(`Migration #${migration.version} (${migration.name}) failed: ${cause.message}`)
     this.name = 'MigrationError'
   }
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -5,11 +5,13 @@ import type {
   CreateClientInput,
   UpdateClientInput,
   CreateEntryInput,
+  CreateManualEntryInput,
   UpdateEntryInput,
   MonthQuery,
   Settings,
   IpcResult,
-  BackupInfo
+  BackupInfo,
+  DashboardSummary
 } from '../shared/types'
 
 declare global {
@@ -40,8 +42,10 @@ declare global {
         heartbeat(id: number): Promise<IpcResult<void>>
         getRunning(): Promise<IpcResult<Entry | null>>
         getByMonth(query: MonthQuery): Promise<IpcResult<Entry[]>>
+        create(input: CreateManualEntryInput): Promise<IpcResult<Entry>>
         update(input: UpdateEntryInput): Promise<IpcResult<Entry>>
         delete(id: number): Promise<IpcResult<void>>
+        undelete(id: number): Promise<IpcResult<Entry>>
       }
       settings: {
         getAll(): Promise<IpcResult<Settings>>
@@ -54,6 +58,7 @@ declare global {
       }
       dashboard: {
         todayTotal(): Promise<IpcResult<number>>
+        summary(): Promise<IpcResult<DashboardSummary>>
       }
       app: {
         relaunch(): Promise<IpcResult<void>>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -6,11 +6,13 @@ import type {
   CreateClientInput,
   UpdateClientInput,
   CreateEntryInput,
+  CreateManualEntryInput,
   UpdateEntryInput,
   MonthQuery,
   Settings,
   IpcResult,
-  BackupInfo
+  BackupInfo,
+  DashboardSummary
 } from '../shared/types'
 
 const api = {
@@ -64,9 +66,12 @@ const api = {
     getRunning: (): Promise<IpcResult<Entry | null>> => ipcRenderer.invoke('entries:getRunning'),
     getByMonth: (query: MonthQuery): Promise<IpcResult<Entry[]>> =>
       ipcRenderer.invoke('entries:getByMonth', query),
+    create: (input: CreateManualEntryInput): Promise<IpcResult<Entry>> =>
+      ipcRenderer.invoke('entries:create', input),
     update: (input: UpdateEntryInput): Promise<IpcResult<Entry>> =>
       ipcRenderer.invoke('entries:update', input),
-    delete: (id: number): Promise<IpcResult<void>> => ipcRenderer.invoke('entries:delete', id)
+    delete: (id: number): Promise<IpcResult<void>> => ipcRenderer.invoke('entries:delete', id),
+    undelete: (id: number): Promise<IpcResult<Entry>> => ipcRenderer.invoke('entries:undelete', id)
   },
   // Settings
   settings: {
@@ -82,7 +87,8 @@ const api = {
   },
   // Dashboard
   dashboard: {
-    todayTotal: (): Promise<IpcResult<number>> => ipcRenderer.invoke('dashboard:todayTotal')
+    todayTotal: (): Promise<IpcResult<number>> => ipcRenderer.invoke('dashboard:todayTotal'),
+    summary: (): Promise<IpcResult<DashboardSummary>> => ipcRenderer.invoke('dashboard:summary')
   },
   app: {
     relaunch: (): Promise<IpcResult<void>> => ipcRenderer.invoke('app:relaunch'),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -3,6 +3,7 @@ import TimerView from './views/TimerView'
 import ClientsView from './views/ClientsView'
 import SettingsView from './views/SettingsView'
 import { IdleModal } from './components/IdleModal'
+import { ToastTray } from './components/Toast'
 import { useTimer } from './hooks/useTimer'
 
 type View = 'timer' | 'calendar' | 'clients' | 'settings'
@@ -57,10 +58,10 @@ function App(): React.JSX.Element {
           onMarkPause={idleMarkPause}
         />
       )}
+
+      <ToastTray />
     </div>
   )
 }
 
 export default App
-
-

--- a/src/renderer/src/components/ConfirmDialog.tsx
+++ b/src/renderer/src/components/ConfirmDialog.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useRef } from 'react'
+
+interface Props {
+  open: boolean
+  title: string
+  message: string
+  confirmLabel?: string
+  cancelLabel?: string
+  /** Visual style for the confirm button. 'danger' = red. */
+  variant?: 'danger' | 'primary'
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+/**
+ * Confirmation dialog used for destructive actions (e.g. entry delete).
+ *
+ * Default focus is on Cancel — never on the destructive action — so a
+ * stray Enter press does not delete user data.
+ */
+export function ConfirmDialog({
+  open,
+  title,
+  message,
+  confirmLabel = 'OK',
+  cancelLabel = 'Abbrechen',
+  variant = 'primary',
+  onConfirm,
+  onCancel
+}: Props): React.ReactElement | null {
+  const cancelRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') onCancel()
+    }
+    window.addEventListener('keydown', handler)
+    queueMicrotask(() => cancelRef.current?.focus())
+    return () => window.removeEventListener('keydown', handler)
+  }, [open, onCancel])
+
+  if (!open) return null
+
+  const confirmClass =
+    variant === 'danger'
+      ? 'bg-red-600 hover:bg-red-500 focus:ring-red-400'
+      : 'bg-indigo-600 hover:bg-indigo-500 focus:ring-indigo-400'
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="confirm-title"
+      aria-describedby="confirm-message"
+    >
+      <div className="w-[440px] rounded-xl bg-zinc-900 p-6 shadow-2xl ring-1 ring-zinc-700">
+        <h2 id="confirm-title" className="mb-2 text-lg font-semibold text-zinc-100">
+          {title}
+        </h2>
+        <p id="confirm-message" className="mb-6 text-sm text-zinc-400">
+          {message}
+        </p>
+        <div className="flex justify-end gap-2">
+          <button
+            ref={cancelRef}
+            type="button"
+            onClick={onCancel}
+            className="rounded-lg bg-zinc-800 px-4 py-2.5 text-sm font-medium text-zinc-100 hover:bg-zinc-700 focus:outline-none focus:ring-2 focus:ring-zinc-500"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className={`rounded-lg px-4 py-2.5 text-sm font-medium text-white focus:outline-none focus:ring-2 ${confirmClass}`}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/Dialog.tsx
+++ b/src/renderer/src/components/Dialog.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useRef, type ReactNode } from 'react'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  title: string
+  children: ReactNode
+  /** Maximum width in tailwind units. Default: w-[460px]. */
+  widthClass?: string
+}
+
+/**
+ * Generic modal dialog used for "+ Eintrag nachtragen" on TodayView.
+ * Inside the Calendar Drawer the form is inlined directly — this wrapper
+ * is for the case where there is no surrounding drawer to host it.
+ *
+ * Focus management: traps focus inside on mount, returns it to the
+ * previously focused element on close. Escape closes.
+ */
+export function Dialog({
+  open,
+  onClose,
+  title,
+  children,
+  widthClass = 'w-[460px]'
+}: Props): React.ReactElement | null {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const previouslyFocused = useRef<Element | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    previouslyFocused.current = document.activeElement
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handler)
+    // Move focus into the dialog after mount so screen readers announce it.
+    queueMicrotask(() => {
+      const first = containerRef.current?.querySelector<HTMLElement>(
+        'input, select, textarea, button'
+      )
+      first?.focus()
+    })
+    return () => {
+      window.removeEventListener('keydown', handler)
+      const prev = previouslyFocused.current
+      if (prev instanceof HTMLElement) prev.focus()
+    }
+  }, [open, onClose])
+
+  if (!open) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-40 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="dialog-title"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div
+        ref={containerRef}
+        className={`${widthClass} rounded-xl bg-zinc-900 p-6 shadow-2xl ring-1 ring-zinc-700`}
+      >
+        <div className="mb-4 flex items-center justify-between">
+          <h2 id="dialog-title" className="text-lg font-semibold text-zinc-100">
+            {title}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="-mr-2 grid h-11 w-11 place-items-center rounded-lg text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-zinc-500"
+            aria-label="Schließen"
+          >
+            ×
+          </button>
+        </div>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/EntryEditForm.tsx
+++ b/src/renderer/src/components/EntryEditForm.tsx
@@ -1,0 +1,236 @@
+import { useEffect, useMemo, useState } from 'react'
+import type { Client, Entry } from '../../../shared/types'
+import { formatTimeHHMM, isSameLocalDay, parseTimeToDate } from '../../../shared/date'
+import { useEntriesStore } from '../store/entriesStore'
+
+interface Props {
+  /** Existing entry to edit; omit for create-mode. */
+  entry?: Entry
+  /** Default date used in create-mode when no entry is supplied. */
+  defaultDate?: Date
+  clients: Client[]
+  onSaved: (entry: Entry) => void
+  onCancel: () => void
+}
+
+type FormState = 'idle' | 'saving' | 'success'
+
+const MAX_DESCRIPTION_LEN = 500
+
+function toDateInputValue(d: Date): string {
+  // <input type="date"> wants YYYY-MM-DD in LOCAL time.
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+/**
+ * Inline edit/create form used both inside the Calendar Drawer and inside
+ * the Today "+ Eintrag nachtragen" dialog. Validation runs client-side
+ * for fast feedback; the server enforces the same rules authoritatively
+ * (see `validateManualEntry` in src/main/ipc.ts).
+ *
+ * v1.2 limitation: cross-midnight entries are rejected. The persistent
+ * info banner above the time fields tells the user this and points to v1.3.
+ */
+export function EntryEditForm({
+  entry,
+  defaultDate,
+  clients,
+  onSaved,
+  onCancel
+}: Props): React.ReactElement {
+  const initialStart = entry ? new Date(entry.started_at) : (defaultDate ?? new Date())
+  const initialStop = entry?.stopped_at
+    ? new Date(entry.stopped_at)
+    : new Date(initialStart.getTime() + 60 * 60 * 1000)
+
+  const [date, setDate] = useState(toDateInputValue(initialStart))
+  const [startTime, setStartTime] = useState(formatTimeHHMM(initialStart))
+  const [stopTime, setStopTime] = useState(formatTimeHHMM(initialStop))
+  const [clientId, setClientId] = useState<number>(entry?.client_id ?? clients[0]?.id ?? 0)
+  const [description, setDescription] = useState(entry?.description ?? '')
+  const [state, setState] = useState<FormState>('idle')
+  const [error, setError] = useState<string | null>(null)
+  const bumpVersion = useEntriesStore((s) => s.bumpVersion)
+
+  // Local validation (200ms debounce so it doesn't flicker while typing).
+  const [localError, setLocalError] = useState<string | null>(null)
+  useEffect(() => {
+    const t = setTimeout(() => setLocalError(validateLocal()), 200)
+    return () => clearTimeout(t)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [date, startTime, stopTime, clientId, description])
+
+  function validateLocal(): string | null {
+    if (!clientId) return 'Bitte einen Kunden wählen'
+    let start: Date
+    let stop: Date
+    try {
+      start = parseTimeToDate(date, startTime)
+      stop = parseTimeToDate(date, stopTime)
+    } catch (e) {
+      return (e as Error).message
+    }
+    if (stop.getTime() <= start.getTime()) return 'Endzeit muss nach der Startzeit liegen'
+    if (!isSameLocalDay(start, stop)) {
+      return 'Einträge können aktuell nicht über Mitternacht gehen (folgt in v1.3)'
+    }
+    if (start.getTime() > Date.now()) return 'Startzeit darf nicht in der Zukunft liegen'
+    if (description.length > MAX_DESCRIPTION_LEN) {
+      return `Beschreibung überschreitet ${MAX_DESCRIPTION_LEN} Zeichen`
+    }
+    return null
+  }
+
+  const activeClients = useMemo(
+    () => clients.filter((c) => c.active === 1 || c.id === clientId),
+    [clients, clientId]
+  )
+
+  async function handleSubmit(e: React.FormEvent): Promise<void> {
+    e.preventDefault()
+    const err = validateLocal()
+    if (err) {
+      setLocalError(err)
+      return
+    }
+    setState('saving')
+    setError(null)
+    const start = parseTimeToDate(date, startTime).toISOString()
+    const stop = parseTimeToDate(date, stopTime).toISOString()
+    const res = entry
+      ? await window.api.entries.update({
+          id: entry.id,
+          client_id: clientId,
+          description: description.trim(),
+          started_at: start,
+          stopped_at: stop
+        })
+      : await window.api.entries.create({
+          client_id: clientId,
+          description: description.trim(),
+          started_at: start,
+          stopped_at: stop
+        })
+    if (!res.ok) {
+      setState('idle')
+      setError(res.error)
+      return
+    }
+    setState('success')
+    bumpVersion()
+    // Brief success flash before handing control back to the parent.
+    setTimeout(() => onSaved(res.data), 300)
+  }
+
+  const isSaving = state === 'saving'
+  const visibleError = error ?? localError
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-3 text-sm">
+      <div
+        role="note"
+        className="rounded border border-amber-700/40 bg-amber-900/20 px-3 py-2 text-xs text-amber-200"
+      >
+        ℹ️ Einträge können aktuell nicht über Mitternacht gehen. Lösung folgt in v1.3.
+      </div>
+
+      <div className="grid grid-cols-3 gap-2">
+        <label className="flex flex-col gap-1">
+          <span className="text-xs text-zinc-400">Datum</span>
+          <input
+            type="date"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+            className="rounded border border-zinc-700 bg-zinc-900 px-2 py-1.5 text-zinc-100 focus:border-indigo-500 focus:outline-none"
+            disabled={isSaving}
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-xs text-zinc-400">Start</span>
+          <input
+            type="time"
+            value={startTime}
+            onChange={(e) => setStartTime(e.target.value)}
+            className="rounded border border-zinc-700 bg-zinc-900 px-2 py-1.5 text-zinc-100 focus:border-indigo-500 focus:outline-none"
+            disabled={isSaving}
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-xs text-zinc-400">Ende</span>
+          <input
+            type="time"
+            value={stopTime}
+            onChange={(e) => setStopTime(e.target.value)}
+            className="rounded border border-zinc-700 bg-zinc-900 px-2 py-1.5 text-zinc-100 focus:border-indigo-500 focus:outline-none"
+            disabled={isSaving || (entry?.stopped_at == null && entry !== undefined)}
+          />
+        </label>
+      </div>
+
+      <label className="flex flex-col gap-1">
+        <span className="text-xs text-zinc-400">Kunde</span>
+        <select
+          value={clientId}
+          onChange={(e) => setClientId(parseInt(e.target.value, 10))}
+          className="rounded border border-zinc-700 bg-zinc-900 px-2 py-1.5 text-zinc-100 focus:border-indigo-500 focus:outline-none"
+          disabled={isSaving}
+        >
+          {activeClients.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="flex flex-col gap-1">
+        <span className="text-xs text-zinc-400">
+          Beschreibung{' '}
+          <span className="text-zinc-600">
+            ({description.length}/{MAX_DESCRIPTION_LEN})
+          </span>
+        </span>
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          rows={2}
+          maxLength={MAX_DESCRIPTION_LEN}
+          className="rounded border border-zinc-700 bg-zinc-900 px-2 py-1.5 text-zinc-100 focus:border-indigo-500 focus:outline-none"
+          disabled={isSaving}
+        />
+      </label>
+
+      {visibleError && (
+        <p role="alert" className="text-xs text-red-400">
+          {visibleError}
+        </p>
+      )}
+      {state === 'success' && (
+        <p role="status" className="text-xs text-emerald-400">
+          Gespeichert
+        </p>
+      )}
+
+      <div className="sticky bottom-0 -mx-1 mt-1 flex justify-end gap-2 bg-zinc-900/80 px-1 pt-2 backdrop-blur">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isSaving}
+          className="rounded-lg bg-zinc-800 px-3 py-1.5 text-sm font-medium text-zinc-100 hover:bg-zinc-700 focus:outline-none focus:ring-2 focus:ring-zinc-500 disabled:opacity-50"
+        >
+          Abbrechen
+        </button>
+        <button
+          type="submit"
+          disabled={isSaving || localError !== null}
+          className="rounded-lg bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400 disabled:opacity-50"
+        >
+          {isSaving ? 'Speichert…' : 'Speichern'}
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/src/renderer/src/components/Toast.tsx
+++ b/src/renderer/src/components/Toast.tsx
@@ -1,0 +1,45 @@
+import { useToastStore } from '../store/toastStore'
+
+/**
+ * Toast tray. Mount once at the App root. Renders bottom-right above any
+ * Drawer (z-index 60). Each toast lives ~5s; clicking the action button
+ * (e.g. "Rückgängig") fires the snapshot stored on the toast.
+ */
+export function ToastTray(): React.ReactElement | null {
+  const toasts = useToastStore((s) => s.toasts)
+  const dismiss = useToastStore((s) => s.dismiss)
+  const executeAction = useToastStore((s) => s.executeAction)
+
+  if (toasts.length === 0) return null
+
+  return (
+    <div className="pointer-events-none fixed bottom-4 right-4 z-[60] flex flex-col gap-2">
+      {toasts.map((t) => (
+        <div
+          key={t.id}
+          role="status"
+          className="pointer-events-auto flex min-w-[280px] max-w-[420px] items-center gap-3 rounded-lg bg-zinc-800 px-4 py-3 text-sm text-zinc-100 shadow-lg ring-1 ring-zinc-700"
+        >
+          <span className="flex-1">{t.message}</span>
+          {t.action && (
+            <button
+              type="button"
+              onClick={() => void executeAction(t.id)}
+              className="rounded px-2 py-1 text-sm font-medium text-indigo-300 hover:bg-zinc-700 hover:text-indigo-200 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+            >
+              {t.action.label}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => dismiss(t.id)}
+            aria-label="Schließen"
+            className="grid h-7 w-7 place-items-center rounded text-zinc-500 hover:bg-zinc-700 hover:text-zinc-300 focus:outline-none focus:ring-2 focus:ring-zinc-500"
+          >
+            ×
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/src/store/entriesStore.ts
+++ b/src/renderer/src/store/entriesStore.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand'
+
+/**
+ * Mutation-version store (E1).
+ *
+ * Pattern: any IPC call that mutates entry data (`entries:start`, `:stop`,
+ * `:create`, `:update`, `:delete`, `:undelete`) must call `bumpVersion()`
+ * after success. Views (TodayView, CalendarView, Drawer) re-fetch via
+ * `useEffect([version])`. This replaces 60s polling and keeps every visible
+ * surface in sync without per-view subscriptions or manual refresh buttons.
+ *
+ * Keep this store deliberately tiny — version-only — so re-renders are cheap
+ * and any view can subscribe with `useEntriesStore((s) => s.version)`.
+ */
+interface EntriesState {
+  version: number
+  bumpVersion: () => void
+}
+
+export const useEntriesStore = create<EntriesState>((set) => ({
+  version: 0,
+  bumpVersion: (): void => set((s) => ({ version: s.version + 1 }))
+}))

--- a/src/renderer/src/store/toastStore.ts
+++ b/src/renderer/src/store/toastStore.ts
@@ -1,0 +1,74 @@
+import { create } from 'zustand'
+import { useEntriesStore } from './entriesStore'
+
+/**
+ * Toast queue with action snapshots (E9).
+ *
+ * Why snapshot data into the store instead of capturing closures from the
+ * originating component: undo for "Eintrag gelöscht" must still work after
+ * the source component (e.g. CalendarDrawer) unmounts. We keep the minimal
+ * data needed to replay the action (currently just an entry id), and the
+ * store itself calls the IPC.
+ */
+export type ToastActionType = 'undo_delete' | 'undo_edit'
+
+export interface ToastAction {
+  label: string
+  type: ToastActionType
+  /** Action-type specific payload. For undo_delete: { entryId: number }. */
+  data: Record<string, unknown>
+}
+
+export interface Toast {
+  id: number
+  message: string
+  action?: ToastAction
+  /** Epoch ms; toast auto-dismisses at this time. */
+  expiresAt: number
+}
+
+interface ToastState {
+  toasts: Toast[]
+  show: (message: string, action?: ToastAction, ttlMs?: number) => number
+  dismiss: (id: number) => void
+  /** Execute the toast's action (if any) then dismiss it. */
+  executeAction: (id: number) => Promise<void>
+}
+
+let nextId = 1
+
+export const useToastStore = create<ToastState>((set, get) => ({
+  toasts: [],
+
+  show: (message, action, ttlMs = 5000): number => {
+    const id = nextId++
+    const toast: Toast = {
+      id,
+      message,
+      action,
+      expiresAt: Date.now() + ttlMs
+    }
+    set((s) => ({ toasts: [...s.toasts, toast] }))
+    setTimeout(() => {
+      // Only dismiss if still present (user may have clicked the action).
+      if (get().toasts.some((t) => t.id === id)) {
+        set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }))
+      }
+    }, ttlMs)
+    return id
+  },
+
+  dismiss: (id): void => set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) })),
+
+  executeAction: async (id): Promise<void> => {
+    const toast = get().toasts.find((t) => t.id === id)
+    if (!toast?.action) return
+    // Dismiss first so a slow IPC call doesn't leave the toast hanging.
+    set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }))
+    if (toast.action.type === 'undo_delete') {
+      const entryId = toast.action.data.entryId as number
+      const res = await window.api.entries.undelete(entryId)
+      if (res.ok) useEntriesStore.getState().bumpVersion()
+    }
+  }
+}))

--- a/src/shared/date.test.ts
+++ b/src/shared/date.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { isSameLocalDay, parseTimeToDate, formatTimeHHMM } from './date'
+
+describe('isSameLocalDay', () => {
+  it('returns true for two times on the same local day', () => {
+    expect(isSameLocalDay('2026-04-24T08:00:00', '2026-04-24T22:30:00')).toBe(true)
+  })
+
+  it('returns false across midnight', () => {
+    expect(isSameLocalDay('2026-04-24T23:30:00', '2026-04-25T00:30:00')).toBe(false)
+  })
+
+  it('accepts Date objects', () => {
+    const a = new Date(2026, 3, 24, 8, 0)
+    const b = new Date(2026, 3, 24, 22, 0)
+    expect(isSameLocalDay(a, b)).toBe(true)
+  })
+
+  it('handles DST spring-forward (CET → CEST 2026-03-29)', () => {
+    // Both wall-clock times fall on 2026-03-29 even though the local
+    // timezone skips 02:00→03:00. Use local-constructor Dates so the
+    // test is deterministic regardless of the host TZ.
+    const before = new Date(2026, 2, 29, 1, 30)
+    const after = new Date(2026, 2, 29, 4, 30)
+    expect(isSameLocalDay(before, after)).toBe(true)
+  })
+
+  it('respects local timezone (string with explicit offset)', () => {
+    // 23:00 UTC on 04-24 vs 02:00 UTC on 04-25 — in UTC they're different
+    // days; isSameLocalDay should agree because we compare LOCAL dates.
+    // We use ISO strings without TZ to force local interpretation.
+    const a = new Date(2026, 3, 24, 23, 0)
+    const b = new Date(2026, 3, 25, 2, 0)
+    expect(isSameLocalDay(a, b)).toBe(false)
+  })
+})
+
+describe('parseTimeToDate', () => {
+  it('combines a date with HH:MM into a local Date', () => {
+    const out = parseTimeToDate('2026-04-24', '08:30')
+    expect(out.getFullYear()).toBe(2026)
+    expect(out.getMonth()).toBe(3)
+    expect(out.getDate()).toBe(24)
+    expect(out.getHours()).toBe(8)
+    expect(out.getMinutes()).toBe(30)
+    expect(out.getSeconds()).toBe(0)
+  })
+
+  it('accepts a Date as the date source', () => {
+    const out = parseTimeToDate(new Date(2026, 5, 1, 14, 0), '23:59')
+    expect(out.getHours()).toBe(23)
+    expect(out.getMinutes()).toBe(59)
+  })
+
+  it('throws on invalid format', () => {
+    expect(() => parseTimeToDate('2026-04-24', '8:30')).toThrow()
+    expect(() => parseTimeToDate('2026-04-24', '24:00')).toThrow()
+    expect(() => parseTimeToDate('2026-04-24', '12:60')).toThrow()
+    expect(() => parseTimeToDate('2026-04-24', '')).toThrow()
+  })
+})
+
+describe('formatTimeHHMM', () => {
+  it('pads single digits', () => {
+    expect(formatTimeHHMM(new Date(2026, 0, 1, 9, 5))).toBe('09:05')
+  })
+
+  it('formats midnight as 00:00', () => {
+    expect(formatTimeHHMM(new Date(2026, 0, 1, 0, 0))).toBe('00:00')
+  })
+
+  it('accepts ISO strings', () => {
+    const d = new Date(2026, 3, 24, 14, 30)
+    expect(formatTimeHHMM(d.toISOString())).toBe('14:30')
+  })
+})

--- a/src/shared/date.ts
+++ b/src/shared/date.ts
@@ -1,0 +1,50 @@
+/**
+ * Date helpers shared between main and renderer.
+ *
+ * All comparisons are intentionally LOCAL-time (`getYear/getMonth/getDate`)
+ * so a 23:30→00:30 entry is correctly flagged as cross-midnight regardless
+ * of the user's timezone. v1.2 rejects cross-midnight entries; v1.3 will
+ * lift the restriction and split such entries.
+ */
+
+const TIME_RE = /^([01]\d|2[0-3]):([0-5]\d)$/
+
+function toDate(input: string | Date): Date {
+  return input instanceof Date ? input : new Date(input)
+}
+
+/**
+ * True iff `a` and `b` fall on the same calendar day in the host's local
+ * timezone. Uses local Y/M/D — DST transitions are handled correctly because
+ * they shift the wall-clock hour, not the date.
+ */
+export function isSameLocalDay(a: string | Date, b: string | Date): boolean {
+  const da = toDate(a)
+  const db = toDate(b)
+  return (
+    da.getFullYear() === db.getFullYear() &&
+    da.getMonth() === db.getMonth() &&
+    da.getDate() === db.getDate()
+  )
+}
+
+/**
+ * Combine an ISO date (or Date) with a "HH:MM" wall-clock time and return
+ * a Date in the host's local timezone. Throws on malformed `time`.
+ */
+export function parseTimeToDate(dateISO: string | Date, time: string): Date {
+  const m = TIME_RE.exec(time)
+  if (!m) throw new Error(`Invalid time format (expected HH:MM): ${time}`)
+  const base = toDate(dateISO)
+  const out = new Date(base.getFullYear(), base.getMonth(), base.getDate())
+  out.setHours(parseInt(m[1], 10), parseInt(m[2], 10), 0, 0)
+  return out
+}
+
+/** Format a date as "HH:MM" in the host's local timezone. */
+export function formatTimeHHMM(date: string | Date): string {
+  const d = toDate(date)
+  const hh = String(d.getHours()).padStart(2, '0')
+  const mm = String(d.getMinutes()).padStart(2, '0')
+  return `${hh}:${mm}`
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -5,6 +5,7 @@ export interface Client {
   name: string
   color: string
   active: number
+  rate_cent: number
   created_at: string
 }
 
@@ -16,6 +17,7 @@ export interface Entry {
   stopped_at: string | null
   heartbeat_at: string | null
   rounded_min: number | null
+  deleted_at: string | null
   created_at: string
 }
 
@@ -49,6 +51,19 @@ export interface CreateEntryInput {
   started_at: string
 }
 
+/**
+ * Manual-entry creation (Today "+ Eintrag nachtragen" / Calendar drawer
+ * "+ Eintrag hinzufügen"). Distinct from CreateEntryInput because manual
+ * entries always carry a stopped_at; running entries are created via
+ * `entries:start` only.
+ */
+export interface CreateManualEntryInput {
+  client_id: number
+  description: string
+  started_at: string
+  stopped_at: string
+}
+
 export interface UpdateEntryInput {
   id: number
   client_id: number
@@ -72,4 +87,12 @@ export interface BackupInfo {
   reason: BackupReason
   createdAt: string
   sizeBytes: number
+}
+
+/** Aggregated dashboard view returned by `dashboard:summary`. */
+export interface DashboardSummary {
+  todaySeconds: number
+  weekSeconds: number
+  recentEntries: Entry[]
+  topClients30d: Array<{ client_id: number; name: string; color: string; seconds: number }>
 }


### PR DESCRIPTION
**v1.2 PR B — Data layer + IPC + state stores + reusable UI primitives.** Headless infrastructure that PR C will consume. No new user-visible UI yet (the form/dialog/toast components are wired but not yet shown anywhere except `ToastTray`, which is mounted but only renders when something pushes a toast).

Refs #27, #28, #29, #30 (PR C will close them with the actual UI).

## What's in here

### 1. Migration 003 (`src/main/migrations/003-v12-data.ts`)
- `clients.rate_cent INTEGER DEFAULT 0` — v1.3 PDF prep, not used by v1.2 UI.
- `entries.deleted_at TEXT` — soft-delete column. Undo flips it back; the row's `id` is preserved so future PDF FKs stay stable (E10 from /autoplan).
- `idx_entries_started_at` — speeds up `dashboard:summary` and `getByMonth` (E12).
- Backfills `rounded_min` for legacy v1.0 entries that never received it. Skips running entries (`stopped_at IS NULL`) and clock-skew rows (`stopped_at < started_at`).
- **Runner additions** (`migrations/runner.ts`):
  - **Pre-apply log** for v3: prints clock-skew + running-entry counts so support tickets can be correlated with the pre-state (E13).
  - **Post-apply assertion**: fails the transaction (auto-rollback + restore from pre-migration backup) if any `rounded_min < 0` sneaks through (E2).
- Migration 003 uses `ALTER TABLE`, which is **not** idempotent in SQLite. The "idempotency" test was scoped to seed-only migrations (001 + 002); 003+ rely on `schema_version` + the runner (which only applies pending migrations) for safety. This is documented in the test and in 003's docstring.

### 2. IPC (`src/main/ipc.ts`)
- **`entries:create`** — full server-side validation contract (E3):
  - `started_at <= now`, `stopped_at > started_at`
  - `isSameLocalDay(started_at, stopped_at)` — cross-midnight rejected (v1.3 will lift this)
  - `client_id` exists in `clients`
  - `description.length <= 500`, duration `<= 24h`
  - no overlap with non-deleted entries of the same client
- **`entries:update`** reuses the same validator with `excludeId` so an entry doesn't overlap itself.
- **`entries:delete`** is now a soft-delete: `UPDATE entries SET deleted_at = ?`.
- **`entries:undelete`** clears `deleted_at` and returns the restored row.
- **All read queries** now `AND deleted_at IS NULL` (`getRunning`, `getByMonth`, `dashboard:todayTotal`).
- **`dashboard:summary`** — single read transaction returning today + week (Mon-anchored) + recent5 + topClients30d.

### 3. Shared (`src/shared/`)
- **`date.ts`** — `isSameLocalDay`, `parseTimeToDate`, `formatTimeHHMM`. Local-Y/M/D comparison so DST transitions (CET → CEST 2026-03-29) don't false-positive cross-midnight.
- **`types.ts`** — `CreateManualEntryInput`, `DashboardSummary`; `Client.rate_cent`; `Entry.deleted_at`.

### 4. Stores (`src/renderer/src/store/`)
- **`entriesStore`** — `{ version, bumpVersion }`. Every mutating IPC call (PR C will wire them) bumps version; views re-fetch via `useEffect([version])`. Replaces 60s polling (E1).
- **`toastStore`** — action-snapshot pattern: store the data needed to replay the action, not a closure from the calling component. Undo for "Eintrag gelöscht" survives the originating drawer/view unmount (E9). On `undo_delete` the store calls `entries:undelete` and bumps `entriesStore.version` itself.

### 5. Components (`src/renderer/src/components/`)
- **`Dialog.tsx`** — generic modal with focus trap + return-focus on close. Used by Today's "+ Eintrag nachtragen" in PR C.
- **`ConfirmDialog.tsx`** — `alertdialog` with default focus on **Cancel** (never on the destructive action) so a stray Enter cannot delete data.
- **`Toast.tsx`** (`ToastTray`) — mounted in `App.tsx`, bottom-right `z-[60]` above any future drawer.
- **`EntryEditForm.tsx`** — inline create/edit form:
  - 200 ms-debounced local validation (no flicker while typing)
  - persistent cross-midnight info banner above time fields (D5)
  - sticky Save/Cancel footer
  - states: `idle` → `saving` → `success` (300 ms green flash) or `idle` + inline red error
  - calls `bumpVersion()` after successful create/update

## Verification

| Check                               | Result                            |
| ----------------------------------- | --------------------------------- |
| `pnpm typecheck`                    | ✅ green (node + web)             |
| `pnpm test`                         | ✅ **51/51** pass                 |
| `pnpm lint`                         | ✅ baseline unchanged (21 pre-existing errors, no new ones) |

### New tests (33 total)
- **`src/shared/date.test.ts`** — 11 tests incl. DST spring-forward 2026-03-29.
- **`src/main/ipc.test.ts`** — 10 tests covering every validation rule, soft-delete-ignored-in-overlap, and update-without-self-overlap. Replays `validateManualEntry` against an in-memory DB seeded with all migrations (no Electron runtime required).
- **`src/main/migrations/migrations.test.ts`** — 4 new tests for 003: columns added, index created, backfill correctness, clock-skew skipped, `rate_cent` default = 0. Also rescoped the idempotency test to seed-only migrations.

## Out of scope (PR C)

- TodayView, CalendarView, Drawer
- Wiring the form/dialogs/toasts into actual user flows
- delete + undo end-to-end test in the renderer

## Out of scope (PR D)

- CI `electron-rebuild` + smoke test (release infra)
