### PR TITLE
feat(v1.2 PR D): packaged-binary smoke test in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,46 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm build:win
 
+      - name: Smoke test packaged binary (DB + migrations against Electron ABI)
+        shell: pwsh
+        run: |
+          $exe = Get-ChildItem -Path "dist/win-unpacked" -Filter "*.exe" |
+                 Where-Object { $_.Name -notmatch '(uninstall|crashpad|elevate)' } |
+                 Select-Object -First 1
+          if (-not $exe) {
+            Write-Error "No packaged exe found in dist/win-unpacked"
+            exit 1
+          }
+          $out = Join-Path $env:RUNNER_TEMP "smoke.json"
+          if (Test-Path $out) { Remove-Item $out -Force }
+          Write-Host "Running smoke test: $($exe.FullName) --smoke-test=$out"
+          $proc = Start-Process -FilePath $exe.FullName -ArgumentList "--smoke-test=$out" -PassThru -NoNewWindow
+          if (-not $proc.WaitForExit(60000)) {
+            Stop-Process -Id $proc.Id -Force
+            Write-Error "Smoke test timed out after 60s"
+            exit 1
+          }
+          if ($proc.ExitCode -ne 0) {
+            Write-Error "Smoke test exited with code $($proc.ExitCode)"
+            if (Test-Path $out) { Get-Content $out }
+            exit 1
+          }
+          if (-not (Test-Path $out)) {
+            Write-Error "Smoke test did not produce $out"
+            exit 1
+          }
+          $payload = Get-Content $out -Raw | ConvertFrom-Json
+          Write-Host "Smoke result: $($payload | ConvertTo-Json -Compress)"
+          if (-not $payload.ok) {
+            Write-Error "Smoke test reported ok=false: $($payload.error)"
+            exit 1
+          }
+          if ($payload.schemaVersion -lt 3) {
+            Write-Error "Expected schemaVersion >= 3 (v1.2 migrations), got $($payload.schemaVersion)"
+            exit 1
+          }
+          Write-Host "Smoke test passed (schema v$($payload.schemaVersion), Electron $($payload.electronVersion))"
+
       - name: Upload installer artifact
         uses: actions/upload-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 All notable changes to TimeTrack are documented here.
 
