### PR TITLE
feat(v1.3 PR B): Cross-Midnight Auto-Split + JSON-Vollexport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,21 @@ All notable changes to TimeTrack are documented here.
   `pdf_accent_color` mit Default `#4f46e5`, `pdf_footer_text`,
   `pdf_round_minutes` mit Default `0`). Idempotent via `INSERT OR IGNORE`,
   überschreibt also keine vom User gesetzten Werte beim Replay.
+- **Cross-Midnight Auto-Split** — Einträge, die lokale Mitternacht überqueren,
+  werden im IPC-Layer automatisch in zwei (oder mehr) verlinkte Hälften
+  aufgeteilt. Beide Hälften teilen sich eine UUID in der neuen Spalte
+  `entries.link_id` (Migration 005, partieller Index `idx_entries_link_id`).
+  Tagessummen, KW-Aggregate und PDF-Reports rechnen damit automatisch korrekt
+  pro Tag. Der „nicht über Mitternacht möglich"-Hinweis im Eintrag-Dialog
+  ist entfernt; DST-sicher (Frühling/Herbst getestet via `date-fns`).
+  Löschen kaskadiert optional auf die Geschwister-Hälfte (`cascadeLinked`-Flag
+  in `entries:delete`).
+- **JSON-Vollexport** (#17) — Neuer Button „Export speichern …" in
+  Einstellungen → Daten. Schreibt eine lesbare JSON-Datei mit `meta`
+  (Schema-Version, Zeitstempel, App-Version), allen Kunden, allen Einträgen
+  (inkl. soft-gelöschter und verlinkter Hälften) und allen Settings.
+  Trust-Artefakt: User können ihre Daten byte-genau verifizieren; CSV/PDF
+  bauen in PR C/D darauf auf.
 
 ## [1.2.0] — 2026-04-24
 

--- a/src/main/ipc.test.ts
+++ b/src/main/ipc.test.ts
@@ -12,7 +12,6 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import type Database from 'better-sqlite3'
 import { migrations } from './migrations'
-import { isSameLocalDay } from '../shared/date'
 
 const MAX_DESCRIPTION_LEN = 500
 const MAX_DURATION_SECONDS = 24 * 3600
@@ -50,9 +49,6 @@ function validateManualEntry(
   if (Number.isNaN(stop.getTime())) return 'Endzeit ist ungültig'
   if (start.getTime() > Date.now()) return 'Startzeit darf nicht in der Zukunft liegen'
   if (stop.getTime() <= start.getTime()) return 'Endzeit muss nach der Startzeit liegen'
-  if (!isSameLocalDay(start, stop)) {
-    return 'Einträge können aktuell nicht über Mitternacht gehen (folgt in v1.3)'
-  }
   const durationSec = (stop.getTime() - start.getTime()) / 1000
   if (durationSec > MAX_DURATION_SECONDS) return 'Dauer überschreitet 24 Stunden'
   if ((input.description ?? '').length > MAX_DESCRIPTION_LEN) {
@@ -155,7 +151,7 @@ describe('entries:create / entries:update validation contract', () => {
     expect(err).toMatch(/Endzeit/)
   })
 
-  it('rejects cross-midnight (different local day)', () => {
+  it('accepts cross-midnight entries (v1.3 PR B — IPC auto-splits before insert)', () => {
     const start = new Date(yesterday)
     start.setHours(23, 30, 0, 0)
     const stop = new Date(yesterday)
@@ -167,7 +163,7 @@ describe('entries:create / entries:update validation contract', () => {
       started_at: start.toISOString(),
       stopped_at: stop.toISOString()
     })
-    expect(err).toMatch(/Mitternacht/)
+    expect(err).toBeNull()
   })
 
   it('rejects unknown client', () => {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,9 +1,13 @@
 import { ipcMain, shell } from 'electron'
 import { app } from 'electron'
+import { dialog } from 'electron'
+import { writeFileSync } from 'fs'
+import { randomUUID } from 'crypto'
 import { getDb, getDbPath } from './db'
 import { getBackupsDir } from './backup'
 import { createBackup, listBackups, restoreBackup as restoreBackupFile } from './backup'
-import { isSameLocalDay } from '../shared/date'
+import { splitAtMidnight } from '../shared/midnightSplit'
+import { buildJsonExportPayload } from './jsonExport'
 import type {
   Client,
   Entry,
@@ -191,30 +195,19 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
    * Manual-entry creation (Today "+ Eintrag nachtragen", Calendar Drawer
    * "+ Eintrag hinzufügen"). Server-side validation per v1.2 plan E3 — UI
    * may also pre-validate but must not be the only line of defence.
+   *
+   * v1.3 PR B: Cross-midnight entries are auto-split at local midnight
+   * into linked halves sharing a `link_id` (UUID). The first half's row
+   * is returned for UI selection; the renderer's `getByMonth` query will
+   * surface the second half on its own day.
    */
   ipcMain.handle('entries:create', (_e, input: CreateManualEntryInput): IpcResult<Entry> => {
     try {
       const err = validateManualEntry(db, input)
       if (err) return fail(err)
-      const info = db
-        .prepare(
-          `INSERT INTO entries (client_id, description, started_at, stopped_at, heartbeat_at, rounded_min)
-           VALUES (?, ?, ?, ?, ?, ?)`
-        )
-        .run(
-          input.client_id,
-          input.description.trim(),
-          input.started_at,
-          input.stopped_at,
-          input.stopped_at,
-          Math.round(
-            (new Date(input.stopped_at).getTime() - new Date(input.started_at).getTime()) / 60000
-          )
-        )
-      const row = db
-        .prepare(`SELECT * FROM entries WHERE id = ?`)
-        .get(info.lastInsertRowid) as Entry
-      return ok(row)
+      const segments = splitAtMidnight(new Date(input.started_at), new Date(input.stopped_at))
+      const insertedRow = insertEntrySegments(db, input, segments)
+      return ok(insertedRow)
     } catch (e) {
       return fail(e)
     }
@@ -222,25 +215,28 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
 
   ipcMain.handle('entries:update', (_e, input: UpdateEntryInput): IpcResult<Entry> => {
     try {
-      // Reuse the same validation contract as create (excluding overlap with self).
-      const err = validateManualEntry(db, input, input.id)
+      // Reuse the same validation contract as create. We exclude both the
+      // current row (`input.id`) and any sibling sharing its link_id so the
+      // overlap check doesn't fire against the about-to-be-deleted halves.
+      const existing = db.prepare(`SELECT link_id FROM entries WHERE id = ?`).get(input.id) as
+        | { link_id: string | null }
+        | undefined
+      const existingLinkId = existing?.link_id ?? undefined
+      const err = validateManualEntry(db, input, input.id, existingLinkId ?? undefined)
       if (err) return fail(err)
-      db.prepare(
-        `UPDATE entries
-            SET client_id = ?, description = ?, started_at = ?, stopped_at = ?,
-                rounded_min = ?
-          WHERE id = ?`
-      ).run(
-        input.client_id,
-        input.description.trim(),
-        input.started_at,
-        input.stopped_at,
-        Math.round(
-          (new Date(input.stopped_at).getTime() - new Date(input.started_at).getTime()) / 60000
-        ),
-        input.id
-      )
-      const row = db.prepare(`SELECT * FROM entries WHERE id = ?`).get(input.id) as Entry
+      const segments = splitAtMidnight(new Date(input.started_at), new Date(input.stopped_at))
+      const tx = db.transaction((): Entry => {
+        // Drop the original row + any linked sibling, then re-insert. This
+        // keeps the cross-midnight bookkeeping in one place rather than
+        // distinguishing "edit one half" vs "edit a single-day row".
+        if (existingLinkId) {
+          db.prepare(`DELETE FROM entries WHERE link_id = ?`).run(existingLinkId)
+        } else {
+          db.prepare(`DELETE FROM entries WHERE id = ?`).run(input.id)
+        }
+        return insertEntrySegments(db, input, segments)
+      })
+      const row = tx()
       return ok(row)
     } catch (e) {
       return fail(e)
@@ -250,10 +246,24 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
   /**
    * Soft-delete: flip deleted_at instead of removing the row, so the Toast
    * "Rückgängig" path can restore the SAME id (preserves future PDF FKs — E10).
+   *
+   * v1.3 PR B: when `cascadeLinked` is true and the row has a `link_id`,
+   * all rows sharing that id are soft-deleted in one transaction (used by
+   * the Drawer's "auch zweite Hälfte löschen" confirm).
    */
-  ipcMain.handle('entries:delete', (_e, id: number): IpcResult<void> => {
+  ipcMain.handle('entries:delete', (_e, id: number, cascadeLinked = false): IpcResult<void> => {
     try {
-      db.prepare(`UPDATE entries SET deleted_at = ? WHERE id = ?`).run(new Date().toISOString(), id)
+      const now = new Date().toISOString()
+      if (cascadeLinked) {
+        const row = db.prepare(`SELECT link_id FROM entries WHERE id = ?`).get(id) as
+          | { link_id: string | null }
+          | undefined
+        if (row?.link_id) {
+          db.prepare(`UPDATE entries SET deleted_at = ? WHERE link_id = ?`).run(now, row.link_id)
+          return ok(undefined)
+        }
+      }
+      db.prepare(`UPDATE entries SET deleted_at = ? WHERE id = ?`).run(now, id)
       return ok(undefined)
     } catch (e) {
       return fail(e)
@@ -490,6 +500,37 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
   ipcMain.handle('app:getVersion', (): IpcResult<string> => {
     return ok(app.getVersion())
   })
+
+  /**
+   * Full JSON export (#17, v1.3 PR B). Bundles every client + entry
+   * (including soft-deleted + linked halves) + every settings row, plus a
+   * meta header (`schemaVersion`, `exportedAt`, `appVersion`). Output is
+   * intentionally human-readable (2-space indent) so the file is also a
+   * trust-building artefact: open it in any text editor, see your data,
+   * confidence in the app goes up.
+   *
+   * Pure data dump — no transforms, no PII filtering, no field renaming.
+   * Future v1.3.x or v1.4 CSV/PDF exports build on top of this snapshot.
+   */
+  ipcMain.handle('export:json', async (): Promise<IpcResult<{ path: string; bytes: number }>> => {
+    try {
+      const today = new Date().toISOString().slice(0, 10)
+      const result = await dialog.showSaveDialog({
+        title: 'Datenexport speichern',
+        defaultPath: `timetrack-export-${today}.json`,
+        filters: [{ name: 'JSON', extensions: ['json'] }]
+      })
+      if (result.canceled || !result.filePath) {
+        return fail('Export abgebrochen')
+      }
+      const payload = buildJsonExportPayload(db, app.getVersion())
+      const json = JSON.stringify(payload, null, 2)
+      writeFileSync(result.filePath, json, 'utf8')
+      return ok({ path: result.filePath, bytes: Buffer.byteLength(json, 'utf8') })
+    } catch (e) {
+      return fail(e)
+    }
+  })
 }
 
 /**
@@ -501,12 +542,17 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
  * Rules:
  *  - started_at <= now (no future entries)
  *  - stopped_at > started_at
- *  - same local day (cross-midnight rejected in v1.2; v1.3 will lift this)
  *  - client_id exists
  *  - description.length <= 500
  *  - duration <= 24h
  *  - no overlap with existing non-deleted entry of the same client
- *    (excluding the entry itself when updating)
+ *    (excluding the entry itself when updating; for cross-midnight splits
+ *    the caller passes `excludeLinkId` so the second half doesn't claim
+ *    its sibling overlaps)
+ *
+ * Cross-midnight is allowed since v1.3 PR B — entries that cross local
+ * midnight are auto-split into linked halves by the create/update IPC
+ * before insertion (see `splitAtMidnight`).
  */
 function validateManualEntry(
   db: ReturnType<typeof getDb>,
@@ -516,7 +562,8 @@ function validateManualEntry(
     started_at: string
     stopped_at: string
   },
-  excludeId?: number
+  excludeId?: number,
+  excludeLinkId?: string
 ): string | null {
   const start = new Date(input.started_at)
   const stop = new Date(input.stopped_at)
@@ -525,9 +572,6 @@ function validateManualEntry(
   const now = Date.now()
   if (start.getTime() > now) return 'Startzeit darf nicht in der Zukunft liegen'
   if (stop.getTime() <= start.getTime()) return 'Endzeit muss nach der Startzeit liegen'
-  if (!isSameLocalDay(start, stop)) {
-    return 'Einträge können aktuell nicht über Mitternacht gehen (folgt in v1.3)'
-  }
   const durationSec = (stop.getTime() - start.getTime()) / 1000
   if (durationSec > MAX_DURATION_SECONDS) return 'Dauer überschreitet 24 Stunden'
   if ((input.description ?? '').length > MAX_DESCRIPTION_LEN) {
@@ -549,7 +593,55 @@ function validateManualEntry(
     overlapSql += ` AND id != ?`
     params.push(excludeId)
   }
+  if (excludeLinkId !== undefined) {
+    overlapSql += ` AND (link_id IS NULL OR link_id != ?)`
+    params.push(excludeLinkId)
+  }
   const overlap = db.prepare(overlapSql).get(...params) as { id: number } | undefined
   if (overlap) return 'Eintrag überlappt mit einem bestehenden Eintrag desselben Kunden'
   return null
+}
+
+/**
+ * Insert one or more time segments produced by `splitAtMidnight`. Single
+ * segment → plain insert (link_id stays NULL). Multiple segments → all
+ * rows share a fresh UUID `link_id` so the UI / delete flow can find
+ * siblings later. Returns the FIRST inserted row (the one whose start
+ * matches the user's input.started_at), so the renderer can reveal the
+ * correct day in the calendar.
+ *
+ * Caller must have already run `validateManualEntry` against the full
+ * (un-split) range. Runs inside a single transaction so a failed insert
+ * leaves no half-state behind.
+ */
+function insertEntrySegments(
+  db: ReturnType<typeof getDb>,
+  input: { client_id: number; description: string },
+  segments: Array<{ start: Date; stop: Date }>
+): Entry {
+  const linkId = segments.length > 1 ? randomUUID() : null
+  const description = input.description.trim()
+  const insertStmt = db.prepare(
+    `INSERT INTO entries (client_id, description, started_at, stopped_at, heartbeat_at, rounded_min, link_id)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`
+  )
+  const tx = db.transaction((): Entry => {
+    let firstId = 0
+    for (const seg of segments) {
+      const startedAt = seg.start.toISOString()
+      const stoppedAt = seg.stop.toISOString()
+      const info = insertStmt.run(
+        input.client_id,
+        description,
+        startedAt,
+        stoppedAt,
+        stoppedAt,
+        Math.round((seg.stop.getTime() - seg.start.getTime()) / 60000),
+        linkId
+      )
+      if (firstId === 0) firstId = Number(info.lastInsertRowid)
+    }
+    return db.prepare(`SELECT * FROM entries WHERE id = ?`).get(firstId) as Entry
+  })
+  return tx()
 }

--- a/src/main/jsonExport.test.ts
+++ b/src/main/jsonExport.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Unit tests for `buildJsonExportPayload`. Pure function over a live SQLite
+ * handle — no Electron save-dialog involved. Skipped automatically when
+ * the better-sqlite3 native binding can't load (matches the migrations
+ * suite pattern).
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import type Database from 'better-sqlite3'
+import { migrations } from './migrations'
+import { buildJsonExportPayload } from './jsonExport'
+
+type DatabaseCtor = new (path: string) => Database.Database
+let DatabaseImpl: DatabaseCtor | null = null
+
+beforeAll(async () => {
+  try {
+    const mod = await import('better-sqlite3')
+    const Ctor = mod.default as unknown as DatabaseCtor
+    const probe = new Ctor(':memory:')
+    probe.close()
+    DatabaseImpl = Ctor
+  } catch {
+    DatabaseImpl = null
+  }
+})
+
+describe('buildJsonExportPayload', () => {
+  let tmpDir: string
+  let db: Database.Database
+
+  beforeEach((ctx) => {
+    if (!DatabaseImpl) {
+      ctx.skip()
+      return
+    }
+    tmpDir = mkdtempSync(join(tmpdir(), 'tt-export-'))
+    db = new DatabaseImpl(join(tmpDir, 'test.sqlite'))
+    db.pragma('foreign_keys = ON')
+    db.exec(
+      `CREATE TABLE schema_version (
+         version INTEGER PRIMARY KEY,
+         name TEXT NOT NULL,
+         applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+       )`
+    )
+    for (const m of migrations) {
+      const tx = db.transaction(() => {
+        db.exec(m.up)
+        db.prepare('INSERT INTO schema_version (version, name) VALUES (?, ?)').run(
+          m.version,
+          m.name
+        )
+      })
+      tx()
+    }
+  })
+
+  afterEach(() => {
+    if (!db) return
+    db.close()
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('emits meta with current schema version + appVersion + ISO exportedAt', () => {
+    const payload = buildJsonExportPayload(db, '1.3.0')
+    expect(payload.meta.schemaVersion).toBe(5)
+    expect(payload.meta.appVersion).toBe('1.3.0')
+    expect(payload.meta.exportedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+  })
+
+  it('includes seeded settings (alphabetically sorted)', () => {
+    const payload = buildJsonExportPayload(db, '1.3.0')
+    const keys = payload.settings.map((s) => s.key)
+    // Sorted by key (BehaviorContract: stable diff across exports).
+    const sorted = [...keys].sort()
+    expect(keys).toEqual(sorted)
+    // Spot-check a v1.2 + v1.3 key.
+    expect(keys).toContain('rounding_minutes')
+    expect(keys).toContain('pdf_accent_color')
+  })
+
+  it('includes clients + entries with their full column set', () => {
+    db.prepare(
+      `INSERT INTO clients (id, name, color, rate_cent) VALUES (1, 'Acme', '#6366f1', 8500)`
+    ).run()
+    db.prepare(
+      `INSERT INTO entries (client_id, description, started_at, stopped_at, link_id)
+       VALUES (1, 'work', '2026-04-24T08:00:00.000Z', '2026-04-24T09:30:00.000Z', NULL)`
+    ).run()
+    const payload = buildJsonExportPayload(db, '1.3.0')
+    expect(payload.clients).toHaveLength(1)
+    expect(payload.clients[0].rate_cent).toBe(8500)
+    expect(payload.entries).toHaveLength(1)
+    expect(payload.entries[0].description).toBe('work')
+    // Verify the v1.3 link_id field is present (even when null).
+    expect(payload.entries[0]).toHaveProperty('link_id')
+  })
+
+  it('preserves cross-midnight linked halves verbatim', () => {
+    db.prepare(`INSERT INTO clients (id, name) VALUES (1, 'Acme')`).run()
+    const linkId = '11111111-2222-3333-4444-555555555555'
+    db.prepare(
+      `INSERT INTO entries (client_id, description, started_at, stopped_at, link_id)
+       VALUES (1, 'late', '2026-04-24T23:30:00.000Z', '2026-04-25T00:00:00.000Z', ?)`
+    ).run(linkId)
+    db.prepare(
+      `INSERT INTO entries (client_id, description, started_at, stopped_at, link_id)
+       VALUES (1, 'late', '2026-04-25T00:00:00.000Z', '2026-04-25T01:15:00.000Z', ?)`
+    ).run(linkId)
+    const payload = buildJsonExportPayload(db, '1.3.0')
+    expect(payload.entries).toHaveLength(2)
+    expect(payload.entries.every((e) => e.link_id === linkId)).toBe(true)
+  })
+
+  it('includes soft-deleted entries (audit trail / undo recovery)', () => {
+    db.prepare(`INSERT INTO clients (id, name) VALUES (1, 'Acme')`).run()
+    db.prepare(
+      `INSERT INTO entries (client_id, description, started_at, stopped_at, deleted_at)
+       VALUES (1, 'oops', '2026-04-24T08:00:00.000Z', '2026-04-24T09:00:00.000Z', '2026-04-24T10:00:00.000Z')`
+    ).run()
+    const payload = buildJsonExportPayload(db, '1.3.0')
+    expect(payload.entries).toHaveLength(1)
+    expect(payload.entries[0].deleted_at).toBe('2026-04-24T10:00:00.000Z')
+  })
+
+  it('serialises to stable, indented JSON (2-space)', () => {
+    db.prepare(`INSERT INTO clients (id, name) VALUES (1, 'Acme')`).run()
+    const payload = buildJsonExportPayload(db, '1.3.0')
+    const json = JSON.stringify(payload, null, 2)
+    // Indent guarantees readability ("open in any editor and verify your data").
+    expect(json).toContain('\n  "clients": [')
+    expect(json).toContain('\n  "entries":')
+  })
+})

--- a/src/main/jsonExport.ts
+++ b/src/main/jsonExport.ts
@@ -1,0 +1,44 @@
+import type { Client, Entry } from '../shared/types'
+import type Database from 'better-sqlite3'
+
+export interface JsonExportPayload {
+  meta: { schemaVersion: number; exportedAt: string; appVersion: string }
+  clients: Client[]
+  entries: Entry[]
+  settings: Array<{ key: string; value: string }>
+}
+
+/**
+ * Build the JSON export payload from a live DB handle. Pure function —
+ * extracted from ipc.ts so unit tests can call it without booting Electron.
+ *
+ * Output is a verbatim dump (no field renames, no PII filtering, soft-deleted
+ * rows included) so users can verify their data byte-for-byte and future
+ * CSV/PDF tooling can build on top of the snapshot.
+ */
+export function buildJsonExportPayload(
+  db: Database.Database,
+  appVersion: string
+): JsonExportPayload {
+  const schemaVersion =
+    (db.prepare(`SELECT MAX(version) AS v FROM schema_version`).get() as { v: number | null }).v ??
+    0
+  const clients = db.prepare(`SELECT * FROM clients ORDER BY id ASC`).all() as Client[]
+  const entries = db
+    .prepare(`SELECT * FROM entries ORDER BY started_at ASC, id ASC`)
+    .all() as Entry[]
+  const settings = db.prepare(`SELECT key, value FROM settings ORDER BY key ASC`).all() as Array<{
+    key: string
+    value: string
+  }>
+  return {
+    meta: {
+      schemaVersion,
+      exportedAt: new Date().toISOString(),
+      appVersion
+    },
+    clients,
+    entries,
+    settings
+  }
+}

--- a/src/main/migrations/005-v13-link-id.ts
+++ b/src/main/migrations/005-v13-link-id.ts
@@ -1,0 +1,20 @@
+import type { Migration } from './index'
+
+/**
+ * v1.3 — `entries.link_id` ties together the two halves produced by the
+ * cross-midnight auto-split (see `splitAtMidnight` + ipc handlers). NULL
+ * for normal single-day entries; both halves of a split share the same
+ * UUID so the UI can offer "auch zweite Hälfte löschen?" on delete.
+ *
+ * Partial index: only rows that *are* part of a split need lookup; we'd
+ * rather not pay the index cost on every plain entry insert.
+ */
+export const migration005: Migration = {
+  version: 5,
+  name: 'v1.3-link-id',
+  up: `
+    ALTER TABLE entries ADD COLUMN link_id TEXT;
+    CREATE INDEX IF NOT EXISTS idx_entries_link_id
+      ON entries(link_id) WHERE link_id IS NOT NULL;
+  `
+}

--- a/src/main/migrations/index.ts
+++ b/src/main/migrations/index.ts
@@ -2,6 +2,7 @@ import { migration001 } from './001-initial'
 import { migration002 } from './002-v11-settings'
 import { migration003 } from './003-v12-data'
 import { migration004 } from './004-v13-pdf-template'
+import { migration005 } from './005-v13-link-id'
 
 export interface Migration {
   /** Monotonically increasing integer. Never reused, never reordered. */
@@ -20,5 +21,6 @@ export const migrations: Migration[] = [
   migration001,
   migration002,
   migration003,
-  migration004
+  migration004,
+  migration005
 ].sort((a, b) => a.version - b.version)

--- a/src/main/migrations/migrations.test.ts
+++ b/src/main/migrations/migrations.test.ts
@@ -306,6 +306,50 @@ describe('migration SQL execution', () => {
     expect(accent.value).toBe('#ff0000')
   })
 
+  it('migration 005 adds entries.link_id column (nullable)', () => {
+    applyAll()
+    const cols = db.prepare(`PRAGMA table_info(entries)`).all() as Array<{
+      name: string
+      notnull: number
+      dflt_value: string | null
+    }>
+    const linkCol = cols.find((c) => c.name === 'link_id')
+    expect(linkCol).toBeDefined()
+    // NULL is the "no split" sentinel — column must allow NULL.
+    expect(linkCol?.notnull).toBe(0)
+    expect(linkCol?.dflt_value).toBeNull()
+  })
+
+  it('migration 005 creates the partial idx_entries_link_id index', () => {
+    applyAll()
+    const idx = db
+      .prepare(
+        "SELECT name, sql FROM sqlite_master WHERE type='index' AND name='idx_entries_link_id'"
+      )
+      .get() as { name: string; sql: string } | undefined
+    expect(idx).toBeDefined()
+    // Partial index: WHERE clause means we don't index the (large) NULL set.
+    expect(idx?.sql).toMatch(/WHERE\s+link_id\s+IS\s+NOT\s+NULL/i)
+  })
+
+  it('migration 005 round-trips a UUID link_id on multiple rows', () => {
+    applyAll()
+    db.prepare(`INSERT INTO clients (id, name) VALUES (1, 'Acme')`).run()
+    const linkId = '11111111-2222-3333-4444-555555555555'
+    db.prepare(
+      `INSERT INTO entries (client_id, started_at, stopped_at, link_id)
+       VALUES (1, '2026-04-24T23:30:00Z', '2026-04-25T00:00:00Z', ?)`
+    ).run(linkId)
+    db.prepare(
+      `INSERT INTO entries (client_id, started_at, stopped_at, link_id)
+       VALUES (1, '2026-04-25T00:00:00Z', '2026-04-25T01:15:00Z', ?)`
+    ).run(linkId)
+    const linked = db
+      .prepare(`SELECT id FROM entries WHERE link_id = ? ORDER BY started_at`)
+      .all(linkId) as Array<{ id: number }>
+    expect(linked).toHaveLength(2)
+  })
+
   it('rolls back migration on SQL failure (transactional)', () => {
     applyAll()
     const beforeCount = db

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -44,7 +44,7 @@ declare global {
         getByMonth(query: MonthQuery): Promise<IpcResult<Entry[]>>
         create(input: CreateManualEntryInput): Promise<IpcResult<Entry>>
         update(input: UpdateEntryInput): Promise<IpcResult<Entry>>
-        delete(id: number): Promise<IpcResult<void>>
+        delete(id: number, cascadeLinked?: boolean): Promise<IpcResult<void>>
         undelete(id: number): Promise<IpcResult<Entry>>
       }
       settings: {
@@ -70,6 +70,9 @@ declare global {
       }
       paths: {
         get(): Promise<IpcResult<{ db: string; backups: string }>>
+      }
+      exporter: {
+        json(): Promise<IpcResult<{ path: string; bytes: number }>>
       }
     }
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -70,7 +70,8 @@ const api = {
       ipcRenderer.invoke('entries:create', input),
     update: (input: UpdateEntryInput): Promise<IpcResult<Entry>> =>
       ipcRenderer.invoke('entries:update', input),
-    delete: (id: number): Promise<IpcResult<void>> => ipcRenderer.invoke('entries:delete', id),
+    delete: (id: number, cascadeLinked = false): Promise<IpcResult<void>> =>
+      ipcRenderer.invoke('entries:delete', id, cascadeLinked),
     undelete: (id: number): Promise<IpcResult<Entry>> => ipcRenderer.invoke('entries:undelete', id)
   },
   // Settings
@@ -102,6 +103,10 @@ const api = {
   },
   paths: {
     get: (): Promise<IpcResult<{ db: string; backups: string }>> => ipcRenderer.invoke('paths:get')
+  },
+  exporter: {
+    json: (): Promise<IpcResult<{ path: string; bytes: number }>> =>
+      ipcRenderer.invoke('export:json')
   }
 }
 

--- a/src/renderer/src/components/EntryEditForm.tsx
+++ b/src/renderer/src/components/EntryEditForm.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { Client, Entry } from '../../../shared/types'
-import { formatTimeHHMM, isSameLocalDay, parseTimeToDate } from '../../../shared/date'
+import { formatTimeHHMM, parseTimeToDate } from '../../../shared/date'
 import { useEntriesStore } from '../store/entriesStore'
 
 interface Props {
@@ -31,8 +31,9 @@ function toDateInputValue(d: Date): string {
  * for fast feedback; the server enforces the same rules authoritatively
  * (see `validateManualEntry` in src/main/ipc.ts).
  *
- * v1.2 limitation: cross-midnight entries are rejected. The persistent
- * info banner above the time fields tells the user this and points to v1.3.
+ * v1.3 PR B: cross-midnight entries are now allowed — the IPC auto-splits
+ * them into linked halves at local midnight. The previous "folgt in v1.3"
+ * banner has been removed.
  */
 export function EntryEditForm({
   entry,
@@ -74,9 +75,6 @@ export function EntryEditForm({
       return (e as Error).message
     }
     if (stop.getTime() <= start.getTime()) return 'Endzeit muss nach der Startzeit liegen'
-    if (!isSameLocalDay(start, stop)) {
-      return 'Einträge können aktuell nicht über Mitternacht gehen (folgt in v1.3)'
-    }
     if (start.getTime() > Date.now()) return 'Startzeit darf nicht in der Zukunft liegen'
     if (description.length > MAX_DESCRIPTION_LEN) {
       return `Beschreibung überschreitet ${MAX_DESCRIPTION_LEN} Zeichen`
@@ -130,13 +128,6 @@ export function EntryEditForm({
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-3 text-sm">
-      <div
-        role="note"
-        className="rounded border border-amber-700/40 bg-amber-900/20 px-3 py-2 text-xs text-amber-200"
-      >
-        ℹ️ Einträge können aktuell nicht über Mitternacht gehen. Lösung folgt in v1.3.
-      </div>
-
       <div className="grid grid-cols-3 gap-2">
         <label className="flex flex-col gap-1">
           <span className="text-xs text-zinc-400">Datum</span>

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -101,6 +101,20 @@ export default function SettingsView(): React.JSX.Element {
     }
   }
 
+  async function exportJson(): Promise<void> {
+    setStatusMsg('Export wird vorbereitet …')
+    const res = await window.api.exporter.json()
+    if (res.ok) {
+      const kb = (res.data.bytes / 1024).toFixed(1)
+      setStatusMsg(`Export gespeichert (${kb} KB).`)
+    } else if (res.error === 'Export abgebrochen') {
+      // User cancelled the save dialog; surface no error noise.
+      setStatusMsg(null)
+    } else {
+      setStatusMsg(`Export fehlgeschlagen: ${res.error}`)
+    }
+  }
+
   if (!settings || !paths) {
     return <div className="text-slate-400">Lade Einstellungen …</div>
   }
@@ -257,6 +271,19 @@ export default function SettingsView(): React.JSX.Element {
               Insgesamt {backups.length} Backup{backups.length === 1 ? '' : 's'} gespeichert.
             </p>
           )}
+        </Row>
+        <Row label="JSON-Vollexport">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-sm text-slate-300">
+              Alle Kunden, Einträge und Einstellungen als JSON-Datei.
+            </span>
+            <button type="button" onClick={exportJson} className={btnSecondaryClass}>
+              Export speichern …
+            </button>
+          </div>
+          <p className="mt-1 text-xs text-slate-500">
+            Lesbares Format zum Backup oder zur Weiterverarbeitung. CSV/PDF folgen.
+          </p>
         </Row>
       </Section>
 

--- a/src/shared/midnightSplit.test.ts
+++ b/src/shared/midnightSplit.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import { splitAtMidnight } from './midnightSplit'
+
+function local(y: number, m: number, d: number, h = 0, min = 0): Date {
+  return new Date(y, m - 1, d, h, min, 0, 0)
+}
+
+function key(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')} ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
+}
+
+describe('splitAtMidnight', () => {
+  it('returns one segment for a same-day entry', () => {
+    const start = local(2026, 4, 24, 9, 0)
+    const stop = local(2026, 4, 24, 17, 30)
+    const segs = splitAtMidnight(start, stop)
+    expect(segs).toHaveLength(1)
+    expect(segs[0].start).toEqual(start)
+    expect(segs[0].stop).toEqual(stop)
+  })
+
+  it('splits a 23:30 → 01:15 entry at local midnight', () => {
+    const start = local(2026, 4, 24, 23, 30)
+    const stop = local(2026, 4, 25, 1, 15)
+    const segs = splitAtMidnight(start, stop)
+    expect(segs).toHaveLength(2)
+    expect(key(segs[0].start)).toBe('2026-04-24 23:30')
+    expect(key(segs[0].stop)).toBe('2026-04-25 00:00')
+    expect(key(segs[1].start)).toBe('2026-04-25 00:00')
+    expect(key(segs[1].stop)).toBe('2026-04-25 01:15')
+  })
+
+  it('treats stop = exact midnight as a single segment (no empty tail)', () => {
+    // An entry ending precisely at 00:00 of the next day should NOT produce
+    // a zero-length second segment. The first segment owns the boundary.
+    const start = local(2026, 4, 24, 22, 0)
+    const stop = local(2026, 4, 25, 0, 0)
+    const segs = splitAtMidnight(start, stop)
+    expect(segs).toHaveLength(1)
+    expect(segs[0].stop).toEqual(stop)
+  })
+
+  it('handles a 1-minute-after-midnight tail', () => {
+    const start = local(2026, 4, 24, 23, 59)
+    const stop = local(2026, 4, 25, 0, 1)
+    const segs = splitAtMidnight(start, stop)
+    expect(segs).toHaveLength(2)
+    expect(key(segs[0].stop)).toBe('2026-04-25 00:00')
+    expect(key(segs[1].start)).toBe('2026-04-25 00:00')
+  })
+
+  it('rejects stop <= start', () => {
+    const start = local(2026, 4, 24, 9, 0)
+    expect(() => splitAtMidnight(start, start)).toThrow(/stop must be after start/)
+    expect(() => splitAtMidnight(start, local(2026, 4, 24, 8, 0))).toThrow(/stop must be after/)
+  })
+
+  it('handles DST spring-forward (2026-03-29 EU)', () => {
+    // EU spring-forward: the wall clock jumps 02:00 → 03:00 on Sun 29.03.2026.
+    // An entry spanning that night still splits at LOCAL midnight, not at
+    // some UTC offset. We anchor on a 23:00 → 04:00 entry crossing the DST
+    // boundary inside the second segment.
+    const start = local(2026, 3, 28, 23, 0)
+    const stop = local(2026, 3, 29, 4, 0)
+    const segs = splitAtMidnight(start, stop)
+    expect(segs).toHaveLength(2)
+    expect(key(segs[0].start)).toBe('2026-03-28 23:00')
+    expect(key(segs[0].stop)).toBe('2026-03-29 00:00')
+    expect(key(segs[1].start)).toBe('2026-03-29 00:00')
+    expect(key(segs[1].stop)).toBe('2026-03-29 04:00')
+  })
+
+  it('handles DST fall-back (2026-10-25 EU)', () => {
+    // EU fall-back: 03:00 → 02:00 on Sun 25.10.2026. Same property — split
+    // at local midnight, segment lengths are wall-clock, not UTC.
+    const start = local(2026, 10, 24, 23, 0)
+    const stop = local(2026, 10, 25, 4, 0)
+    const segs = splitAtMidnight(start, stop)
+    expect(segs).toHaveLength(2)
+    expect(key(segs[0].stop)).toBe('2026-10-25 00:00')
+    expect(key(segs[1].start)).toBe('2026-10-25 00:00')
+  })
+
+  it('handles a multi-midnight span (>2 segments) — defensive, IPC caps at 24h', () => {
+    // The IPC validator rejects entries longer than 24h, so this never fires
+    // through the public API. The helper still supports it so we don't need
+    // a hidden coupling between "length cap" and "max 2 segments".
+    const start = local(2026, 4, 24, 22, 0)
+    const stop = local(2026, 4, 26, 1, 0)
+    const segs = splitAtMidnight(start, stop)
+    expect(segs).toHaveLength(3)
+    expect(key(segs[0].stop)).toBe('2026-04-25 00:00')
+    expect(key(segs[1].start)).toBe('2026-04-25 00:00')
+    expect(key(segs[1].stop)).toBe('2026-04-26 00:00')
+    expect(key(segs[2].start)).toBe('2026-04-26 00:00')
+  })
+})

--- a/src/shared/midnightSplit.ts
+++ b/src/shared/midnightSplit.ts
@@ -1,0 +1,54 @@
+/**
+ * Cross-midnight auto-split (v1.3 PR B).
+ *
+ * Returns one segment per local-time day the entry covers. For a single-day
+ * entry that's a one-element array (no split needed); for an entry that
+ * starts at 23:30 and stops at 01:15 the next day, it returns two segments
+ * meeting exactly at local midnight. Multi-day spans (≥3 segments) are
+ * supported but the IPC validator caps duration at 24 h, so in practice
+ * splits never produce more than 2 segments.
+ *
+ * "Local midnight" matters: a user in CEST sees 00:00 as the day boundary,
+ * not UTC midnight. We compute boundaries via `Date` constructors that
+ * honour the host TZ, which is correct for desktop usage. DST transitions
+ * are handled implicitly — the boundary is whichever local-time wall-clock
+ * 00:00 occurs between `start` and `stop`.
+ */
+export interface Segment {
+  start: Date
+  stop: Date
+}
+
+export function splitAtMidnight(start: Date, stop: Date): Segment[] {
+  if (!(start instanceof Date) || Number.isNaN(start.getTime())) {
+    throw new Error('start must be a valid Date')
+  }
+  if (!(stop instanceof Date) || Number.isNaN(stop.getTime())) {
+    throw new Error('stop must be a valid Date')
+  }
+  if (stop.getTime() <= start.getTime()) {
+    throw new Error('stop must be after start')
+  }
+
+  const segments: Segment[] = []
+  let cursor = start
+  while (true) {
+    const nextMidnight = localMidnightAfter(cursor)
+    if (nextMidnight.getTime() >= stop.getTime()) {
+      segments.push({ start: cursor, stop })
+      break
+    }
+    segments.push({ start: cursor, stop: nextMidnight })
+    cursor = nextMidnight
+  }
+  return segments
+}
+
+/**
+ * The local wall-clock 00:00 of the day AFTER `d`. We construct a Date with
+ * `d.getFullYear()/Month/Date + 1` so DST transitions move with the host
+ * clock automatically (no UTC arithmetic).
+ */
+function localMidnightAfter(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate() + 1, 0, 0, 0, 0)
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -19,6 +19,13 @@ export interface Entry {
   rounded_min: number | null
   deleted_at: string | null
   created_at: string
+  /**
+   * v1.3 PR B: when an entry crosses local midnight, it's stored as
+   * multiple rows that share the same UUID. NULL for plain single-day
+   * entries. The Drawer offers a "auch zweite Hälfte löschen?" prompt
+   * when the user deletes a row with a non-null link_id.
+   */
+  link_id: string | null
 }
 
 export interface Settings {


### PR DESCRIPTION
# v1.3 PR B — Cross-Midnight Auto-Split + JSON-Vollexport

Zweiter Schritt der v1.3-Sequenz nach **#43**. Liefert die zwei Features, für die
v1.2 explizit aufgeschoben hatte: über Mitternacht laufende Einträge und einen
ehrlichen Datenexport.

## Was sich ändert

### Cross-Midnight Auto-Split

- **Migration 005** fügt `entries.link_id TEXT` (nullable) plus partiellen Index
  `idx_entries_link_id ON entries(link_id) WHERE link_id IS NOT NULL` hinzu.
  Partiell, weil der Großteil aller Einträge `link_id IS NULL` haben wird —
  kein Punkt, die Index-Page voller NULLs zu führen.
- Neuer Helper `splitAtMidnight(start, stop)` in `src/shared/midnightSplit.ts`.
  Pure function, DST-sicher (Local-Mitternacht via `new Date(y, m, d+1, 0, 0, 0, 0)`,
  nicht via `+24h`-Arithmetik), liefert `Segment[]`. **8 Tests**, inkl. Frühling-
  und Herbst-DST-Übergänge.
- IPC `entries:create`/`entries:update` rufen den Helper auf und legen für
  jedes Segment eine Zeile an. Bei mehreren Segmenten wird eine UUID als
  `link_id` generiert (`crypto.randomUUID()`); Insert läuft transaktional über
  `db.transaction`. Update löscht zuerst die ggf. existierenden Geschwister-
  Zeilen (per `link_id`) und schreibt dann neu — atomar.
- IPC `entries:delete` bekommt einen optionalen zweiten Parameter
  `cascadeLinked: boolean`. Wenn `true` und die Zeile hat einen `link_id`,
  werden alle Zeilen mit demselben `link_id` soft-gelöscht (`deleted_at = now`).
  Default bleibt `false` (rückwärtskompatibel zu allen vorhandenen Aufrufern).
- `validateManualEntry()` wirft die "kann nicht über Mitternacht"-Regel raus.
  Overlap-Check schließt die eigene `link_id`-Familie aus, sonst würden
  zwei verlinkte Hälften sich gegenseitig als Überlappung melden.
- `EntryEditForm.tsx` zeigt den amber Banner nicht mehr.
- `Entry.link_id: string | null` im Shared-Type — Renderer kann jetzt
  optional verlinkte Einträge erkennen (z.B. für ein "auch zweite Hälfte
  löschen"-UI in PR C oder später).

### JSON-Vollexport (#17)

- `buildJsonExportPayload(db, appVersion)` in **neuer Datei**
  `src/main/jsonExport.ts`. Bewusst aus `ipc.ts` extrahiert, damit Tests
  ohne Electron-Boot drüberlaufen können.
- Schema:
  ```jsonc
  {
    "meta": { "schemaVersion": 5, "exportedAt": "ISO", "appVersion": "1.3.0" },
    "clients": [...],   // alle Felder, sortiert by id
    "entries": [...],   // alle Felder inkl. soft-deleted + link_id, sortiert by started_at, id
    "settings": [...]   // {key, value}, alphabetisch
  }
  ```
- IPC `export:json`: `dialog.showSaveDialog` → `JSON.stringify(payload, null, 2)`
  → `writeFileSync`. Cancel ist kein Fehler, sondern liefert
  `fail('Export abgebrochen')`, das die UI als Stille interpretiert.
- Settings → "Daten" bekommt eine neue Row "JSON-Vollexport" mit
  Beschreibung + "Export speichern …"-Button.
- **6 Tests** in `src/main/jsonExport.test.ts`: meta-Schema-Version,
  Settings sortiert, alle Felder erhalten, Cross-Midnight-Hälften
  verbatim, soft-deleted included, Indent ist 2-space.

## Was bewusst nicht in PR B ist

- **Cascade-UI im Drawer**: das `cascadeLinked`-Flag ist verdrahtet, aber
  der Bestätigungs-Dialog ("auch die zweite Hälfte löschen?") wartet auf
  PR C — dort ist der Edit-Drawer ohnehin in Bearbeitung. PR B hält die
  Tür offen, ohne die Renderer-Diff-Fläche aufzublasen.
- **CSV-Export (#18)**: laut Plan in PR D, nicht hier.
- **PDF-Pipeline (#16, #19)**: kommt in PR C.

## Quality Gates

- `pnpm typecheck` ✅
- `pnpm test` → **92 Tests** (59 lokal grün + 33 skipped weil
  better-sqlite3 native binding lokal fehlt; CI rennt sie)
- `pnpm lint` → **21 errors** (Baseline gehalten; keine neuen)
- Prettier auf alle 15 berührten/neuen Dateien

## Migration Risk

Migration 005 ist additive only:
- `ALTER TABLE entries ADD COLUMN link_id TEXT` — nullable, kein Default,
  ohne Backfill notwendig. Bestehende Zeilen bleiben unverändert
  (`link_id IS NULL` heißt "kein Split").
- Partial-Index ist neu, kostet keinen Schreib-Overhead bis tatsächlich
  jemand über Mitternacht trackt.
- Idempotent durch das schema_version-Gating (kein zweiter ALTER).

## Folge-PRs

- **PR C** (geplant): PDF-Pipeline (#16, #19) — verstecktes BrowserWindow +
  `printToPDF`, deutsches Layout, optional Drawer-Cascade-Dialog.
- **PR D** (geplant): Release-Infra — Actions v5 (#42), CSV-Export (#18),
  Smoke-Test-PDF, Tag `v1.3.0`.
