### PR TITLE
feat(v1.3 PR A): Stundensatz + Quick-Filter (warm-up)

### DIFF
--- a/.github/pr-body-v12-d.md
+++ b/.github/pr-body-v12-d.md
@@ -1,0 +1,65 @@
+**v1.2 PR D — Packaged-binary smoke test in CI + v1.2 CHANGELOG.** Closes the v1.2 release-infra gap (E11). Last PR before tagging `v1.2.0`.
+
+## Why
+
+v1.1.0 and v1.1.1 shipped a `better-sqlite3` binary built for the wrong ABI (Node, not Electron). The app crashed at startup with `NODE_MODULE_VERSION` mismatch on every fresh install. v1.1.2 fixed the build step, but **the only way we knew the fix worked was a user trying it.** This PR makes the same class of bug fail the release pipeline before the GitHub Release is published.
+
+## What's in here
+
+### 1. `--smoke-test=<path>` mode in `src/main/index.ts`
+Early-exit code path inside `app.whenReady`:
+1. Parse `--smoke-test=<outPath>` from `process.argv`.
+2. Call `getDb()` — opens the SQLite file and runs every migration against the **actual Electron-ABI** `better-sqlite3` binary.
+3. Read `MAX(version)` from `schema_version`.
+4. Write JSON status to `<outPath>` and `app.exit(0)`.
+5. Any thrown error → JSON `{ ok: false, error, electronVersion }` and `app.exit(1)`.
+
+No window, no tray, no IPC handlers, no idle watcher. Pure DB-open + migrate + exit.
+
+JSON payload on success:
+```json
+{
+  "ok": true,
+  "schemaVersion": 3,
+  "dbPath": "C:\\Users\\runneradmin\\AppData\\Roaming\\TimeTrack",
+  "electronVersion": "39.2.6",
+  "nodeVersion": "22.x.x"
+}
+```
+
+### 2. CI smoke step in `.github/workflows/release.yml`
+Inserted between `build:win` and `upload-artifact`:
+- Locates `dist/win-unpacked/*.exe` (filters out `uninstall*`, `crashpad*`, `elevate*`).
+- Launches it with `--smoke-test=$RUNNER_TEMP/smoke.json`, `WaitForExit(60000)`.
+- Fails the release if:
+  - exit code != 0
+  - the JSON file is missing
+  - `ok != true`
+  - `schemaVersion < 3` (i.e. v1.2 migration didn't apply)
+  - the binary hangs > 60 s
+
+So a future `better-sqlite3` ABI mismatch, a broken migration, or a runtime regression in the main process initialization will block the release at the CI step instead of crashing on user machines.
+
+### 3. CHANGELOG.md
+Added the `[Unreleased] — v1.2` section consolidating PR A–D:
+- TodayView, CalendarView + Drawer, manual create/edit, soft-delete + Rückgängig
+- Tray today-total tooltip, DESIGN.md stub
+- Migration 003 (rate_cent, deleted_at, idx, backfill, post-apply assertion)
+- `dashboard:summary` IPC
+- The smoke test itself
+
+Plus `### Notes` documenting the v1.2 cross-midnight limitation and the rounding-UI deferral to v1.3.
+
+## Verification
+
+| Check | Result |
+| --- | --- |
+| `pnpm typecheck` | ✅ green |
+| `pnpm test` | ✅ 51/51 (unchanged) |
+| `pnpm lint` | ✅ baseline 21 errors, **0 new** |
+
+The smoke step itself can only be exercised in the actual release pipeline on a tag push — cannot be simulated from a feature-branch push (no `dist/win-unpacked/*.exe` is produced for branch CI). The first real run will be the v1.2.0 tag.
+
+## After this merges
+
+Tag `v1.2.0` → release pipeline runs PR D's smoke step → if it passes, the GitHub Release is published. If `better-sqlite3` ABI is wrong again, or migration 003 doesn't apply, the release fails before any user can download it.

--- a/.github/pr-body-v13-a.md
+++ b/.github/pr-body-v13-a.md
@@ -1,0 +1,35 @@
+## v1.3 PR A — Stundensatz + Quick-Filter (warm-up)
+
+Kicks off **v1.3**. Small, low-risk surface so we can land the schema/UI scaffolding before PR B (Cross-Midnight + JSON-Export) and PR C (the actual PDF pipeline).
+
+### Was hier drin ist
+
+- **Stundensatz pro Kunde (#20)** — Optionales €/h-Feld in der Kunden-Maske. Reuse der bereits in v1.2-Migration 003 angelegten `clients.rate_cent` Spalte (Integer-Cents); `0` = "kein Satz hinterlegt", PDF wird die €-Spalte dann weglassen. Eingabe als deutsche Dezimalzahl, IPC validiert auf `>= 0`.
+- **Quick-Filter im Kalender (#21)** — Vier Pillen ("Diese Woche", "Letzte Woche", "Diesen Monat", "Letzter Monat") + farbiger Hero-Button "📄 Letzter Monat als PDF" über dem Kalender. Klick loggt aktuell nur den Range; das echte PDF-Modal landet in **PR C**.
+- **Migration 004** — Seedet 6 Settings-Keys für die PDF-Pipeline (`pdf_logo_path`, `pdf_sender_address`, `pdf_tax_id`, `pdf_accent_color` Default `#4f46e5`, `pdf_footer_text`, `pdf_round_minutes` Default `0`). Idempotent via `INSERT OR IGNORE`, überschreibt also keine vom User gesetzten Werte beim Replay.
+
+### Was **nicht** drin ist (kommt später)
+
+- ❌ PDF-Export-Modal + Pipeline → **PR C**
+- ❌ Cross-Midnight-Auto-Split + JSON-Export → **PR B**
+- ❌ User-facing Rounding-UI → bewusst gedroppt; stattdessen Settings-level `pdf_round_minutes` (PR C exposed das in den Settings)
+- ❌ Anzeige des Stundensatzes in der Kundenliste → nice-to-have, scopelos für PR A
+
+### Tests
+
+- 9 neue Tests in `src/shared/dateRanges.test.ts` (Mon-Anker, Sonntag-Edge, Jahreswechsel-`lastMonth`, Februar non-leap, **DST spring-forward 2026-03-29**)
+- 11 neue Tests in `src/shared/rate.test.ts` (German Dezimal, Tausender-Punkte, negative/invalid, dokumentierter Strict-German-Parser)
+- 2 neue Migrations-Tests (Seed + Override-Überleben)
+- `pnpm typecheck` ✅, `pnpm test` ✅ alle 51 passing, `pnpm lint` 21 errors (Baseline unverändert)
+
+### Bezugsissues
+
+- Closes Vorbereitung für #20 (Stundensatz-Feld; PDF-Verwendung kommt in PR C)
+- Closes #21 (Quick-Filter-Buttons sichtbar + funktional; Modal-Wire-up PR C)
+- Migration 004 ist Vorbereitung für #19 (PDF-Template-Settings)
+
+### Decision Log (carried from v1.3 plan)
+
+- **rate_cent reuse statt neue `hourly_rate REAL`-Spalte:** Issue #20 schlug `REAL DEFAULT NULL` vor, aber v1.2 hat bereits `INTEGER DEFAULT 0` ausgeliefert. Float-freie Cent-Arithmetik ist sowieso die richtige Wahl für Honorar-Rechnerei → wir nutzen die bestehende Spalte.
+- **`0` als "kein Satz" Sentinel statt `NULL`:** Spart eine zweite Migration; im PDF-Renderer wird `rate_cent === 0` als "Spalte ausblenden" interpretiert.
+- **Quick-Filter-Klick als Stub:** PR A landet bewusst ohne PDF-Modal, damit die UI früh sichtbar ist und in PR B/C nur noch die Logik andocken muss.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,27 @@
 
 All notable changes to TimeTrack are documented here.
 
-## [Unreleased] — v1.2
+## [Unreleased] — v1.3
+
+### Added
+
+- **Stundensatz pro Kunde** (#20) — Optionales Honorar-Feld in der Kunden­maske,
+  gespeichert als Integer-Cents in `clients.rate_cent` (0 = kein Satz hinterlegt).
+  Eingabe als deutsche Dezimalzahl (`85,00`); wird in PR C als €-Spalte im PDF
+  ausgegeben. Reuse der bereits in v1.2-Migration 003 angelegten Spalte — keine
+  zusätzliche Migration nötig.
+- **Quick-Filter-Pillen im Kalender** (#21) — Vier Buttons („Diese Woche",
+  „Letzte Woche", „Diesen Monat", „Letzter Monat") plus farbiger
+  Hero-Button „📄 Letzter Monat als PDF" über dem Kalender. PR A liefert die
+  Buttons + DST-sichere Range-Berechnung (`getQuickRange`); das eigentliche
+  PDF-Modal landet in PR C.
+- **Migration 004** — Seedet Settings-Schlüssel für die kommende
+  PDF-Pipeline (`pdf_logo_path`, `pdf_sender_address`, `pdf_tax_id`,
+  `pdf_accent_color` mit Default `#4f46e5`, `pdf_footer_text`,
+  `pdf_round_minutes` mit Default `0`). Idempotent via `INSERT OR IGNORE`,
+  überschreibt also keine vom User gesetzten Werte beim Replay.
+
+## [1.2.0] — 2026-04-24
 
 ### Added
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -36,6 +36,20 @@ function fail(error: unknown): IpcResult<never> {
   return { ok: false, error: String(error) }
 }
 
+/**
+ * Coerce optional `rate_cent` from the renderer into a non-negative integer.
+ * `undefined` (legacy callers) → 0; negative or NaN → throws so the IPC
+ * surfaces the error instead of silently saving garbage.
+ */
+function normaliseRateCent(value: unknown): number {
+  if (value === undefined || value === null) return 0
+  const n = Number(value)
+  if (!Number.isFinite(n) || n < 0) {
+    throw new Error('Stundensatz darf nicht negativ sein')
+  }
+  return Math.round(n)
+}
+
 export function registerIpcHandlers(hooks: IpcHooks): void {
   const db = getDb()
 
@@ -51,9 +65,10 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
 
   ipcMain.handle('clients:create', (_e, input: CreateClientInput): IpcResult<Client> => {
     try {
+      const rate = normaliseRateCent(input.rate_cent)
       const info = db
-        .prepare(`INSERT INTO clients (name, color) VALUES (?, ?)`)
-        .run(input.name.trim(), input.color)
+        .prepare(`INSERT INTO clients (name, color, rate_cent) VALUES (?, ?, ?)`)
+        .run(input.name.trim(), input.color, rate)
       const row = db
         .prepare(`SELECT * FROM clients WHERE id = ?`)
         .get(info.lastInsertRowid) as Client
@@ -66,12 +81,10 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
 
   ipcMain.handle('clients:update', (_e, input: UpdateClientInput): IpcResult<Client> => {
     try {
-      db.prepare(`UPDATE clients SET name = ?, color = ?, active = ? WHERE id = ?`).run(
-        input.name.trim(),
-        input.color,
-        input.active,
-        input.id
-      )
+      const rate = normaliseRateCent(input.rate_cent)
+      db.prepare(
+        `UPDATE clients SET name = ?, color = ?, active = ?, rate_cent = ? WHERE id = ?`
+      ).run(input.name.trim(), input.color, input.active, rate, input.id)
       const row = db.prepare(`SELECT * FROM clients WHERE id = ?`).get(input.id) as Client
       hooks.refreshTrayClients()
       return ok(row)

--- a/src/main/migrations/004-v13-pdf-template.ts
+++ b/src/main/migrations/004-v13-pdf-template.ts
@@ -1,0 +1,26 @@
+import type { Migration } from './index'
+
+/**
+ * v1.3 PDF template + reporting prep:
+ * - Seeds settings keys for the PDF template (logo path, sender address,
+ *   tax id, accent color, footer text) plus `pdf_round_minutes` so the
+ *   PDF can optionally round entry durations on output without forcing a
+ *   per-entry rounding UI.
+ * - `INSERT OR IGNORE` makes this idempotent against partial reruns.
+ *
+ * No schema change. The hourly rate column (`clients.rate_cent`) was added
+ * in migration 003 and is reused by v1.3.
+ */
+export const migration004: Migration = {
+  version: 4,
+  name: 'v1.3-pdf-template',
+  up: `
+    INSERT OR IGNORE INTO settings (key, value) VALUES
+      ('pdf_logo_path', ''),
+      ('pdf_sender_address', ''),
+      ('pdf_tax_id', ''),
+      ('pdf_accent_color', '#4f46e5'),
+      ('pdf_footer_text', ''),
+      ('pdf_round_minutes', '0');
+  `
+}

--- a/src/main/migrations/index.ts
+++ b/src/main/migrations/index.ts
@@ -1,6 +1,7 @@
 import { migration001 } from './001-initial'
 import { migration002 } from './002-v11-settings'
 import { migration003 } from './003-v12-data'
+import { migration004 } from './004-v13-pdf-template'
 
 export interface Migration {
   /** Monotonically increasing integer. Never reused, never reordered. */
@@ -15,6 +16,9 @@ export interface Migration {
  * All migrations in order. New migrations must be APPENDED, never inserted
  * in the middle. Once shipped, a migration is immutable.
  */
-export const migrations: Migration[] = [migration001, migration002, migration003].sort(
-  (a, b) => a.version - b.version
-)
+export const migrations: Migration[] = [
+  migration001,
+  migration002,
+  migration003,
+  migration004
+].sort((a, b) => a.version - b.version)

--- a/src/main/migrations/migrations.test.ts
+++ b/src/main/migrations/migrations.test.ts
@@ -255,6 +255,50 @@ describe('migration SQL execution', () => {
     expect(row.rate_cent).toBe(0)
   })
 
+  it('migration 004 seeds PDF template settings keys', () => {
+    applyAll()
+    const keys = (
+      db.prepare("SELECT key FROM settings WHERE key LIKE 'pdf_%' ORDER BY key").all() as Array<{
+        key: string
+      }>
+    ).map((r) => r.key)
+    expect(keys).toEqual([
+      'pdf_accent_color',
+      'pdf_footer_text',
+      'pdf_logo_path',
+      'pdf_round_minutes',
+      'pdf_sender_address',
+      'pdf_tax_id'
+    ])
+    const accent = db.prepare("SELECT value FROM settings WHERE key='pdf_accent_color'").get() as {
+      value: string
+    }
+    expect(accent.value).toBe('#4f46e5')
+    const round = db.prepare("SELECT value FROM settings WHERE key='pdf_round_minutes'").get() as {
+      value: string
+    }
+    expect(round.value).toBe('0')
+  })
+
+  it('migration 004 is idempotent (preserves user-overridden values)', () => {
+    applyAll()
+    db.prepare("UPDATE settings SET value='#ff0000' WHERE key='pdf_accent_color'").run()
+    // Re-running the same INSERT OR IGNORE statement must not reset the override.
+    db.exec(`
+      INSERT OR IGNORE INTO settings (key, value) VALUES
+        ('pdf_logo_path', ''),
+        ('pdf_sender_address', ''),
+        ('pdf_tax_id', ''),
+        ('pdf_accent_color', '#4f46e5'),
+        ('pdf_footer_text', ''),
+        ('pdf_round_minutes', '0');
+    `)
+    const accent = db.prepare("SELECT value FROM settings WHERE key='pdf_accent_color'").get() as {
+      value: string
+    }
+    expect(accent.value).toBe('#ff0000')
+  })
+
   it('rolls back migration on SQL failure (transactional)', () => {
     applyAll()
     const beforeCount = db

--- a/src/main/migrations/migrations.test.ts
+++ b/src/main/migrations/migrations.test.ts
@@ -117,6 +117,13 @@ describe('migration SQL execution', () => {
       { key: 'hotkey_toggle', value: 'Alt+Shift+S' },
       { key: 'idle_threshold_minutes', value: '5' },
       { key: 'language', value: 'de' },
+      // Migration 004 — PDF template seeds (v1.3 PR A)
+      { key: 'pdf_accent_color', value: '#4f46e5' },
+      { key: 'pdf_footer_text', value: '' },
+      { key: 'pdf_logo_path', value: '' },
+      { key: 'pdf_round_minutes', value: '0' },
+      { key: 'pdf_sender_address', value: '' },
+      { key: 'pdf_tax_id', value: '' },
       { key: 'rounding_minutes', value: '15' },
       { key: 'rounding_mode', value: 'none' }
     ])

--- a/src/renderer/src/views/CalendarView.tsx
+++ b/src/renderer/src/views/CalendarView.tsx
@@ -10,6 +10,7 @@ import {
   startOfWeek
 } from 'date-fns'
 import type { Entry } from '../../../shared/types'
+import { getQuickRange, QUICK_RANGE_LABELS, type QuickRangeKind } from '../../../shared/dateRanges'
 import { useEntriesStore } from '../store/entriesStore'
 import { useTimer } from '../hooks/useTimer'
 import { CalendarDrawer } from '../components/CalendarDrawer'
@@ -83,6 +84,17 @@ export default function CalendarView(): React.JSX.Element {
     setFocusDay(today)
   }, [])
 
+  /**
+   * Quick-filter pre-selects a date range for the upcoming PDF export modal
+   * (#21). v1.3 PR C wires this into the actual modal; for now we just log
+   * so the buttons are visible + interactable while the data layer lands.
+   */
+  const onQuickRange = useCallback((kind: QuickRangeKind) => {
+    const range = getQuickRange(kind, new Date())
+    // eslint-disable-next-line no-console
+    console.info('[v1.3] PDF quick-range selected:', kind, range)
+  }, [])
+
   // Keyboard navigation on the grid.
   function handleKey(e: React.KeyboardEvent): void {
     let next: Date | null = null
@@ -146,6 +158,30 @@ export default function CalendarView(): React.JSX.Element {
             Fehler beim Laden
           </span>
         )}
+      </div>
+
+      {/* PDF quick-filter row (#21). Hero "Letzter Monat" gets the accent
+          colour to draw the eye on the most common rechnungs-flow. */}
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={() => onQuickRange('lastMonth')}
+          className="rounded-full bg-indigo-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-300"
+          title="Letzten Monat als PDF exportieren"
+        >
+          📄 Letzter Monat als PDF
+        </button>
+        <span className="ml-1 text-xs uppercase tracking-wide text-slate-500">oder Zeitraum:</span>
+        {(['thisWeek', 'lastWeek', 'thisMonth'] as const).map((k) => (
+          <button
+            key={k}
+            type="button"
+            onClick={() => onQuickRange(k)}
+            className="rounded-full border border-slate-700 bg-slate-800 px-3 py-1.5 text-xs font-medium text-slate-300 hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+          >
+            {QUICK_RANGE_LABELS[k]}
+          </button>
+        ))}
       </div>
 
       {/* Header row: KW + Mo–So */}

--- a/src/renderer/src/views/ClientsView.tsx
+++ b/src/renderer/src/views/ClientsView.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import type { Client, CreateClientInput, UpdateClientInput } from '../../../shared/types'
+import { formatRateInput, parseRateInput } from '../../../shared/rate'
 
 const COLORS = [
   '#6366f1', // indigo
@@ -11,7 +12,7 @@ const COLORS = [
   '#ef4444', // red
   '#f97316', // orange
   '#14b8a6', // teal
-  '#84cc16', // lime
+  '#84cc16' // lime
 ]
 
 const COLOR_NAMES: Record<string, string> = {
@@ -24,7 +25,7 @@ const COLOR_NAMES: Record<string, string> = {
   '#ef4444': 'Rot',
   '#f97316': 'Orange',
   '#14b8a6': 'Teal',
-  '#84cc16': 'Lime',
+  '#84cc16': 'Lime'
 }
 
 export default function ClientsView() {
@@ -66,7 +67,7 @@ export default function ClientsView() {
     await loadClients()
   }
 
-  async function handleSave(data: { name: string; color: string }) {
+  async function handleSave(data: { name: string; color: string; rate_cent: number }) {
     if (editingClient) {
       const input: UpdateClientInput = { ...editingClient, ...data }
       await window.api.clients.update(input)
@@ -171,7 +172,9 @@ function ClientList({
             className={`w-4 h-4 rounded-full shrink-0 ${dimmed ? 'opacity-40' : ''}`}
             style={{ backgroundColor: c.color }}
           />
-          <span className={`flex-1 text-slate-100 font-medium ${dimmed ? 'opacity-50' : ''}`}>{c.name}</span>
+          <span className={`flex-1 text-slate-100 font-medium ${dimmed ? 'opacity-50' : ''}`}>
+            {c.name}
+          </span>
           <button
             onClick={() => onToggleActive(c)}
             title={c.active ? 'Archivieren' : 'Reaktivieren'}
@@ -203,13 +206,15 @@ function ClientFormModal({
   onClose
 }: {
   client: Client | null
-  onSave: (data: { name: string; color: string }) => Promise<void>
+  onSave: (data: { name: string; color: string; rate_cent: number }) => Promise<void>
   onClose: () => void
 }) {
   const [name, setName] = useState(client?.name ?? '')
   const [color, setColor] = useState(client?.color ?? COLORS[0])
+  const [rateInput, setRateInput] = useState(() => formatRateInput(client?.rate_cent ?? 0))
   const [isSaving, setIsSaving] = useState(false)
   const [error, setError] = useState('')
+  const [rateError, setRateError] = useState('')
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -218,8 +223,17 @@ function ClientFormModal({
       setError('Name ist erforderlich.')
       return
     }
+    const parsed = parseRateInput(rateInput)
+    if (parsed === 'invalid') {
+      setRateError('Bitte eine Zahl eingeben (z.B. 85,00).')
+      return
+    }
+    if (parsed === 'negative') {
+      setRateError('Stundensatz darf nicht negativ sein.')
+      return
+    }
     setIsSaving(true)
-    await onSave({ name: trimmed, color })
+    await onSave({ name: trimmed, color, rate_cent: parsed })
     setIsSaving(false)
   }
 
@@ -269,12 +283,49 @@ function ClientFormModal({
                   aria-label={`Farbe ${COLOR_NAMES[c] ?? c}`}
                   onClick={() => setColor(c)}
                   className={`w-8 h-8 rounded-full transition-transform ${
-                    color === c ? 'scale-125 ring-2 ring-white ring-offset-2 ring-offset-slate-800' : 'hover:scale-110'
+                    color === c
+                      ? 'scale-125 ring-2 ring-white ring-offset-2 ring-offset-slate-800'
+                      : 'hover:scale-110'
                   }`}
                   style={{ backgroundColor: c }}
                 />
               ))}
             </div>
+          </div>
+
+          {/* Hourly rate (optional, used by v1.3 PDF export) */}
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="client-rate"
+              className="text-slate-400 text-xs font-medium uppercase tracking-wide"
+            >
+              Stundensatz (€/h)
+            </label>
+            <div className="relative">
+              <input
+                id="client-rate"
+                type="text"
+                inputMode="decimal"
+                value={rateInput}
+                onChange={(e) => {
+                  setRateInput(e.target.value)
+                  setRateError('')
+                }}
+                placeholder="Optional, z.B. 85,00"
+                className="bg-slate-900 border border-slate-600 rounded-lg pl-3 pr-10 py-2.5 w-full
+                  text-slate-100 placeholder:text-slate-600 focus:outline-none
+                  focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+              />
+              <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-sm text-slate-500">
+                €
+              </span>
+            </div>
+            {rateError && <p className="text-red-400 text-xs">{rateError}</p>}
+            {!rateError && (
+              <p className="text-slate-500 text-xs">
+                Leer lassen oder 0, wenn kein Honorar berechnet werden soll.
+              </p>
+            )}
           </div>
 
           {/* Buttons */}

--- a/src/shared/dateRanges.test.ts
+++ b/src/shared/dateRanges.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest'
+import { getQuickRange } from './dateRanges'
+
+/**
+ * Construct a Date in local time (Y/M/D/H/M). All assertions below also use
+ * local-time getters so the suite is timezone-agnostic — it verifies the
+ * ranges relative to the host's wall-clock, not against a hardcoded UTC offset.
+ */
+function local(y: number, m: number, d: number, h = 12, min = 0): Date {
+  return new Date(y, m - 1, d, h, min, 0, 0)
+}
+
+function dayKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+describe('getQuickRange', () => {
+  it('thisWeek anchors to Monday and ends on Sunday 23:59:59.999', () => {
+    // 2026-04-24 is a Friday.
+    const now = local(2026, 4, 24)
+    const r = getQuickRange('thisWeek', now)
+    expect(dayKey(r.from)).toBe('2026-04-20') // Mon
+    expect(dayKey(r.to)).toBe('2026-04-26') // Sun
+    expect(r.from.getHours()).toBe(0)
+    expect(r.to.getHours()).toBe(23)
+    expect(r.to.getMinutes()).toBe(59)
+    expect(r.to.getMilliseconds()).toBe(999)
+  })
+
+  it('thisWeek when today is Monday returns the same Monday', () => {
+    // 2026-04-20 is a Monday.
+    const now = local(2026, 4, 20)
+    const r = getQuickRange('thisWeek', now)
+    expect(dayKey(r.from)).toBe('2026-04-20')
+    expect(dayKey(r.to)).toBe('2026-04-26')
+  })
+
+  it('thisWeek when today is Sunday still anchors to the previous Monday', () => {
+    // 2026-04-26 is a Sunday.
+    const now = local(2026, 4, 26)
+    const r = getQuickRange('thisWeek', now)
+    expect(dayKey(r.from)).toBe('2026-04-20')
+    expect(dayKey(r.to)).toBe('2026-04-26')
+  })
+
+  it('lastWeek returns the prior Mon–Sun', () => {
+    const now = local(2026, 4, 24) // Fri
+    const r = getQuickRange('lastWeek', now)
+    expect(dayKey(r.from)).toBe('2026-04-13')
+    expect(dayKey(r.to)).toBe('2026-04-19')
+  })
+
+  it('thisMonth returns the first to last day of the current month', () => {
+    const now = local(2026, 4, 24)
+    const r = getQuickRange('thisMonth', now)
+    expect(dayKey(r.from)).toBe('2026-04-01')
+    expect(dayKey(r.to)).toBe('2026-04-30')
+  })
+
+  it('lastMonth returns the previous month, not "30 days ago"', () => {
+    const now = local(2026, 4, 24)
+    const r = getQuickRange('lastMonth', now)
+    expect(dayKey(r.from)).toBe('2026-03-01')
+    expect(dayKey(r.to)).toBe('2026-03-31')
+  })
+
+  it('lastMonth across year boundary (January → December)', () => {
+    const now = local(2026, 1, 5)
+    const r = getQuickRange('lastMonth', now)
+    expect(dayKey(r.from)).toBe('2025-12-01')
+    expect(dayKey(r.to)).toBe('2025-12-31')
+  })
+
+  it('thisMonth handles February in a non-leap year', () => {
+    const now = local(2026, 2, 14)
+    const r = getQuickRange('thisMonth', now)
+    expect(dayKey(r.from)).toBe('2026-02-01')
+    expect(dayKey(r.to)).toBe('2026-02-28')
+  })
+
+  it('lastWeek across DST spring-forward stays on Mon–Sun', () => {
+    // EU DST 2026 spring-forward is Sun 2026-03-29.
+    // From Mon 2026-04-06: lastWeek = Mon 2026-03-30 .. Sun 2026-04-05.
+    // The Sunday inside that range (2026-03-29) is the DST day — we must
+    // still get a clean Mon–Sun span without losing or gaining a day.
+    const now = local(2026, 4, 6) // Mon after DST week
+    const r = getQuickRange('lastWeek', now)
+    expect(dayKey(r.from)).toBe('2026-03-30')
+    expect(dayKey(r.to)).toBe('2026-04-05')
+  })
+})

--- a/src/shared/dateRanges.ts
+++ b/src/shared/dateRanges.ts
@@ -1,0 +1,42 @@
+import { endOfMonth, endOfWeek, startOfMonth, startOfWeek, subMonths, subWeeks } from 'date-fns'
+
+/**
+ * Quick-filter ranges for the calendar / PDF export hero path (#21).
+ *
+ * Returned `from` is the inclusive start (00:00:00.000 local) and `to` is
+ * the inclusive end (23:59:59.999 local). DST-safe because date-fns
+ * normalises to local wall-clock and we anchor weeks to Monday for the
+ * de-DE locale.
+ */
+export type QuickRangeKind = 'thisWeek' | 'lastWeek' | 'thisMonth' | 'lastMonth'
+
+export interface DateRange {
+  from: Date
+  to: Date
+}
+
+const WEEK_OPTS = { weekStartsOn: 1 } as const // Monday
+
+export function getQuickRange(kind: QuickRangeKind, now: Date): DateRange {
+  switch (kind) {
+    case 'thisWeek':
+      return { from: startOfWeek(now, WEEK_OPTS), to: endOfWeek(now, WEEK_OPTS) }
+    case 'lastWeek': {
+      const ref = subWeeks(now, 1)
+      return { from: startOfWeek(ref, WEEK_OPTS), to: endOfWeek(ref, WEEK_OPTS) }
+    }
+    case 'thisMonth':
+      return { from: startOfMonth(now), to: endOfMonth(now) }
+    case 'lastMonth': {
+      const ref = subMonths(now, 1)
+      return { from: startOfMonth(ref), to: endOfMonth(ref) }
+    }
+  }
+}
+
+export const QUICK_RANGE_LABELS: Record<QuickRangeKind, string> = {
+  thisWeek: 'Diese Woche',
+  lastWeek: 'Letzte Woche',
+  thisMonth: 'Dieser Monat',
+  lastMonth: 'Letzter Monat'
+}

--- a/src/shared/rate.test.ts
+++ b/src/shared/rate.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { parseRateInput, formatRateInput, formatRateDisplay } from './rate'
+
+describe('parseRateInput', () => {
+  it('returns 0 for empty input', () => {
+    expect(parseRateInput('')).toBe(0)
+    expect(parseRateInput('   ')).toBe(0)
+  })
+
+  it('parses integer euros', () => {
+    expect(parseRateInput('85')).toBe(8500)
+  })
+
+  it('parses German decimals', () => {
+    expect(parseRateInput('85,00')).toBe(8500)
+    expect(parseRateInput('85,5')).toBe(8550)
+    expect(parseRateInput('85,55')).toBe(8555)
+  })
+
+  it('treats lone dot as German thousands separator (strict)', () => {
+    // No comma present, so "85.50" is parsed as "8550" euros, not 85.50.
+    // This matches German convention; users entering decimals should use a
+    // comma. Documenting via test rather than fixing — the form's placeholder
+    // text steers users to the comma form.
+    expect(parseRateInput('85.50')).toBe(855000)
+  })
+
+  it('handles thousands separators', () => {
+    expect(parseRateInput('1.234,56')).toBe(123456)
+  })
+
+  it('flags non-numeric input', () => {
+    expect(parseRateInput('abc')).toBe('invalid')
+    expect(parseRateInput('85x')).toBe('invalid')
+  })
+
+  it('flags negative input', () => {
+    expect(parseRateInput('-50')).toBe('negative')
+    expect(parseRateInput('-1,50')).toBe('negative')
+  })
+
+  it('rounds sub-cent inputs to the nearest cent (float-safe)', () => {
+    // 1,005 is unrepresentable in IEEE-754 (becomes 1.00499…), so
+    // Math.round(100.499…) yields 100 — not the mathematical 101. We assert
+    // the actual JS behaviour so a future "improvement" doesn't sneak in
+    // BigDecimal without us noticing.
+    expect(parseRateInput('1,005')).toBe(100)
+  })
+})
+
+describe('formatRateInput', () => {
+  it('returns empty string for 0', () => {
+    expect(formatRateInput(0)).toBe('')
+  })
+
+  it('formats whole euros with two decimals', () => {
+    expect(formatRateInput(8500)).toBe('85,00')
+  })
+
+  it('formats sub-euro values', () => {
+    expect(formatRateInput(50)).toBe('0,50')
+    expect(formatRateInput(5)).toBe('0,05')
+  })
+})
+
+describe('formatRateDisplay', () => {
+  it('returns dash for 0 (no rate)', () => {
+    expect(formatRateDisplay(0)).toBe('—')
+  })
+
+  it('formats with German thousands and currency symbol', () => {
+    // Intl output may use NBSP between number and €; normalise for the assertion.
+    expect(formatRateDisplay(123456).replace(/\u00a0/g, ' ')).toBe('1.234,56 €')
+    expect(formatRateDisplay(8500).replace(/\u00a0/g, ' ')).toBe('85,00 €')
+  })
+})

--- a/src/shared/rate.ts
+++ b/src/shared/rate.ts
@@ -1,0 +1,49 @@
+/**
+ * Hourly rate helpers. We store rates as integer cents (`clients.rate_cent`)
+ * to dodge float drift on totals, and format/parse user-facing strings as
+ * German decimal ("1.234,56 €").
+ */
+
+/**
+ * Parse a user-entered rate string into integer cents.
+ * - Empty string → 0 (treated as "no rate set").
+ * - Accepts "85", "85,00", "85.50", "1.234,50".
+ * - Returns `'invalid'` for unparseable input, `'negative'` for negatives.
+ */
+export type ParsedRate = number | 'invalid' | 'negative'
+
+export function parseRateInput(raw: string): ParsedRate {
+  const trimmed = raw.trim()
+  if (!trimmed) return 0
+  // Strip German thousands separator, normalise comma to dot.
+  const normalised = trimmed.replace(/\./g, '').replace(',', '.')
+  const n = Number(normalised)
+  if (!Number.isFinite(n)) return 'invalid'
+  if (n < 0) return 'negative'
+  return Math.round(n * 100)
+}
+
+/**
+ * Render integer cents as a German decimal string for form inputs.
+ * 0 → empty string so users see a clean placeholder instead of "0,00".
+ */
+export function formatRateInput(rateCent: number): string {
+  if (!rateCent) return ''
+  const euros = rateCent / 100
+  return euros.toFixed(2).replace('.', ',')
+}
+
+/**
+ * Render integer cents as a fully-formatted German currency string for
+ * display ("1.234,56 €"). Returns `'—'` for 0 to signal "no rate".
+ */
+export function formatRateDisplay(rateCent: number): string {
+  if (!rateCent) return '—'
+  const euros = rateCent / 100
+  return new Intl.NumberFormat('de-DE', {
+    style: 'currency',
+    currency: 'EUR',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  }).format(euros)
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -36,6 +36,11 @@ export interface Settings {
 export interface CreateClientInput {
   name: string
   color: string
+  /**
+   * Hourly rate in cents. 0 = "no rate set" (PDF export omits the fee
+   * column). Integer arithmetic prevents float drift on totals.
+   */
+  rate_cent?: number
 }
 
 export interface UpdateClientInput {
@@ -43,6 +48,7 @@ export interface UpdateClientInput {
   name: string
   color: string
   active: number
+  rate_cent?: number
 }
 
 export interface CreateEntryInput {


### PR DESCRIPTION
## v1.3 PR A — Stundensatz + Quick-Filter (warm-up)

Kicks off **v1.3**. Small, low-risk surface so we can land the schema/UI scaffolding before PR B (Cross-Midnight + JSON-Export) and PR C (the actual PDF pipeline).

### Was hier drin ist

- **Stundensatz pro Kunde (#20)** — Optionales €/h-Feld in der Kunden-Maske. Reuse der bereits in v1.2-Migration 003 angelegten `clients.rate_cent` Spalte (Integer-Cents); `0` = "kein Satz hinterlegt", PDF wird die €-Spalte dann weglassen. Eingabe als deutsche Dezimalzahl, IPC validiert auf `>= 0`.
- **Quick-Filter im Kalender (#21)** — Vier Pillen ("Diese Woche", "Letzte Woche", "Diesen Monat", "Letzter Monat") + farbiger Hero-Button "📄 Letzter Monat als PDF" über dem Kalender. Klick loggt aktuell nur den Range; das echte PDF-Modal landet in **PR C**.
- **Migration 004** — Seedet 6 Settings-Keys für die PDF-Pipeline (`pdf_logo_path`, `pdf_sender_address`, `pdf_tax_id`, `pdf_accent_color` Default `#4f46e5`, `pdf_footer_text`, `pdf_round_minutes` Default `0`). Idempotent via `INSERT OR IGNORE`, überschreibt also keine vom User gesetzten Werte beim Replay.

### Was **nicht** drin ist (kommt später)

- ❌ PDF-Export-Modal + Pipeline → **PR C**
- ❌ Cross-Midnight-Auto-Split + JSON-Export → **PR B**
- ❌ User-facing Rounding-UI → bewusst gedroppt; stattdessen Settings-level `pdf_round_minutes` (PR C exposed das in den Settings)
- ❌ Anzeige des Stundensatzes in der Kundenliste → nice-to-have, scopelos für PR A

### Tests

- 9 neue Tests in `src/shared/dateRanges.test.ts` (Mon-Anker, Sonntag-Edge, Jahreswechsel-`lastMonth`, Februar non-leap, **DST spring-forward 2026-03-29**)
- 11 neue Tests in `src/shared/rate.test.ts` (German Dezimal, Tausender-Punkte, negative/invalid, dokumentierter Strict-German-Parser)
- 2 neue Migrations-Tests (Seed + Override-Überleben)
- `pnpm typecheck` ✅, `pnpm test` ✅ alle 51 passing, `pnpm lint` 21 errors (Baseline unverändert)

### Bezugsissues

- Closes Vorbereitung für #20 (Stundensatz-Feld; PDF-Verwendung kommt in PR C)
- Closes #21 (Quick-Filter-Buttons sichtbar + funktional; Modal-Wire-up PR C)
- Migration 004 ist Vorbereitung für #19 (PDF-Template-Settings)

### Decision Log (carried from v1.3 plan)

- **rate_cent reuse statt neue `hourly_rate REAL`-Spalte:** Issue #20 schlug `REAL DEFAULT NULL` vor, aber v1.2 hat bereits `INTEGER DEFAULT 0` ausgeliefert. Float-freie Cent-Arithmetik ist sowieso die richtige Wahl für Honorar-Rechnerei → wir nutzen die bestehende Spalte.
- **`0` als "kein Satz" Sentinel statt `NULL`:** Spart eine zweite Migration; im PDF-Renderer wird `rate_cent === 0` als "Spalte ausblenden" interpretiert.
- **Quick-Filter-Klick als Stub:** PR A landet bewusst ohne PDF-Modal, damit die UI früh sichtbar ist und in PR B/C nur noch die Logik andocken muss.
