### PR TITLE
feat(v1.2 PR C): TodayView + CalendarView + Drawer with delete/undo wiring

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,22 +1,32 @@
 import { useState } from 'react'
+import TodayView from './views/TodayView'
 import TimerView from './views/TimerView'
+import CalendarView from './views/CalendarView'
 import ClientsView from './views/ClientsView'
 import SettingsView from './views/SettingsView'
 import { IdleModal } from './components/IdleModal'
 import { ToastTray } from './components/Toast'
 import { useTimer } from './hooks/useTimer'
 
-type View = 'timer' | 'calendar' | 'clients' | 'settings'
+type View = 'today' | 'timer' | 'calendar' | 'clients' | 'settings'
+
+const NAV_LABEL: Record<View, string> = {
+  today: 'Heute',
+  timer: 'Timer',
+  calendar: 'Kalender',
+  clients: 'Kunden',
+  settings: 'Einstellungen'
+}
 
 function App(): React.JSX.Element {
-  const [view, setView] = useState<View>('timer')
+  const [view, setView] = useState<View>('today')
   const { idleEvent, idleKeep, idleStopAtIdle, idleMarkPause } = useTimer()
 
   return (
     <div className="h-screen bg-slate-900 text-slate-100 flex flex-col overflow-hidden">
       {/* Nav */}
       <nav className="flex gap-1 px-3 py-2 bg-slate-800 border-b border-slate-700 shrink-0">
-        {(['timer', 'calendar', 'clients', 'settings'] as View[]).map((v) => (
+        {(['today', 'timer', 'calendar', 'clients', 'settings'] as View[]).map((v) => (
           <button
             key={v}
             onClick={() => setView(v)}
@@ -24,27 +34,16 @@ function App(): React.JSX.Element {
               focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500
               ${view === v ? 'bg-indigo-600 text-white' : 'text-slate-400 hover:text-slate-200 hover:bg-slate-700'}`}
           >
-            {v === 'timer'
-              ? 'Timer'
-              : v === 'calendar'
-                ? 'Kalender'
-                : v === 'clients'
-                  ? 'Kunden'
-                  : 'Einstellungen'}
+            {NAV_LABEL[v]}
           </button>
         ))}
       </nav>
 
       {/* Content */}
       <main className="flex-1 overflow-y-auto p-6">
+        {view === 'today' && <TodayView />}
         {view === 'timer' && <TimerView />}
-        {view === 'calendar' && (
-          <div className="flex flex-col items-center justify-center mt-24 gap-3 text-slate-600">
-            <span className="text-5xl">📅</span>
-            <p className="font-medium text-slate-400">Kalender-Ansicht</p>
-            <p className="text-sm">Kommt in der nächsten Session.</p>
-          </div>
-        )}
+        {view === 'calendar' && <CalendarView />}
         {view === 'clients' && <ClientsView />}
         {view === 'settings' && <SettingsView />}
       </main>

--- a/src/renderer/src/components/CalendarDrawer.tsx
+++ b/src/renderer/src/components/CalendarDrawer.tsx
@@ -1,0 +1,289 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import type { Client, Entry } from '../../../shared/types'
+import { useEntriesStore } from '../store/entriesStore'
+import { useToastStore } from '../store/toastStore'
+import { ConfirmDialog } from './ConfirmDialog'
+import { EntryEditForm } from './EntryEditForm'
+
+interface Props {
+  open: boolean
+  /** ISO date YYYY-MM-DD (LOCAL) the drawer is showing entries for. */
+  dateISO: string
+  /** Entries for this day (caller filters from getByMonth). */
+  entries: Entry[]
+  clients: Client[]
+  onClose: () => void
+}
+
+/**
+ * Right-side drawer for a single day in CalendarView. Shows the
+ * chronological list of entries with inline edit / delete and a
+ * sticky-footer "+ Eintrag hinzufügen" button.
+ *
+ * Delete uses a `ConfirmDialog` (default-focus = Cancel) and on confirm
+ * fires a soft-delete + 5s "Rückgängig" toast. The toast snapshot owns
+ * the entry id so undo still works after the drawer closes (E9).
+ */
+export function CalendarDrawer({
+  open,
+  dateISO,
+  entries,
+  clients,
+  onClose
+}: Props): React.ReactElement | null {
+  const showToast = useToastStore((s) => s.show)
+  const [editingId, setEditingId] = useState<number | null>(null)
+  const [creating, setCreating] = useState(false)
+  const [deleteCandidate, setDeleteCandidate] = useState<Entry | null>(null)
+  const drawerRef = useRef<HTMLDivElement>(null)
+  const previouslyFocused = useRef<Element | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    previouslyFocused.current = document.activeElement
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        if (editingId !== null) setEditingId(null)
+        else if (creating) setCreating(false)
+        else if (deleteCandidate) setDeleteCandidate(null)
+        else onClose()
+      }
+    }
+    window.addEventListener('keydown', handler)
+    queueMicrotask(() => {
+      drawerRef.current?.querySelector<HTMLElement>('button, [tabindex]')?.focus()
+    })
+    return () => {
+      window.removeEventListener('keydown', handler)
+      const prev = previouslyFocused.current
+      if (prev instanceof HTMLElement) prev.focus()
+    }
+  }, [open, onClose, editingId, creating, deleteCandidate])
+
+  const clientsById = useMemo(() => {
+    const m = new Map<number, Client>()
+    for (const c of clients) m.set(c.id, c)
+    return m
+  }, [clients])
+
+  if (!open) return null
+
+  async function confirmDelete(entry: Entry): Promise<void> {
+    setDeleteCandidate(null)
+    const res = await window.api.entries.delete(entry.id)
+    if (!res.ok) {
+      showToast(`Löschen fehlgeschlagen: ${res.error}`)
+      return
+    }
+    useEntriesStore.getState().bumpVersion()
+    showToast('Eintrag gelöscht', {
+      label: 'Rückgängig',
+      type: 'undo_delete',
+      data: { entryId: entry.id }
+    })
+  }
+
+  const dateLabel = formatHumanDate(dateISO)
+  const totalSeconds = entries.reduce((sum, e) => sum + durationSeconds(e), 0)
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div className="fixed inset-0 z-30 bg-black/40" onClick={onClose} aria-hidden="true" />
+      {/* Drawer */}
+      <aside
+        ref={drawerRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Einträge für ${dateLabel}`}
+        className="fixed right-0 top-0 z-40 flex h-screen w-96 flex-col bg-slate-900 shadow-2xl ring-1 ring-slate-700"
+      >
+        {/* Sticky header */}
+        <div className="flex shrink-0 items-center justify-between border-b border-slate-700 bg-slate-800 px-4 py-3">
+          <div>
+            <h2 className="text-base font-semibold text-slate-100">Einträge für {dateLabel}</h2>
+            {entries.length > 0 && (
+              <p className="mt-0.5 text-xs text-slate-400">
+                {entries.length} Eintrag{entries.length === 1 ? '' : 'e'} ·{' '}
+                {formatHHMM(totalSeconds)}
+              </p>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Schließen"
+            className="grid h-11 w-11 place-items-center rounded-lg text-slate-400 hover:bg-slate-700 hover:text-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-500"
+          >
+            ×
+          </button>
+        </div>
+
+        {/* Scroll body */}
+        <div className="flex-1 overflow-y-auto p-3">
+          {entries.length === 0 && !creating && (
+            <div className="mt-8 text-center text-sm text-slate-500">
+              <p>Kein Eintrag an diesem Tag.</p>
+            </div>
+          )}
+          <ul className="flex flex-col gap-2">
+            {entries.map((e) => {
+              const client = clientsById.get(e.client_id)
+              const isEditing = editingId === e.id
+              return (
+                <li key={e.id} className="rounded-lg border border-slate-700 bg-slate-800/60">
+                  {!isEditing && (
+                    <div className="flex items-center gap-2 p-2">
+                      <span
+                        className="h-2.5 w-2.5 shrink-0 rounded-full"
+                        style={{ backgroundColor: client?.color ?? '#64748b' }}
+                      />
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2 text-xs text-slate-400">
+                          <span className="font-mono tabular-nums">{formatTimeRange(e)}</span>
+                          <span>·</span>
+                          <span className="truncate text-slate-200">
+                            {client?.name ?? 'Unbekannt'}
+                          </span>
+                        </div>
+                        {e.description && (
+                          <p
+                            className="mt-0.5 truncate text-xs text-slate-400"
+                            title={e.description}
+                          >
+                            {e.description}
+                          </p>
+                        )}
+                      </div>
+                      <span className="font-mono text-xs tabular-nums text-slate-300">
+                        {formatHHMM(durationSeconds(e))}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => setEditingId(e.id)}
+                        className="rounded p-1 text-slate-400 hover:bg-slate-700 hover:text-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                        aria-label="Bearbeiten"
+                        title="Bearbeiten"
+                      >
+                        ✏️
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setDeleteCandidate(e)}
+                        disabled={e.stopped_at === null}
+                        className="rounded p-1 text-slate-400 hover:bg-slate-700 hover:text-red-300 focus:outline-none focus:ring-2 focus:ring-red-400 disabled:cursor-not-allowed disabled:opacity-30"
+                        aria-label="Löschen"
+                        title={e.stopped_at === null ? 'Laufenden Timer zuerst stoppen' : 'Löschen'}
+                      >
+                        🗑️
+                      </button>
+                    </div>
+                  )}
+                  {isEditing && (
+                    <div className="border-t border-slate-700 p-3">
+                      <EntryEditForm
+                        entry={e}
+                        clients={clients}
+                        onSaved={() => {
+                          setEditingId(null)
+                          showToast('Eintrag gespeichert')
+                        }}
+                        onCancel={() => setEditingId(null)}
+                      />
+                    </div>
+                  )}
+                </li>
+              )
+            })}
+            {creating && (
+              <li className="rounded-lg border border-indigo-500/60 bg-slate-800/60 p-3">
+                <EntryEditForm
+                  clients={clients}
+                  defaultDate={defaultStartForDay(dateISO)}
+                  onSaved={() => {
+                    setCreating(false)
+                    showToast('Eintrag gespeichert')
+                  }}
+                  onCancel={() => setCreating(false)}
+                />
+              </li>
+            )}
+          </ul>
+        </div>
+
+        {/* Sticky footer */}
+        {!creating && (
+          <div className="shrink-0 border-t border-slate-700 bg-slate-800 p-3">
+            <button
+              type="button"
+              onClick={() => setCreating(true)}
+              disabled={clients.length === 0}
+              className="w-full rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              + Eintrag für {dateLabel} hinzufügen
+            </button>
+          </div>
+        )}
+      </aside>
+
+      <ConfirmDialog
+        open={deleteCandidate !== null}
+        title="Eintrag löschen?"
+        message={
+          deleteCandidate
+            ? buildDeleteMessage(deleteCandidate, clientsById.get(deleteCandidate.client_id))
+            : ''
+        }
+        confirmLabel="Löschen"
+        cancelLabel="Abbrechen"
+        variant="danger"
+        onConfirm={() => deleteCandidate && void confirmDelete(deleteCandidate)}
+        onCancel={() => setDeleteCandidate(null)}
+      />
+    </>
+  )
+}
+
+// --- helpers ---
+
+function durationSeconds(entry: Entry): number {
+  const stop = entry.stopped_at ? new Date(entry.stopped_at).getTime() : Date.now()
+  return Math.floor((stop - new Date(entry.started_at).getTime()) / 1000)
+}
+
+function formatHHMM(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return '00:00'
+  const total = Math.floor(seconds)
+  const h = Math.floor(total / 3600)
+  const m = Math.floor((total % 3600) / 60)
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`
+}
+
+function formatTimeRange(e: Entry): string {
+  const start = new Date(e.started_at)
+  const startStr = `${String(start.getHours()).padStart(2, '0')}:${String(start.getMinutes()).padStart(2, '0')}`
+  if (!e.stopped_at) return `${startStr} – …`
+  const stop = new Date(e.stopped_at)
+  const stopStr = `${String(stop.getHours()).padStart(2, '0')}:${String(stop.getMinutes()).padStart(2, '0')}`
+  return `${startStr} – ${stopStr}`
+}
+
+function formatHumanDate(dateISO: string): string {
+  // dateISO is YYYY-MM-DD (LOCAL); show as DD.MM.YYYY
+  const [y, m, d] = dateISO.split('-')
+  return `${d}.${m}.${y}`
+}
+
+function defaultStartForDay(dateISO: string): Date {
+  const [y, m, d] = dateISO.split('-').map((s) => parseInt(s, 10))
+  // Default to 09:00 local on the chosen day for backfill convenience.
+  return new Date(y, m - 1, d, 9, 0, 0, 0)
+}
+
+function buildDeleteMessage(entry: Entry, client: Client | undefined): string {
+  const dur = formatHHMM(durationSeconds(entry))
+  const date = new Date(entry.started_at)
+  const dateStr = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
+  const name = client?.name ?? 'Unbekannt'
+  return `${name} · ${dateStr} · ${dur} — Wirklich löschen? Du kannst es 5 Sekunden lang rückgängig machen.`
+}

--- a/src/renderer/src/hooks/useTimer.ts
+++ b/src/renderer/src/hooks/useTimer.ts
@@ -263,6 +263,7 @@ export function useTimer() {
     setDescription,
     start,
     stop,
+    startWithClient,
     idleKeep,
     idleStopAtIdle,
     idleMarkPause

--- a/src/renderer/src/views/CalendarView.tsx
+++ b/src/renderer/src/views/CalendarView.tsx
@@ -1,0 +1,360 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  addMonths,
+  endOfMonth,
+  endOfWeek,
+  getISOWeek,
+  isSameDay,
+  isSameMonth,
+  startOfMonth,
+  startOfWeek
+} from 'date-fns'
+import type { Entry } from '../../../shared/types'
+import { useEntriesStore } from '../store/entriesStore'
+import { useTimer } from '../hooks/useTimer'
+import { CalendarDrawer } from '../components/CalendarDrawer'
+
+/**
+ * Month-grid calendar view. 7×N rows, KW column on the left.
+ * Click a cell → opens `CalendarDrawer` with that day's entries.
+ *
+ * Performance budget (E12): grouping + render for 200 entries < 100ms.
+ * The grouping pass is `O(n)` and uses local YYYY-MM-DD strings as keys.
+ *
+ * Refresh: re-fetches `entries:getByMonth` on mount, on month change,
+ * and on `entriesStore.version` bump.
+ */
+export default function CalendarView(): React.JSX.Element {
+  const { clients } = useTimer()
+  const version = useEntriesStore((s) => s.version)
+
+  const [cursor, setCursor] = useState(() => startOfMonth(new Date()))
+  const [entries, setEntries] = useState<Entry[]>([])
+  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading')
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+  const [selectedDay, setSelectedDay] = useState<Date | null>(null)
+  const [focusDay, setFocusDay] = useState<Date>(() => new Date())
+  const gridRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    async function load(): Promise<void> {
+      setStatus((s) => (s === 'ready' ? s : 'loading'))
+      const res = await window.api.entries.getByMonth({
+        year: cursor.getFullYear(),
+        month: cursor.getMonth() + 1
+      })
+      if (cancelled) return
+      if (res.ok) {
+        setEntries(res.data)
+        setStatus('ready')
+        setErrorMsg(null)
+      } else {
+        setStatus('error')
+        setErrorMsg(res.error)
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [cursor, version])
+
+  // Group entries by local YYYY-MM-DD (the local-day key).
+  const byDay = useMemo(() => {
+    const map = new Map<string, Entry[]>()
+    for (const e of entries) {
+      const key = localDateKey(new Date(e.started_at))
+      const arr = map.get(key)
+      if (arr) arr.push(e)
+      else map.set(key, [e])
+    }
+    return map
+  }, [entries])
+
+  // Build the visible grid (Mon-anchored weeks covering the whole month).
+  const weeks = useMemo(() => buildMonthWeeks(cursor), [cursor])
+
+  const onPrev = useCallback(() => setCursor((d) => addMonths(d, -1)), [])
+  const onNext = useCallback(() => setCursor((d) => addMonths(d, 1)), [])
+  const onToday = useCallback(() => {
+    const today = new Date()
+    setCursor(startOfMonth(today))
+    setFocusDay(today)
+  }, [])
+
+  // Keyboard navigation on the grid.
+  function handleKey(e: React.KeyboardEvent): void {
+    let next: Date | null = null
+    if (e.key === 'ArrowLeft') next = addDays(focusDay, -1)
+    else if (e.key === 'ArrowRight') next = addDays(focusDay, 1)
+    else if (e.key === 'ArrowUp') next = addDays(focusDay, -7)
+    else if (e.key === 'ArrowDown') next = addDays(focusDay, 7)
+    else if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      setSelectedDay(focusDay)
+      return
+    } else return
+    e.preventDefault()
+    setFocusDay(next)
+    if (!isSameMonth(next, cursor)) setCursor(startOfMonth(next))
+  }
+
+  // When focusDay changes, move DOM focus to it (if rendered).
+  useEffect(() => {
+    if (!gridRef.current) return
+    const key = localDateKey(focusDay)
+    const cell = gridRef.current.querySelector<HTMLElement>(`[data-day="${key}"]`)
+    cell?.focus({ preventScroll: true })
+  }, [focusDay, cursor])
+
+  const selectedKey = selectedDay ? localDateKey(selectedDay) : null
+  const drawerEntries = selectedKey ? (byDay.get(selectedKey) ?? []) : []
+
+  return (
+    <div className="mx-auto flex max-w-5xl flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onPrev}
+          className="grid h-9 w-9 place-items-center rounded-lg border border-slate-700 bg-slate-800 text-slate-300 hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+          aria-label="Vorheriger Monat"
+        >
+          ‹
+        </button>
+        <h2 className="min-w-[200px] text-center text-lg font-semibold text-slate-100">
+          {formatMonthHeader(cursor)}
+        </h2>
+        <button
+          type="button"
+          onClick={onNext}
+          className="grid h-9 w-9 place-items-center rounded-lg border border-slate-700 bg-slate-800 text-slate-300 hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+          aria-label="Nächster Monat"
+        >
+          ›
+        </button>
+        <button
+          type="button"
+          onClick={onToday}
+          className="ml-2 rounded-lg border border-slate-700 bg-slate-800 px-3 py-1.5 text-sm font-medium text-slate-200 hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+        >
+          Heute
+        </button>
+        {status === 'loading' && <span className="ml-auto text-xs text-slate-500">Lade…</span>}
+        {status === 'error' && (
+          <span className="ml-auto text-xs text-red-400" title={errorMsg ?? ''}>
+            Fehler beim Laden
+          </span>
+        )}
+      </div>
+
+      {/* Header row: KW + Mo–So */}
+      <div className="grid grid-cols-[40px_repeat(7,minmax(0,1fr))] gap-px rounded-t-lg bg-slate-700">
+        <div className="bg-slate-800 px-2 py-1 text-center text-xs font-medium text-slate-500">
+          KW
+        </div>
+        {['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'].map((d) => (
+          <div
+            key={d}
+            className="bg-slate-800 px-2 py-1 text-center text-xs font-medium text-slate-400"
+          >
+            {d}
+          </div>
+        ))}
+      </div>
+
+      {/* Grid */}
+      <div
+        ref={gridRef}
+        role="grid"
+        aria-label="Kalender"
+        onKeyDown={handleKey}
+        className="grid grid-cols-[40px_repeat(7,minmax(0,1fr))] gap-px rounded-b-lg bg-slate-700"
+      >
+        {weeks.map((week) => (
+          <Week
+            key={week.weekKey}
+            week={week}
+            cursor={cursor}
+            byDay={byDay}
+            focusDay={focusDay}
+            onSelect={(d) => {
+              setFocusDay(d)
+              setSelectedDay(d)
+            }}
+          />
+        ))}
+      </div>
+
+      <CalendarDrawer
+        open={selectedDay !== null}
+        dateISO={selectedDay ? localDateKey(selectedDay) : ''}
+        entries={drawerEntries}
+        clients={clients}
+        onClose={() => setSelectedDay(null)}
+      />
+    </div>
+  )
+}
+
+interface WeekData {
+  weekKey: string
+  weekNumber: number
+  days: Date[]
+}
+
+function Week({
+  week,
+  cursor,
+  byDay,
+  focusDay,
+  onSelect
+}: {
+  week: WeekData
+  cursor: Date
+  byDay: Map<string, Entry[]>
+  focusDay: Date
+  onSelect: (d: Date) => void
+}): React.JSX.Element {
+  return (
+    <>
+      <div className="bg-slate-900/60 px-2 py-2 text-center text-xs text-slate-500">
+        {week.weekNumber}
+      </div>
+      {week.days.map((day) => {
+        const key = localDateKey(day)
+        const dayEntries = byDay.get(key) ?? []
+        const inMonth = isSameMonth(day, cursor)
+        const isToday = isSameDay(day, new Date())
+        const isFocus = isSameDay(day, focusDay)
+        const totalSeconds = dayEntries.reduce((sum, e) => sum + entryDurationSeconds(e), 0)
+        return (
+          <button
+            key={key}
+            type="button"
+            data-day={key}
+            tabIndex={isFocus ? 0 : -1}
+            role="gridcell"
+            aria-label={`${formatAriaDate(day)}${dayEntries.length ? `, ${dayEntries.length} Einträge` : ''}`}
+            onClick={() => onSelect(day)}
+            className={[
+              'relative flex h-24 flex-col gap-0.5 px-2 py-1 text-left transition-colors',
+              'bg-slate-900 hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-400',
+              !inMonth && 'opacity-40',
+              isToday && 'border-2 border-indigo-500'
+            ]
+              .filter(Boolean)
+              .join(' ')}
+          >
+            <div className="flex items-start justify-between">
+              <span
+                className={`text-sm font-semibold ${isToday ? 'text-indigo-300' : 'text-slate-100'}`}
+              >
+                {day.getDate()}
+              </span>
+              {dayEntries.length > 0 && (
+                <span className="font-mono text-[10px] tabular-nums text-slate-400">
+                  {formatHHMM(totalSeconds)}
+                </span>
+              )}
+            </div>
+            <DayBars entries={dayEntries} />
+          </button>
+        )
+      })}
+    </>
+  )
+}
+
+const MAX_BARS = 5
+
+function DayBars({ entries }: { entries: Entry[] }): React.JSX.Element | null {
+  if (entries.length === 0) return null
+  const visible = entries.slice(0, MAX_BARS)
+  const overflow = entries.length - visible.length
+  return (
+    <div className="mt-auto flex flex-col gap-[2px]">
+      {visible.map((e) => (
+        <div
+          key={e.id}
+          className="h-[3px] rounded-sm"
+          style={{ backgroundColor: '#6366f1' }}
+          title={`${e.description || 'Eintrag'} (${formatHHMM(entryDurationSeconds(e))})`}
+        />
+      ))}
+      {overflow > 0 && <span className="text-[10px] text-slate-400">+{overflow}</span>}
+    </div>
+  )
+}
+
+// --- helpers ---
+
+function buildMonthWeeks(cursor: Date): WeekData[] {
+  // Mon-anchored weeks covering the visible month.
+  const start = startOfWeek(startOfMonth(cursor), { weekStartsOn: 1 })
+  const end = endOfWeek(endOfMonth(cursor), { weekStartsOn: 1 })
+  const weeks: WeekData[] = []
+  let d = start
+  while (d <= end) {
+    const days: Date[] = []
+    for (let i = 0; i < 7; i++) {
+      days.push(d)
+      d = addDays(d, 1)
+    }
+    weeks.push({
+      weekKey: localDateKey(days[0]),
+      weekNumber: getISOWeek(days[0]),
+      days
+    })
+  }
+  return weeks
+}
+
+function localDateKey(d: Date): string {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+function addDays(d: Date, n: number): Date {
+  const next = new Date(d)
+  next.setDate(next.getDate() + n)
+  return next
+}
+
+function entryDurationSeconds(e: Entry): number {
+  const stop = e.stopped_at ? new Date(e.stopped_at).getTime() : Date.now()
+  return Math.max(0, Math.floor((stop - new Date(e.started_at).getTime()) / 1000))
+}
+
+function formatHHMM(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return '00:00'
+  const total = Math.floor(seconds)
+  const h = Math.floor(total / 3600)
+  const m = Math.floor((total % 3600) / 60)
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`
+}
+
+const MONTHS_DE = [
+  'Januar',
+  'Februar',
+  'März',
+  'April',
+  'Mai',
+  'Juni',
+  'Juli',
+  'August',
+  'September',
+  'Oktober',
+  'November',
+  'Dezember'
+]
+
+function formatMonthHeader(d: Date): string {
+  return `${MONTHS_DE[d.getMonth()]} ${d.getFullYear()}`
+}
+
+function formatAriaDate(d: Date): string {
+  return `${d.getDate()}. ${MONTHS_DE[d.getMonth()]} ${d.getFullYear()}`
+}

--- a/src/renderer/src/views/TodayView.tsx
+++ b/src/renderer/src/views/TodayView.tsx
@@ -1,0 +1,429 @@
+import { useEffect, useMemo, useState } from 'react'
+import type { Client, DashboardSummary, Entry } from '../../../shared/types'
+import { useEntriesStore } from '../store/entriesStore'
+import { useToastStore } from '../store/toastStore'
+import { useTimer, formatDuration } from '../hooks/useTimer'
+import { Dialog } from '../components/Dialog'
+import { ConfirmDialog } from '../components/ConfirmDialog'
+import { EntryEditForm } from '../components/EntryEditForm'
+
+/**
+ * `Heute` view — the new default tab in v1.2 (D1).
+ *
+ * Layout:
+ *   - Top: compact `Aktiver Timer` pill (or "Kein Timer läuft").
+ *   - Two stat cards: today + this week (HH:MM, no seconds).
+ *   - Quick-Start row: top-3 frequent clients of the last 30d.
+ *   - Recent list: last 5 entries with edit / delete icons.
+ *   - "+ Eintrag nachtragen" button → opens the edit form in a Dialog.
+ *
+ * Refresh strategy (E1): re-fetch on mount, on `entriesStore.version`
+ * change (any mutation in the app bumps it), and when the running entry
+ * starts/stops. No polling.
+ */
+export default function TodayView(): React.JSX.Element {
+  const { runningEntry, clients, startWithClient } = useTimer()
+  const version = useEntriesStore((s) => s.version)
+  const showToast = useToastStore((s) => s.show)
+
+  const [summary, setSummary] = useState<DashboardSummary | null>(null)
+  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading')
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+
+  // Edit / create / delete dialog state
+  const [createOpen, setCreateOpen] = useState(false)
+  const [editEntry, setEditEntry] = useState<Entry | null>(null)
+  const [deleteCandidate, setDeleteCandidate] = useState<Entry | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    async function load(): Promise<void> {
+      setStatus((s) => (s === 'ready' ? s : 'loading'))
+      const res = await window.api.dashboard.summary()
+      if (cancelled) return
+      if (res.ok) {
+        setSummary(res.data)
+        setStatus('ready')
+        setErrorMsg(null)
+      } else {
+        setStatus('error')
+        setErrorMsg(res.error)
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [version, runningEntry?.id])
+
+  const clientsById = useMemo(() => {
+    const map = new Map<number, Client>()
+    for (const c of clients) map.set(c.id, c)
+    return map
+  }, [clients])
+
+  async function confirmDelete(entry: Entry): Promise<void> {
+    setDeleteCandidate(null)
+    const res = await window.api.entries.delete(entry.id)
+    if (!res.ok) {
+      showToast(`Löschen fehlgeschlagen: ${res.error}`)
+      return
+    }
+    useEntriesStore.getState().bumpVersion()
+    showToast('Eintrag gelöscht', {
+      label: 'Rückgängig',
+      type: 'undo_delete',
+      data: { entryId: entry.id }
+    })
+  }
+
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-6">
+      <ActiveTimerPill runningEntry={runningEntry} clientsById={clientsById} />
+
+      {status === 'loading' && <SummarySkeleton />}
+      {status === 'error' && (
+        <div className="rounded-lg border border-red-700/50 bg-red-900/20 p-4 text-sm text-red-200">
+          <p className="mb-2 font-medium">Daten konnten nicht geladen werden.</p>
+          {errorMsg && <p className="mb-2 text-xs text-red-300/80">{errorMsg}</p>}
+          <button
+            type="button"
+            className="rounded bg-red-800 px-3 py-1 text-xs hover:bg-red-700"
+            onClick={() => useEntriesStore.getState().bumpVersion()}
+          >
+            Erneut versuchen
+          </button>
+        </div>
+      )}
+      {status === 'ready' && summary && (
+        <>
+          <div className="grid grid-cols-2 gap-4">
+            <StatCard label="Heute" seconds={summary.todaySeconds} accent="text-indigo-300" />
+            <StatCard label="Diese Woche" seconds={summary.weekSeconds} accent="text-emerald-300" />
+          </div>
+
+          <QuickStartRow
+            topClients={summary.topClients30d}
+            disabled={!!runningEntry}
+            clientsById={clientsById}
+            onStart={(id) => void startWithClient(id)}
+          />
+
+          <RecentList
+            entries={summary.recentEntries}
+            clientsById={clientsById}
+            onEdit={(e) => setEditEntry(e)}
+            onDelete={(e) => setDeleteCandidate(e)}
+          />
+        </>
+      )}
+
+      <button
+        type="button"
+        onClick={() => setCreateOpen(true)}
+        disabled={clients.length === 0}
+        className="self-start rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        + Eintrag nachtragen
+      </button>
+
+      <Dialog
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        title="Eintrag nachtragen"
+        widthClass="w-[520px]"
+      >
+        <EntryEditForm
+          clients={clients}
+          defaultDate={defaultBackfillStart()}
+          onSaved={() => {
+            setCreateOpen(false)
+            showToast('Eintrag gespeichert')
+          }}
+          onCancel={() => setCreateOpen(false)}
+        />
+      </Dialog>
+
+      <Dialog
+        open={editEntry !== null}
+        onClose={() => setEditEntry(null)}
+        title="Eintrag bearbeiten"
+        widthClass="w-[520px]"
+      >
+        {editEntry && (
+          <EntryEditForm
+            entry={editEntry}
+            clients={clients}
+            onSaved={() => {
+              setEditEntry(null)
+              showToast('Eintrag gespeichert')
+            }}
+            onCancel={() => setEditEntry(null)}
+          />
+        )}
+      </Dialog>
+
+      <ConfirmDialog
+        open={deleteCandidate !== null}
+        title="Eintrag löschen?"
+        message={
+          deleteCandidate
+            ? buildDeleteMessage(deleteCandidate, clientsById.get(deleteCandidate.client_id))
+            : ''
+        }
+        confirmLabel="Löschen"
+        cancelLabel="Abbrechen"
+        variant="danger"
+        onConfirm={() => deleteCandidate && void confirmDelete(deleteCandidate)}
+        onCancel={() => setDeleteCandidate(null)}
+      />
+    </div>
+  )
+}
+
+function ActiveTimerPill({
+  runningEntry,
+  clientsById
+}: {
+  runningEntry: Entry | null
+  clientsById: Map<number, Client>
+}): React.JSX.Element {
+  // A `now` tick instead of derived `tickSeconds` so we don't call
+  // setState synchronously when `runningEntry` changes (lint rule).
+  const [, setNow] = useState(0)
+  useEffect(() => {
+    if (!runningEntry) return
+    const id = setInterval(() => setNow((n) => n + 1), 1000)
+    return () => clearInterval(id)
+  }, [runningEntry])
+  const tickSeconds = liveSeconds(runningEntry)
+
+  if (!runningEntry) {
+    return (
+      <div className="rounded-lg border border-slate-700 bg-slate-800/60 px-4 py-2 text-sm text-slate-500">
+        Kein Timer läuft
+      </div>
+    )
+  }
+  const client = clientsById.get(runningEntry.client_id)
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-emerald-700/60 bg-emerald-900/20 px-4 py-2 text-sm">
+      <span
+        className="h-2.5 w-2.5 animate-pulse rounded-full"
+        style={{ backgroundColor: client?.color ?? '#10b981' }}
+      />
+      <span className="font-medium text-slate-100">{client?.name ?? 'Unbekannt'}</span>
+      {runningEntry.description && (
+        <span className="truncate text-slate-400">— {runningEntry.description}</span>
+      )}
+      <span className="ml-auto font-mono tabular-nums text-emerald-300">
+        {formatDuration(tickSeconds)}
+      </span>
+    </div>
+  )
+}
+
+function StatCard({
+  label,
+  seconds,
+  accent
+}: {
+  label: string
+  seconds: number
+  accent: string
+}): React.JSX.Element {
+  return (
+    <div className="rounded-lg border border-slate-700 bg-slate-800 p-4">
+      <p className="text-xs font-medium uppercase tracking-wide text-slate-400">{label}</p>
+      <p className={`mt-1 font-mono text-3xl font-bold tabular-nums ${accent}`}>
+        {formatHHMM(seconds)}
+      </p>
+    </div>
+  )
+}
+
+function QuickStartRow({
+  topClients,
+  disabled,
+  clientsById,
+  onStart
+}: {
+  topClients: DashboardSummary['topClients30d']
+  disabled: boolean
+  clientsById: Map<number, Client>
+  onStart: (clientId: number) => void
+}): React.JSX.Element | null {
+  if (topClients.length === 0) return null
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="text-xs uppercase tracking-wide text-slate-500">Quick-Start</span>
+      {topClients.map((c) => {
+        const stillActive = clientsById.get(c.client_id)?.active === 1
+        return (
+          <button
+            key={c.client_id}
+            type="button"
+            disabled={disabled || !stillActive}
+            onClick={() => onStart(c.client_id)}
+            className="flex items-center gap-2 rounded-full border border-slate-700 bg-slate-800 px-3 py-1 text-sm text-slate-200 hover:border-indigo-500 hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
+            title={stillActive ? `Timer für ${c.name} starten` : 'Kunde inaktiv'}
+          >
+            <span className="h-2 w-2 rounded-full" style={{ backgroundColor: c.color }} />
+            {c.name}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+function RecentList({
+  entries,
+  clientsById,
+  onEdit,
+  onDelete
+}: {
+  entries: Entry[]
+  clientsById: Map<number, Client>
+  onEdit: (e: Entry) => void
+  onDelete: (e: Entry) => void
+}): React.JSX.Element {
+  if (entries.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-slate-700 bg-slate-800/40 px-4 py-8 text-center">
+        <p className="text-sm font-medium text-slate-300">Noch kein Eintrag heute</p>
+        <p className="mt-1 text-xs text-slate-500">
+          Starte einen Timer oder lege einen Eintrag manuell nach.
+        </p>
+      </div>
+    )
+  }
+  return (
+    <div className="overflow-hidden rounded-lg border border-slate-700">
+      <table className="w-full text-sm">
+        <thead className="bg-slate-800 text-xs uppercase tracking-wide text-slate-400">
+          <tr>
+            <th className="px-3 py-2 text-left font-medium">Zeit</th>
+            <th className="px-3 py-2 text-left font-medium">Kunde</th>
+            <th className="px-3 py-2 text-left font-medium">Beschreibung</th>
+            <th className="px-3 py-2 text-right font-medium">Dauer</th>
+            <th className="w-20 px-3 py-2"></th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-800 bg-slate-900/40">
+          {entries.map((e) => {
+            const client = clientsById.get(e.client_id)
+            return (
+              <tr key={e.id} className="hover:bg-slate-800/60">
+                <td className="px-3 py-2 font-mono text-xs text-slate-300 tabular-nums">
+                  {formatTimeRange(e)}
+                </td>
+                <td className="px-3 py-2">
+                  <span className="inline-flex items-center gap-2 text-slate-200">
+                    <span
+                      className="h-2 w-2 rounded-full"
+                      style={{ backgroundColor: client?.color ?? '#64748b' }}
+                    />
+                    {client?.name ?? 'Unbekannt'}
+                  </span>
+                </td>
+                <td className="px-3 py-2 text-slate-300">
+                  <span className="block max-w-[280px] truncate" title={e.description}>
+                    {e.description || <span className="text-slate-600">—</span>}
+                  </span>
+                </td>
+                <td className="px-3 py-2 text-right font-mono text-xs text-slate-300 tabular-nums">
+                  {formatHHMM(durationSeconds(e))}
+                </td>
+                <td className="px-3 py-2 text-right">
+                  <div className="flex justify-end gap-1">
+                    <button
+                      type="button"
+                      onClick={() => onEdit(e)}
+                      className="rounded p-1 text-slate-400 hover:bg-slate-700 hover:text-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                      aria-label="Bearbeiten"
+                      title="Bearbeiten"
+                    >
+                      ✏️
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onDelete(e)}
+                      disabled={e.stopped_at === null}
+                      className="rounded p-1 text-slate-400 hover:bg-slate-700 hover:text-red-300 focus:outline-none focus:ring-2 focus:ring-red-400 disabled:cursor-not-allowed disabled:opacity-30"
+                      aria-label="Löschen"
+                      title={e.stopped_at === null ? 'Laufenden Timer zuerst stoppen' : 'Löschen'}
+                    >
+                      🗑️
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function SummarySkeleton(): React.JSX.Element {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="grid grid-cols-2 gap-4">
+        <div className="h-24 animate-pulse rounded-lg bg-slate-800" />
+        <div className="h-24 animate-pulse rounded-lg bg-slate-800" />
+      </div>
+      <div className="space-y-2">
+        {[0, 1, 2, 3, 4].map((i) => (
+          <div key={i} className="h-10 animate-pulse rounded bg-slate-800" />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// --- helpers ---
+
+function liveSeconds(entry: Entry | null): number {
+  if (!entry) return 0
+  return Math.floor((Date.now() - new Date(entry.started_at).getTime()) / 1000)
+}
+
+function durationSeconds(entry: Entry): number {
+  if (!entry.stopped_at) return liveSeconds(entry)
+  return Math.floor(
+    (new Date(entry.stopped_at).getTime() - new Date(entry.started_at).getTime()) / 1000
+  )
+}
+
+/** Format seconds as HH:MM (no seconds, for stat cards / durations). */
+function formatHHMM(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return '00:00'
+  const total = Math.floor(seconds)
+  const h = Math.floor(total / 3600)
+  const m = Math.floor((total % 3600) / 60)
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`
+}
+
+function formatTimeRange(e: Entry): string {
+  const start = new Date(e.started_at)
+  const startStr = `${String(start.getHours()).padStart(2, '0')}:${String(start.getMinutes()).padStart(2, '0')}`
+  if (!e.stopped_at) return `${startStr} – …`
+  const stop = new Date(e.stopped_at)
+  const stopStr = `${String(stop.getHours()).padStart(2, '0')}:${String(stop.getMinutes()).padStart(2, '0')}`
+  return `${startStr} – ${stopStr}`
+}
+
+/** Default `defaultDate` for "+ Eintrag nachtragen": one hour ago. */
+function defaultBackfillStart(): Date {
+  return new Date(Date.now() - 60 * 60 * 1000)
+}
+
+function buildDeleteMessage(entry: Entry, client: Client | undefined): string {
+  const dur = formatHHMM(durationSeconds(entry))
+  const date = new Date(entry.started_at)
+  const dateStr = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
+  const name = client?.name ?? 'Unbekannt'
+  return `${name} · ${dateStr} · ${dur} — Wirklich löschen? Du kannst es 5 Sekunden lang rückgängig machen.`
+}


### PR DESCRIPTION
**v1.2 PR C — TodayView + CalendarView + Drawer + delete/undo wiring.** This is the user-visible payoff of v1.2: PR B's headless IPC + primitives now drive the actual UI.

Closes #26, #27, #28, #29, #30.

## What's in here

### 1. Routing — `src/renderer/src/App.tsx`
- New `'today'` view, **default tab**.
- Nav order: **Heute** · Timer · Kalender · Kunden · Einstellungen.
- Calendar placeholder removed.

### 2. `TodayView.tsx`
The new home screen.

- **Aktiver Timer pill** at the top (D1) — compact, full-width, ~32px:
  - Running: client color dot + name + description + live `HH:MM:SS`.
  - Idle: subtle `Kein Timer läuft`.
- **Stat cards row** — `Heute` / `Diese Woche` in HH:MM (no seconds).
- **Quick-Start row** — top-3 frequent clients of the last 30d, disabled when a timer is running. Calls `useTimer.startWithClient` so `timerStore` is updated in the same flow (no orphaned IPC start).
- **Recent list** — last 5 entries with edit (✏️) / delete (🗑️). Delete on a still-running entry is disabled with a tooltip.
- **+ Eintrag nachtragen** button → opens `EntryEditForm` in a `Dialog`, defaults to one hour ago.
- **State coverage**:
  - `loading` → 3 skeleton bars + 5 placeholder rows
  - `empty` → warm CTA "Noch kein Eintrag heute — starte einen Timer oder lege einen nach"
  - `error` → red banner with the error message + a Retry that bumps `entriesStore.version`
- **Refresh** (E1): on mount, on `entriesStore.version` bump, on `runningEntry?.id` change. **No 60s polling.**

### 3. `CalendarView.tsx`
Mon-anchored 7×N grid replacing the old placeholder.

- Header: ‹ — `Monat YYYY` — › — `Heute`.
- KW column on the left (`date-fns getISOWeek`).
- Per cell:
  - Day number top-left (today: `border-2 border-indigo-500` + indigo number color).
  - Tagessumme top-right (`HH:MM`).
  - Up to **5 mini-bars** (3px height, 2px gap), `+N` for overflow (D3).
- **Keyboard nav** (focusable grid):
  - `←` / `→` / `↑` / `↓` move focus by day / week, auto-changing month at boundaries.
  - `Enter` / `Space` opens the drawer for the focused day.
  - `Esc` (in drawer) closes the innermost layer (form → create → confirm → drawer).
- **Data flow**: `entries:getByMonth` runs on mount, on month change, and on `entriesStore.version` bump. Grouping is `O(n)` over a `Map<YYYY-MM-DD, Entry[]>` in a `useMemo`.

### 4. `CalendarDrawer.tsx`
Right-side `fixed w-96 h-screen` slide-in for the selected day.

- **Sticky header**: "Einträge für DD.MM.YYYY" + count + total HH:MM, close X with 44px touch target.
- **Body**: chronological entry list. Click ✏️ → row expands inline to `EntryEditForm`.
- **Sticky footer**: `+ Eintrag für {Date} hinzufügen` (D6) → expands an inline create form (defaults to 09:00 on the chosen day).
- **Delete flow**:
  1. Click 🗑️ → `ConfirmDialog` (default focus on **Abbrechen**, never on the destructive button).
  2. Confirm → `entries:delete` (soft) + bump version.
  3. Toast: "Eintrag gelöscht — [Rückgängig]" lives 5 s.
  4. The toast snapshot owns the entry id, so undo still works after the drawer closes (E9).
  5. `entries:undelete` restores the row with the **same id** (E10) — required for v1.3 PDF FK stability.

### 5. `useTimer`
- Now also exports `startWithClient` so the Quick-Start row can drive the IPC + the `timerStore` in one call.

## Out of scope

- Cross-midnight entries — still rejected with the persistent v1.2 info banner above the time fields. Lifting this is a v1.3 task tracked separately.
- Tray tooltip i18n, mobile <1024px, colorblind palette — all v1.4.
- Release infra (`electron-rebuild` + smoke) → PR D, must merge before tagging v1.2.0.

## Verification

| Check | Result |
| --- | --- |
| `pnpm typecheck` | ✅ green (node + web) |
| `pnpm test` | ✅ **51/51** pass (no regressions) |
| `pnpm lint` | ✅ baseline 21 errors, **0 new** |

### Manual smoke checklist (run in dev)
- [ ] App opens on **Heute** by default; nav order is `Heute / Timer / Kalender / Kunden / Einstellungen`.
- [ ] With clients but no entries today → empty CTA shows.
- [ ] Start a timer from the Timer tab → pill on Heute updates within ~1s, "Heute" stat keeps growing on each refresh trigger.
- [ ] "+ Eintrag nachtragen" → form pre-filled to one hour ago → save → appears in recent list immediately.
- [ ] Calendar: navigate months, today cell has indigo border, click a day with entries → drawer opens with the right list + total.
- [ ] Edit in drawer → row collapses back to read-mode + toast.
- [ ] Delete in drawer → confirm dialog defaults focus to Abbrechen → confirm → toast "Eintrag gelöscht [Rückgängig]" → click Rückgängig → entry reappears with the same id (verifiable via `SELECT id` if you want to be paranoid).
- [ ] Keyboard: focus a calendar cell, ←/→/↑/↓ move focus across month boundaries, Enter opens the drawer, Esc closes it.