+## [Unreleased] — v1.2
+
+### Added
+
+- **Heute-Ansicht** (neuer Default-Tab) — Aktiver-Timer-Pille mit Live-Counter,
+  zwei Stat-Cards (Heute / Diese Woche), Quick-Start-Reihe für die Top-3-Kunden
+  der letzten 30 Tage, Liste der letzten 5 Einträge mit Bearbeiten/Löschen
+  und „+ Eintrag nachtragen"-Dialog.
+- **Kalender-Ansicht** — 7×N-Monatsraster mit KW-Spalte, Tagessumme und bis zu
+  5 Mini-Bars pro Tag (mit „+N" für Überlauf), Tastatur-Navigation
+  (Pfeil/Enter/Esc), heutige Zelle hervorgehoben.
+- **Tages-Drawer** — Klick auf einen Kalendertag öffnet eine seitliche Liste
+  aller Einträge des Tages. Inline-Bearbeitung, Inline-Anlegen via Sticky-Footer,
+  Löschen mit Bestätigungsdialog.
+- **Manuelles Anlegen & Bearbeiten** von Einträgen mit Server-seitiger
+  Validierung (Überschneidungen, Beschreibungs-Länge, max. 24 h, Kunden-
+  Existenz).
+- **Soft-Delete + Rückgängig** — Gelöschte Einträge werden 5 Sekunden lang per
+  Toast wiederherstellbar; die Einträge werden nicht hart gelöscht (`deleted_at`-
+  Spalte) sodass spätere PDF-Referenzen stabil bleiben.
+- **Tray-Tooltip mit Heute-Total** (#31) — Format `● Kunde · HH:MM · Heute HH:MM`
+  bzw. `TimeTrack — Heute HH:MM` im Idle, aktualisiert über den 30-s-Heartbeat.
+- **DESIGN.md-Stub** — Tokens für Farben, Typografie und Spacing als
+  Design-Source-of-Truth.
+- **Migration 003** — Spalten `clients.rate_cent` (v1.3-PDF-Vorbereitung) und
+  `entries.deleted_at`, Index `idx_entries_started_at`, Backfill für legacy
+  `rounded_min`-Werte. Pre-/Post-Apply-Logging und Assertion (negative
+  Dauern lösen automatischen Rollback aus).
+- **`dashboard:summary`-IPC** — Heute, Woche, letzte 5 Einträge und Top-3-Kunden
+  in einer einzelnen Lese-Transaktion.
+- **CI Smoke-Test** — Die Release-Pipeline startet die gepackte `.exe` mit
+  `--smoke-test=…`, prüft Exit-Code, Schema-Version und Electron-ABI bevor das
+  Artefakt veröffentlicht wird. Schließt die Klasse von ABI-Crashes (v1.1.x)
+  vor dem Tag.
+
+### Notes
+
+- **Einträge über Mitternacht** werden in v1.2 abgelehnt; die Edit-Maske zeigt
+  einen permanenten Hinweis, eine Lösung folgt in v1.3.
+- **User-facing Rounding-UI** wurde aus v1.2 ausgenommen und kommt in v1.3
+  zusammen mit dem PDF-Export.
+
 ## [1.1.2] — 2026-04-24
 
 ### Fixed
@@ -27,13 +69,13 @@ All notable changes to TimeTrack are documented here.
 
 - **Idle-Detection** — When the system is idle longer than the configured
   threshold (default 5 minutes), a modal asks what to do with the time:
-  *Weiter laufen lassen*, *Bei Inaktivität stoppen*, or *Als Pause markieren*.
+  _Weiter laufen lassen_, _Bei Inaktivität stoppen_, or _Als Pause markieren_.
   Driven by `powerMonitor.getSystemIdleTime()` in the main process.
 - **Tray Quick-Start** — Right-click the tray icon to start a timer for any
   client directly, without opening the window. The menu rebuilds dynamically
-  from the active-clients list and shows a *Stop* entry while a timer runs.
-- **Settings-View** — New *Einstellungen* tab with sections *Allgemein*,
-  *Timer*, *Daten* and *Über*. Configure language, auto-start, idle threshold,
+  from the active-clients list and shows a _Stop_ entry while a timer runs.
+- **Settings-View** — New _Einstellungen_ tab with sections _Allgemein_,
+  _Timer_, _Daten_ and _Über_. Configure language, auto-start, idle threshold,
   global hotkey (with capture UI), and inspect data paths and backups.
 - **Auto-Backup** — A daily SQLite backup runs at app startup, kept rolling
   for the last 7 days under `%AppData%\TimeTrack\backups\`. Manual backups,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,6 +10,7 @@ import {
   type MenuItemConstructorOptions
 } from 'electron'
 import { join } from 'path'
+import { writeFileSync } from 'fs'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
 import { getDb, recoverZombieEntries, MigrationError } from './db'
@@ -196,6 +197,56 @@ function createWindow(): void {
 
 app.whenReady().then(() => {
   electronApp.setAppUserModelId('com.timetrack.app')
+
+  // Smoke-test mode (CI release pipeline). When invoked with
+  // `--smoke-test=<path>`, open the DB (which runs migrations against
+  // the Electron-ABI better-sqlite3 binary), write a JSON status to
+  // <path>, and exit. No window, no tray, no IPC handlers.
+  // This is the v1.2 packaged-binary smoke check (E11) that catches
+  // ABI / native-module regressions before we publish a release.
+  const smokeArg = process.argv.find((a) => a.startsWith('--smoke-test'))
+  if (smokeArg) {
+    const outPath = smokeArg.includes('=') ? smokeArg.split('=').slice(1).join('=') : ''
+    try {
+      const db = getDb()
+      const row = db.prepare('SELECT MAX(version) as v FROM schema_version').get() as {
+        v: number | null
+      }
+      const result = {
+        ok: true as const,
+        schemaVersion: row.v ?? 0,
+        dbPath: app.getPath('userData'),
+        electronVersion: process.versions.electron,
+        nodeVersion: process.versions.node
+      }
+      const payload = JSON.stringify(result)
+      console.log(`[smoke] ${payload}`)
+      if (outPath) {
+        try {
+          writeFileSync(outPath, payload, 'utf8')
+        } catch (e) {
+          console.warn('[smoke] could not write to outPath:', (e as Error).message)
+        }
+      }
+      app.exit(0)
+    } catch (err) {
+      const payload = JSON.stringify({
+        ok: false,
+        error: (err as Error).message,
+        electronVersion: process.versions.electron
+      })
+      console.error(`[smoke] ${payload}`)
+      if (outPath) {
+        try {
+          writeFileSync(outPath, payload, 'utf8')
+        } catch {
+          /* ignore — exit code is the source of truth */
+        }
+      }
+      app.exit(1)
+    }
+    return
+  }
 
   app.on('browser-window-created', (_, window) => {
     optimizer.watchWindowShortcuts(window)


### PR DESCRIPTION
**v1.2 PR D — Packaged-binary smoke test in CI + v1.2 CHANGELOG.** Closes the v1.2 release-infra gap (E11). Last PR before tagging `v1.2.0`.

## Why

v1.1.0 and v1.1.1 shipped a `better-sqlite3` binary built for the wrong ABI (Node, not Electron). The app crashed at startup with `NODE_MODULE_VERSION` mismatch on every fresh install. v1.1.2 fixed the build step, but **the only way we knew the fix worked was a user trying it.** This PR makes the same class of bug fail the release pipeline before the GitHub Release is published.

## What's in here

### 1. `--smoke-test=<path>` mode in `src/main/index.ts`
Early-exit code path inside `app.whenReady`:
1. Parse `--smoke-test=<outPath>` from `process.argv`.
2. Call `getDb()` — opens the SQLite file and runs every migration against the **actual Electron-ABI** `better-sqlite3` binary.
3. Read `MAX(version)` from `schema_version`.
4. Write JSON status to `<outPath>` and `app.exit(0)`.
5. Any thrown error → JSON `{ ok: false, error, electronVersion }` and `app.exit(1)`.

No window, no tray, no IPC handlers, no idle watcher. Pure DB-open + migrate + exit.

JSON payload on success:
```json
{
  "ok": true,
  "schemaVersion": 3,
  "dbPath": "C:\\Users\\runneradmin\\AppData\\Roaming\\TimeTrack",
  "electronVersion": "39.2.6",
  "nodeVersion": "22.x.x"
}
```

### 2. CI smoke step in `.github/workflows/release.yml`
Inserted between `build:win` and `upload-artifact`:
- Locates `dist/win-unpacked/*.exe` (filters out `uninstall*`, `crashpad*`, `elevate*`).
- Launches it with `--smoke-test=$RUNNER_TEMP/smoke.json`, `WaitForExit(60000)`.
- Fails the release if:
  - exit code != 0
  - the JSON file is missing
  - `ok != true`
  - `schemaVersion < 3` (i.e. v1.2 migration didn't apply)
  - the binary hangs > 60 s

So a future `better-sqlite3` ABI mismatch, a broken migration, or a runtime regression in the main process initialization will block the release at the CI step instead of crashing on user machines.

### 3. CHANGELOG.md
Added the `[Unreleased] — v1.2` section consolidating PR A–D:
- TodayView, CalendarView + Drawer, manual create/edit, soft-delete + Rückgängig
- Tray today-total tooltip, DESIGN.md stub
- Migration 003 (rate_cent, deleted_at, idx, backfill, post-apply assertion)
- `dashboard:summary` IPC
- The smoke test itself

Plus `### Notes` documenting the v1.2 cross-midnight limitation and the rounding-UI deferral to v1.3.

## Verification

| Check | Result |
| --- | --- |
| `pnpm typecheck` | ✅ green |
| `pnpm test` | ✅ 51/51 (unchanged) |
| `pnpm lint` | ✅ baseline 21 errors, **0 new** |

The smoke step itself can only be exercised in the actual release pipeline on a tag push — cannot be simulated from a feature-branch push (no `dist/win-unpacked/*.exe` is produced for branch CI). The first real run will be the v1.2.0 tag.

## After this merges

Tag `v1.2.0` → release pipeline runs PR D's smoke step → if it passes, the GitHub Release is published. If `better-sqlite3` ABI is wrong again, or migration 003 doesn't apply, the release fails before any user can download it.
