### PR TITLE
feat(v1.3 PR C): PDF-Hero Stundennachweis + Settings-Vorlage (#16, #19)

### DIFF
--- a/.github/pr-body-v13-c.md
+++ b/.github/pr-body-v13-c.md
@@ -1,0 +1,125 @@
+## Summary
+
+PR C of v1.3 — the PDF Hero. Closes #16 (PDF-Stundennachweis) and #19
+(Settings-Vorlage). Continues directly after #43 (PR A — Stundensatz +
+Quick-Filter) and #44 (PR B — Cross-Midnight + JSON-Export) in the v1.3
+sequential merge plan.
+
+## What ships
+
+**Hero flow (1 click):** `Calendar → 📄 Letzter Monat als PDF (oder Quick-Filter-Pille)
+→ Modal mit vorbelegtem Kunde + Zeitraum → "PDF speichern" → Save-Dialog →
+A4-PDF auf der Platte`. The modal is reusable from anywhere with optional
+pre-fill.
+
+**The PDF itself:** German Stundennachweis layout — Logo links + Sender
+rechts oben, Titel "Stundennachweis", Kunde + Zeitraum, Tabelle mit
+Datum/Von/Bis/Tätigkeit/Dauer und optional Honorar-Spalte (nur wenn der
+Kunde einen `rate_cent > 0` hat), Summenzeile, Signatur-Zeile, Footer.
+Akzentfarbe wird durchgängig angewandt; Stundensummen können optional auf
+5/10/15/30 min gerundet werden.
+
+**Settings → PDF-Vorlage:** Logo (Datei-Picker, max. 1 MB; PNG/JPG/SVG/WebP),
+Absenderadresse (Multiline), Steuernummer, Akzentfarbe (Color-Picker),
+Footer-Text, Stunden-Rundung. Logo wird ins `userData` kopiert
+(stabiler Pfad `pdf-logo.<ext>`), beim Rendern als base64 `data:` URL
+in die HTML eingebettet.
+
+**Currency helpers** (`src/shared/currency.ts`): integer-cent math
+(`feeCent(min, rateCent) = round(min × rateCent / 60)`), DE-Format
+(`1.234,56 €`), `formatHoursMinutes(min)` (`H:MM`, negative-safe),
+`roundMinutes(min, step)` (half-up; `step <= 0` = passthrough). 14 tests.
+
+## Architectural deviation from the original v1.3 plan
+
+The plan called for a third Vite renderer entry (`src/renderer-pdf/`)
+that would render a React template inside a hidden BrowserWindow. I
+switched to an **HTML-string template** (`buildPdfHtml(payload)` returns
+a self-contained doc that gets written to `os.tmpdir()` and loaded via
+`file://`) for two reasons:
+
+1. **R1 eliminated** — the plan worried about needing
+   `webSecurity: false` to load the logo. By embedding the logo as a
+   base64 `data:` URL, the PDF window keeps `webSecurity: true` AND a
+   strict CSP meta tag (`default-src 'none'; img-src data:; style-src
+   'unsafe-inline'`).
+2. **R5 eliminated** — no Vite multi-entry build config gymnastics; the
+   PDF code path doesn't need Tailwind, React, or hot-reload.
+
+Trade-off: the template is plain TS/HTML strings, not JSX. Acceptable
+because (a) the layout is simple and unlikely to need component reuse,
+(b) the output is trivially snapshot-testable, and (c) we can swap to
+React-on-renderer later without changing the IPC contract if the
+template ever grows complex.
+
+## Files
+
+**New:**
+- `src/shared/currency.ts` + `.test.ts` (14 tests)
+- `src/main/pdf.ts` (`buildPdfPayload` + `buildPdfHtml`, pure)
+- `src/main/pdf.test.ts` (8 unskipped + 10 DB-skipped pattern matches `jsonExport.test.ts`)
+- `src/main/logo.ts` (file-storage helpers, max 1 MB, ext allow-list, `data:` URL renderer)
+- `src/main/logo.test.ts` (8 tests, fully unskippable — operates on tmpdirs)
+- `src/main/pdfWindow.ts` (hidden-window driver around `printToPDF`)
+- `src/renderer/src/components/PdfExportModal.tsx`
+
+**Modified:**
+- `src/main/ipc.ts` — three new handlers: `pdf:export`, `logo:set`, `logo:clear`
+- `src/preload/index.ts` + `index.d.ts` — `window.api.pdf.*` and `window.api.logo.*` namespaces
+- `src/shared/types.ts` — `Settings` extended with `pdf_logo_path`, `pdf_sender_address`, `pdf_tax_id`, `pdf_accent_color`, `pdf_footer_text`, `pdf_round_minutes` (no migration needed; Migration 004 from PR A already seeded them and `settings:getAll` returns the full key-value bag)
+- `src/renderer/src/views/CalendarView.tsx` — hero button + 3 quick-filter pills now actually open the modal with `prefilledRange`
+- `src/renderer/src/views/SettingsView.tsx` — new "PDF-Vorlage" section between Daten and Über
+- `CHANGELOG.md`
+
+## Security notes
+
+- **CSP:** `default-src 'none'; img-src data:; style-src 'unsafe-inline'` —
+  no scripts allowed at all in the PDF window.
+- **`webSecurity: true`** preserved (no relaxation).
+- **HTML escaping:** all user-controlled strings (client name, sender,
+  description, footer) flow through `esc()` before interpolation. Test
+  coverage: an `<script>` payload in the client name renders as text.
+- **Accent color:** validated against `^#[0-9a-fA-F]{6}$`, falls back to
+  indigo on bad input. Test verifies a `javascript:` payload is dropped.
+- **Logo size cap:** 1 MB (`MAX_LOGO_BYTES`), enforced in both
+  `saveLogo()` and `readLogoAsDataUrl()`.
+- **Logo extension allow-list:** PNG, JPG/JPEG, SVG, WebP. Anything else
+  rejected at save time and ignored at read time.
+
+## Quality gates
+
+- `pnpm typecheck` — green
+- `pnpm test` — **89 passed** | 43 skipped (was 59 passed; +30 from PR C:
+  14 currency, 8 logo, 8 pdf-pure)
+- `pnpm lint` — **21 errors** (baseline maintained, 0 new)
+- `npx prettier --write` ran clean on all touched files
+
+## Deferred to PR D (intentionally out of scope)
+
+- **Icon assets** from `timetrack_icon_glass_final.svg` → `build/icon.png`
+  + `resources/tray-running.png` + `resources/tray-stopped.png` (the SVG is
+  in the working tree but not committed in this PR)
+- **Live PDF preview iframe** in the Settings → PDF-Vorlage section
+- **Drag-and-drop logo upload** (currently file-picker only)
+- **Entry-count preview** in the export modal ("X Einträge, Y Stunden")
+- **PDF smoke test** in CI (visual regression / bytes-non-zero check)
+- **GitHub Actions v5** upgrade (#42)
+
+## How to test
+
+1. Pull `feat/v1.3-pr-c-pdf`, run `pnpm dev`
+2. Settings → PDF-Vorlage → Logo wählen + Adresse + Steuernummer + Akzentfarbe
+3. Kalender → "📄 Letzter Monat als PDF" oder eine Pille klicken
+4. Modal: Kunde + Zeitraum sind vorbelegt → "PDF speichern"
+5. Öffne das PDF — Layout, deutsche Datums-/Zahlenformatierung, Honorar-Spalte
+   (nur bei Kunden mit Stundensatz), optionale Rundung
+6. Wiederholen mit einem 0-€-Kunden → keine Honorar-Spalte, keine Total-Zeile-€
+
+## Decision log
+
+- HTML-string template > React renderer entry (see "Architectural deviation")
+- Logo as base64 `data:` URL > `file://` reference (eliminates R1)
+- 1 MB Logo-Cap > unbounded (PDF size, data: URL practicality)
+- Modal `key={range}` > `useEffect` reset (avoids cascading-renders lint warning)
+- Honorar-Spalte rate-based (`client.rate_cent > 0`) > entry-based — semantic
+  match: "this client is billable", not "did this entry happen to bill"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,20 @@ All notable changes to TimeTrack are documented here.
   (inkl. soft-gelöschter und verlinkter Hälften) und allen Settings.
   Trust-Artefakt: User können ihre Daten byte-genau verifizieren; CSV/PDF
   bauen in PR C/D darauf auf.
+- **PDF-Stundennachweis** (#16, #19) — Hero-Path: 1-Klick aus dem Kalender
+  („📄 Letzter Monat als PDF" oder eine Quick-Filter-Pille) öffnet ein
+  Modal, in dem Kunde + Zeitraum vorbelegt sind, und schreibt nach
+  Bestätigung ein druckbares A4-PDF im deutschen Stundennachweis-Layout
+  (Datum / Von / Bis / Tätigkeit / Dauer, optional Honorar wenn der Kunde
+  einen Stundensatz hat). Logo, Absenderadresse, Steuernummer,
+  Akzentfarbe, Footer-Text und optionale Stunden-Rundung
+  (5/10/15/30 min) konfigurierbar in **Einstellungen → PDF-Vorlage**.
+  Implementierung: Hidden `BrowserWindow` + `printToPDF`; das HTML-Template
+  ist eine String-Render-Funktion mit base64-eingebettetem Logo und CSP
+  `default-src 'none'; img-src data:; style-src 'unsafe-inline'` —
+  kein `webSecurity:false` nötig, kein dritter Vite-Renderer-Entry.
+  Honorar-Berechnung integer-cent: `Math.round(min × rateCent / 60)`,
+  Ausgabe als deutsches Format `1.234,56 €`.
 
 ## [1.2.0] — 2026-04-24
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -8,6 +8,9 @@ import { getBackupsDir } from './backup'
 import { createBackup, listBackups, restoreBackup as restoreBackupFile } from './backup'
 import { splitAtMidnight } from '../shared/midnightSplit'
 import { buildJsonExportPayload } from './jsonExport'
+import { buildPdfHtml, buildPdfPayload, type PdfRequest } from './pdf'
+import { renderPdfBuffer } from './pdfWindow'
+import { readLogoAsDataUrl, removeLogo, saveLogo } from './logo'
 import type {
   Client,
   Entry,
@@ -527,6 +530,93 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
       const json = JSON.stringify(payload, null, 2)
       writeFileSync(result.filePath, json, 'utf8')
       return ok({ path: result.filePath, bytes: Buffer.byteLength(json, 'utf8') })
+    } catch (e) {
+      return fail(e)
+    }
+  })
+
+  // === PDF export (v1.3 PR C, issues #16 + #19) ===========================
+  // The hero feature: client + date range → printable A4 PDF.
+  // Pipeline: gather payload from DB → render template HTML → hidden
+  // BrowserWindow + printToPDF → write to user-chosen path.
+
+  ipcMain.handle(
+    'pdf:export',
+    async (_e, req: PdfRequest): Promise<IpcResult<{ path: string }>> => {
+      try {
+        if (!req || typeof req.clientId !== 'number' || !req.fromIso || !req.toIso) {
+          return fail('Ungültige PDF-Anfrage')
+        }
+        const client = db.prepare(`SELECT id, name FROM clients WHERE id = ?`).get(req.clientId) as
+          | { id: number; name: string }
+          | undefined
+        if (!client) return fail(`Kunde ${req.clientId} nicht gefunden`)
+
+        const monthHint = req.fromIso.slice(0, 7) // YYYY-MM
+        // Strip filesystem-hostile chars from the client name for the suggested filename.
+        const safeName = client.name.replace(/[\\/:*?"<>|]/g, '_').trim() || 'Kunde'
+        const result = await dialog.showSaveDialog({
+          title: 'Stundennachweis speichern',
+          defaultPath: `Stundennachweis-${safeName}-${monthHint}.pdf`,
+          filters: [{ name: 'PDF', extensions: ['pdf'] }]
+        })
+        if (result.canceled || !result.filePath) {
+          return fail('Export abgebrochen')
+        }
+
+        const settingsRows = db.prepare(`SELECT key, value FROM settings`).all() as Array<{
+          key: string
+          value: string
+        }>
+        const settings = Object.fromEntries(
+          settingsRows.map((r) => [r.key, r.value])
+        ) as unknown as Settings
+        const logoDataUrl = readLogoAsDataUrl(settings.pdf_logo_path ?? '')
+
+        const payload = buildPdfPayload(db, req, logoDataUrl)
+        const html = buildPdfHtml(payload)
+        const buf = await renderPdfBuffer({ html })
+        writeFileSync(result.filePath, buf)
+        return ok({ path: result.filePath })
+      } catch (e) {
+        return fail(e)
+      }
+    }
+  )
+
+  // Logo picker — copies user-chosen image into userData/pdf-logo.<ext>
+  // and persists the path into settings.pdf_logo_path.
+  ipcMain.handle('logo:set', async (): Promise<IpcResult<{ path: string }>> => {
+    try {
+      const result = await dialog.showOpenDialog({
+        title: 'Logo auswählen',
+        properties: ['openFile'],
+        filters: [{ name: 'Bilder', extensions: ['png', 'jpg', 'jpeg', 'svg', 'webp'] }]
+      })
+      if (result.canceled || result.filePaths.length === 0) {
+        return fail('Auswahl abgebrochen')
+      }
+      const userDataDir = app.getPath('userData')
+      const target = saveLogo(result.filePaths[0], userDataDir)
+      db.prepare(
+        `INSERT INTO settings (key, value) VALUES ('pdf_logo_path', ?)
+           ON CONFLICT(key) DO UPDATE SET value = excluded.value`
+      ).run(target)
+      return ok({ path: target })
+    } catch (e) {
+      return fail(e)
+    }
+  })
+
+  ipcMain.handle('logo:clear', async (): Promise<IpcResult<void>> => {
+    try {
+      const userDataDir = app.getPath('userData')
+      removeLogo(userDataDir)
+      db.prepare(
+        `INSERT INTO settings (key, value) VALUES ('pdf_logo_path', '')
+           ON CONFLICT(key) DO UPDATE SET value = excluded.value`
+      ).run()
+      return ok(undefined)
     } catch (e) {
       return fail(e)
     }

--- a/src/main/logo.test.ts
+++ b/src/main/logo.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { saveLogo, removeLogo, readLogoAsDataUrl, MAX_LOGO_BYTES } from './logo'
+
+describe('logo storage', () => {
+  let tmpDir: string
+  let userDataDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'tt-logo-'))
+    userDataDir = join(tmpDir, 'userData')
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function writeFixture(name: string, bytes: Buffer | string): string {
+    const p = join(tmpDir, name)
+    writeFileSync(p, bytes)
+    return p
+  }
+
+  it('rejects unsupported extensions', () => {
+    const src = writeFixture('logo.gif', Buffer.from([0x47, 0x49, 0x46]))
+    expect(() => saveLogo(src, userDataDir)).toThrow(/nicht unterstützt/)
+  })
+
+  it('rejects files larger than 1 MB', () => {
+    const big = Buffer.alloc(MAX_LOGO_BYTES + 1, 0xff)
+    const src = writeFixture('big.png', big)
+    expect(() => saveLogo(src, userDataDir)).toThrow(/1 MB/)
+  })
+
+  it('saves a PNG logo into userData and returns the new path', () => {
+    const src = writeFixture('logo.png', Buffer.from([0x89, 0x50, 0x4e, 0x47]))
+    const target = saveLogo(src, userDataDir)
+    expect(target).toBe(join(userDataDir, 'pdf-logo.png'))
+    expect(existsSync(target)).toBe(true)
+    expect(readFileSync(target)).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47]))
+  })
+
+  it('replaces an existing logo even with a different extension', () => {
+    saveLogo(writeFixture('a.png', Buffer.from([1, 2, 3])), userDataDir)
+    expect(existsSync(join(userDataDir, 'pdf-logo.png'))).toBe(true)
+    saveLogo(writeFixture('b.jpg', Buffer.from([4, 5, 6])), userDataDir)
+    expect(existsSync(join(userDataDir, 'pdf-logo.png'))).toBe(false)
+    expect(existsSync(join(userDataDir, 'pdf-logo.jpg'))).toBe(true)
+  })
+
+  it('removeLogo is idempotent and survives a missing directory', () => {
+    expect(() => removeLogo(userDataDir)).not.toThrow()
+    saveLogo(writeFixture('a.png', Buffer.from([1])), userDataDir)
+    removeLogo(userDataDir)
+    expect(existsSync(join(userDataDir, 'pdf-logo.png'))).toBe(false)
+  })
+
+  it('readLogoAsDataUrl returns empty for missing/empty paths', () => {
+    expect(readLogoAsDataUrl('')).toBe('')
+    expect(readLogoAsDataUrl(join(tmpDir, 'does-not-exist.png'))).toBe('')
+  })
+
+  it('readLogoAsDataUrl base64-encodes a stored PNG', () => {
+    const target = saveLogo(writeFixture('logo.png', Buffer.from([1, 2, 3, 4])), userDataDir)
+    const url = readLogoAsDataUrl(target)
+    expect(url).toBe('data:image/png;base64,AQIDBA==')
+  })
+
+  it('readLogoAsDataUrl uses the right MIME type for SVG', () => {
+    const target = saveLogo(writeFixture('logo.svg', '<svg/>'), userDataDir)
+    expect(readLogoAsDataUrl(target).startsWith('data:image/svg+xml;base64,')).toBe(true)
+  })
+})

--- a/src/main/logo.ts
+++ b/src/main/logo.ts
@@ -1,0 +1,98 @@
+/**
+ * Logo storage helpers for the PDF template.
+ *
+ * The logo lives in `app.getPath('userData')` under a stable filename
+ * (`pdf-logo.<ext>`), so it survives app upgrades along with the SQLite
+ * database. The settings table holds the absolute path; PDF rendering
+ * loads the bytes and embeds them as a data: URL — that's why the PDF
+ * pipeline doesn't need `webSecurity: false`.
+ */
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync, statSync } from 'fs'
+import { dirname, extname, join } from 'path'
+
+export const MAX_LOGO_BYTES = 1024 * 1024 // 1 MB — keeps PDFs lean and the data: URL manageable
+
+const ALLOWED_EXTS = ['.png', '.jpg', '.jpeg', '.svg', '.webp'] as const
+type AllowedExt = (typeof ALLOWED_EXTS)[number]
+
+const MIME_BY_EXT: Record<AllowedExt, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp'
+}
+
+function normaliseExt(filename: string): AllowedExt {
+  const ext = extname(filename).toLowerCase() as AllowedExt
+  if (!ALLOWED_EXTS.includes(ext)) {
+    throw new Error(`Logo-Format nicht unterstützt: ${ext || '(unbekannt)'}`)
+  }
+  return ext
+}
+
+/**
+ * Copy a user-picked logo file into `userData/pdf-logo.<ext>`. Returns
+ * the new absolute path so the caller can persist it in
+ * `settings.pdf_logo_path`. Validates size + extension; cleans up any
+ * previously stored logo (including ones with a different extension).
+ */
+export function saveLogo(sourcePath: string, userDataDir: string): string {
+  const stat = statSync(sourcePath)
+  if (stat.size > MAX_LOGO_BYTES) {
+    throw new Error(`Logo überschreitet 1 MB (${(stat.size / 1024).toFixed(0)} KB)`)
+  }
+  const ext = normaliseExt(sourcePath)
+  removeLogo(userDataDir)
+  if (!existsSync(userDataDir)) {
+    mkdirSync(userDataDir, { recursive: true })
+  }
+  const targetPath = join(userDataDir, `pdf-logo${ext}`)
+  const buf = readFileSync(sourcePath)
+  writeFileSync(targetPath, buf)
+  return targetPath
+}
+
+/** Delete every `pdf-logo.*` file under `userDataDir`. Idempotent. */
+export function removeLogo(userDataDir: string): void {
+  if (!existsSync(userDataDir)) return
+  for (const ext of ALLOWED_EXTS) {
+    const candidate = join(userDataDir, `pdf-logo${ext}`)
+    if (existsSync(candidate)) {
+      try {
+        unlinkSync(candidate)
+      } catch {
+        // Best effort — failing to delete an old logo shouldn't block a new upload.
+      }
+    }
+  }
+}
+
+/**
+ * Read a stored logo and produce a `data:image/...;base64,...` URL for
+ * inline embedding in the PDF HTML. Returns the empty string when the
+ * path is empty, missing, or unreadable — the template gracefully omits
+ * the logo block in that case.
+ */
+export function readLogoAsDataUrl(absolutePath: string): string {
+  if (!absolutePath) return ''
+  if (!existsSync(absolutePath)) return ''
+  let ext: AllowedExt
+  try {
+    ext = normaliseExt(absolutePath)
+  } catch {
+    return ''
+  }
+  try {
+    const buf = readFileSync(absolutePath)
+    if (buf.length > MAX_LOGO_BYTES) return ''
+    return `data:${MIME_BY_EXT[ext]};base64,${buf.toString('base64')}`
+  } catch {
+    return ''
+  }
+}
+
+/** Exposed for tests: which directory will `saveLogo` write into for a given userData. */
+export function logoDirFor(absolutePath: string): string {
+  return dirname(absolutePath)
+}

--- a/src/main/pdf.test.ts
+++ b/src/main/pdf.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Tests for the PDF payload assembler + HTML template renderer.
+ * No Electron, no I/O — operates on an in-memory SQLite + checks
+ * the produced HTML string with structural assertions (we deliberately
+ * avoid pixel snapshots; printToPDF rendering varies across Chromium
+ * point releases).
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import type Database from 'better-sqlite3'
+import { migrations } from './migrations'
+import { buildPdfPayload, buildPdfHtml } from './pdf'
+
+type DatabaseCtor = new (path: string) => Database.Database
+let DatabaseImpl: DatabaseCtor | null = null
+
+beforeAll(async () => {
+  try {
+    const mod = await import('better-sqlite3')
+    const Ctor = mod.default as unknown as DatabaseCtor
+    const probe = new Ctor(':memory:')
+    probe.close()
+    DatabaseImpl = Ctor
+  } catch {
+    DatabaseImpl = null
+  }
+})
+
+describe('buildPdfPayload', () => {
+  let tmpDir: string
+  let db: Database.Database
+
+  beforeEach((ctx) => {
+    if (!DatabaseImpl) {
+      ctx.skip()
+      return
+    }
+    tmpDir = mkdtempSync(join(tmpdir(), 'tt-pdf-'))
+    db = new DatabaseImpl(join(tmpDir, 'test.sqlite'))
+    db.pragma('foreign_keys = ON')
+    db.exec(
+      `CREATE TABLE schema_version (
+         version INTEGER PRIMARY KEY,
+         name TEXT NOT NULL,
+         applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+       )`
+    )
+    for (const m of migrations) {
+      const tx = db.transaction(() => {
+        db.exec(m.up)
+        db.prepare('INSERT INTO schema_version (version, name) VALUES (?, ?)').run(
+          m.version,
+          m.name
+        )
+      })
+      tx()
+    }
+    db.prepare(
+      `INSERT INTO clients (id, name, color, rate_cent) VALUES (1, 'Acme', '#6366f1', 8500)`
+    ).run()
+    db.prepare(
+      `INSERT INTO clients (id, name, color, rate_cent) VALUES (2, 'Pro Bono', '#10b981', 0)`
+    ).run()
+  })
+
+  afterEach(() => {
+    if (!db) return
+    db.close()
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('throws when client does not exist', () => {
+    expect(() =>
+      buildPdfPayload(db, { clientId: 999, fromIso: '2026-04-01', toIso: '2026-04-30' }, '')
+    ).toThrow(/Kunde/)
+  })
+
+  it('returns empty rows + zero totals when no entries match', () => {
+    const p = buildPdfPayload(db, { clientId: 1, fromIso: '2026-04-01', toIso: '2026-04-30' }, '')
+    expect(p.rows).toEqual([])
+    expect(p.totals.minutes).toBe(0)
+    // Client has rate 8500 — totals.feeCent stays 0, not null, because
+    // the "no fee column" decision is rate-based not entry-based.
+    expect(p.totals.feeCent).toBe(0)
+  })
+
+  it('omits fee column for clients with rate_cent = 0', () => {
+    db.prepare(
+      `INSERT INTO entries (client_id, started_at, stopped_at)
+       VALUES (2, '2026-04-15T08:00:00.000Z', '2026-04-15T09:30:00.000Z')`
+    ).run()
+    const p = buildPdfPayload(db, { clientId: 2, fromIso: '2026-04-01', toIso: '2026-04-30' }, '')
+    expect(p.totals.feeCent).toBeNull()
+    expect(p.rows[0].feeCent).toBeNull()
+  })
+
+  it('aggregates minutes and fee for paid clients', () => {
+    db.prepare(
+      `INSERT INTO entries (client_id, description, started_at, stopped_at)
+       VALUES (1, 'work', '2026-04-15T08:00:00.000Z', '2026-04-15T09:30:00.000Z')`
+    ).run()
+    db.prepare(
+      `INSERT INTO entries (client_id, description, started_at, stopped_at)
+       VALUES (1, 'more work', '2026-04-16T10:00:00.000Z', '2026-04-16T11:00:00.000Z')`
+    ).run()
+    const p = buildPdfPayload(db, { clientId: 1, fromIso: '2026-04-01', toIso: '2026-04-30' }, '')
+    expect(p.rows).toHaveLength(2)
+    expect(p.totals.minutes).toBe(150) // 90 + 60
+    // 150 min × 8500 cent/h ÷ 60 = 21250 cent
+    expect(p.totals.feeCent).toBe(21250)
+  })
+
+  it('respects pdf_round_minutes setting', () => {
+    db.prepare(`UPDATE settings SET value='15' WHERE key='pdf_round_minutes'`).run()
+    db.prepare(
+      // 23 minutes raw — should round to 30 with step=15
+      `INSERT INTO entries (client_id, description, started_at, stopped_at)
+       VALUES (1, 'short task', '2026-04-15T08:00:00.000Z', '2026-04-15T08:23:00.000Z')`
+    ).run()
+    const p = buildPdfPayload(db, { clientId: 1, fromIso: '2026-04-01', toIso: '2026-04-30' }, '')
+    expect(p.rows[0].minutes).toBe(30)
+    expect(p.totals.minutes).toBe(30)
+  })
+
+  it('excludes soft-deleted entries', () => {
+    db.prepare(
+      `INSERT INTO entries (client_id, started_at, stopped_at, deleted_at)
+       VALUES (1, '2026-04-15T08:00:00.000Z', '2026-04-15T09:00:00.000Z', '2026-04-15T10:00:00.000Z')`
+    ).run()
+    const p = buildPdfPayload(db, { clientId: 1, fromIso: '2026-04-01', toIso: '2026-04-30' }, '')
+    expect(p.rows).toHaveLength(0)
+  })
+
+  it('excludes running entries (stopped_at IS NULL)', () => {
+    db.prepare(
+      `INSERT INTO entries (client_id, started_at, stopped_at)
+       VALUES (1, '2026-04-15T08:00:00.000Z', NULL)`
+    ).run()
+    const p = buildPdfPayload(db, { clientId: 1, fromIso: '2026-04-01', toIso: '2026-04-30' }, '')
+    expect(p.rows).toHaveLength(0)
+  })
+
+  it('range is inclusive — captures entries on the last day', () => {
+    db.prepare(
+      `INSERT INTO entries (client_id, started_at, stopped_at)
+       VALUES (1, '2026-04-30T22:00:00.000Z', '2026-04-30T23:00:00.000Z')`
+    ).run()
+    const p = buildPdfPayload(db, { clientId: 1, fromIso: '2026-04-01', toIso: '2026-04-30' }, '')
+    expect(p.rows).toHaveLength(1)
+  })
+
+  it('includes cross-midnight halves as separate rows (link_id preserved by data layer)', () => {
+    db.prepare(
+      `INSERT INTO entries (client_id, started_at, stopped_at, link_id)
+       VALUES (1, '2026-04-24T22:00:00.000Z', '2026-04-25T00:00:00.000Z', 'aaa')`
+    ).run()
+    db.prepare(
+      `INSERT INTO entries (client_id, started_at, stopped_at, link_id)
+       VALUES (1, '2026-04-25T00:00:00.000Z', '2026-04-25T01:30:00.000Z', 'aaa')`
+    ).run()
+    const p = buildPdfPayload(db, { clientId: 1, fromIso: '2026-04-24', toIso: '2026-04-25' }, '')
+    expect(p.rows).toHaveLength(2)
+  })
+
+  it('uses settings for sender block + accent color', () => {
+    db.prepare(`UPDATE settings SET value='Robin GmbH' WHERE key='company_name'`).run()
+    db.prepare(
+      `UPDATE settings SET value='Musterstr. 1\n12345 Berlin' WHERE key='pdf_sender_address'`
+    ).run()
+    db.prepare(`UPDATE settings SET value='DE12345' WHERE key='pdf_tax_id'`).run()
+    db.prepare(`UPDATE settings SET value='#ff0000' WHERE key='pdf_accent_color'`).run()
+    const p = buildPdfPayload(db, { clientId: 1, fromIso: '2026-04-01', toIso: '2026-04-30' }, '')
+    expect(p.sender.name).toBe('Robin GmbH')
+    expect(p.sender.address).toContain('Musterstr')
+    expect(p.sender.taxId).toBe('DE12345')
+    expect(p.accentColor).toBe('#ff0000')
+  })
+})
+
+describe('buildPdfHtml', () => {
+  function makePayload(
+    overrides: Partial<Parameters<typeof buildPdfHtml>[0]> = {}
+  ): Parameters<typeof buildPdfHtml>[0] {
+    return {
+      client: { id: 1, name: 'Acme', rate_cent: 8500 },
+      sender: { name: 'Robin GmbH', address: 'Musterstr. 1\n12345 Berlin', taxId: 'DE12345' },
+      fromIso: '2026-04-01',
+      toIso: '2026-04-30',
+      rows: [
+        {
+          date: '15.04.2026',
+          startTime: '08:00',
+          stopTime: '09:30',
+          description: 'Work',
+          minutes: 90,
+          feeCent: 12750
+        }
+      ],
+      totals: { minutes: 90, feeCent: 12750 },
+      accentColor: '#4f46e5',
+      footerText: 'Bitte überweisen Sie bis zum 15.05.',
+      logoDataUrl: '',
+      roundMinutes: 0,
+      generatedAtIso: '2026-04-24T12:00:00.000Z',
+      ...overrides
+    }
+  }
+
+  it('produces a self-contained HTML document', () => {
+    const html = buildPdfHtml(makePayload())
+    expect(html).toMatch(/^<!doctype html>/)
+    expect(html).toContain('<title>Stundennachweis</title>')
+    expect(html).toContain('Acme')
+    expect(html).toContain('15.04.2026')
+    expect(html).toContain('127,50 €') // formatted fee
+  })
+
+  it('includes a Content-Security-Policy meta tag (locks down to inline CSS + data: images)', () => {
+    const html = buildPdfHtml(makePayload())
+    expect(html).toMatch(/Content-Security-Policy.*default-src 'none'/)
+  })
+
+  it('escapes user-controlled strings (XSS hardening)', () => {
+    const html = buildPdfHtml(
+      makePayload({
+        client: { id: 1, name: '<script>alert(1)</script>', rate_cent: 8500 },
+        sender: { name: '"><img>', address: '', taxId: '' }
+      })
+    )
+    expect(html).not.toContain('<script>alert(1)')
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+    expect(html).toContain('&quot;&gt;&lt;img&gt;')
+  })
+
+  it('falls back to indigo accent on malformed color input', () => {
+    const html = buildPdfHtml(makePayload({ accentColor: 'javascript:alert(1)' }))
+    expect(html).toContain('#4f46e5')
+    expect(html).not.toContain('javascript:')
+  })
+
+  it('omits the fee column when totals.feeCent is null', () => {
+    const html = buildPdfHtml(
+      makePayload({
+        client: { id: 1, name: 'Pro Bono', rate_cent: 0 },
+        rows: [
+          {
+            date: '15.04.2026',
+            startTime: '08:00',
+            stopTime: '09:00',
+            description: 'Help',
+            minutes: 60,
+            feeCent: null
+          }
+        ],
+        totals: { minutes: 60, feeCent: null }
+      })
+    )
+    expect(html).not.toContain('Honorar')
+    expect(html).not.toContain('€')
+  })
+
+  it('shows an empty-state row when there are no entries', () => {
+    const html = buildPdfHtml(makePayload({ rows: [], totals: { minutes: 0, feeCent: 0 } }))
+    expect(html).toContain('Keine Einträge im gewählten Zeitraum.')
+  })
+
+  it('embeds logo as a data URL when provided', () => {
+    const html = buildPdfHtml(makePayload({ logoDataUrl: 'data:image/png;base64,iVBORw0K' }))
+    expect(html).toContain('data:image/png;base64,iVBORw0K')
+    expect(html).toContain('class="logo"')
+  })
+
+  it('emits the rounding hint only when roundMinutes > 0', () => {
+    expect(buildPdfHtml(makePayload({ roundMinutes: 0 }))).not.toContain('gerundet')
+    expect(buildPdfHtml(makePayload({ roundMinutes: 15 }))).toContain('15 Minuten')
+  })
+})

--- a/src/main/pdf.ts
+++ b/src/main/pdf.ts
@@ -1,0 +1,413 @@
+/**
+ * PDF payload assembly + HTML template rendering.
+ *
+ * Pure functions — no Electron, no I/O. The hidden-window driver in
+ * `pdfWindow.ts` calls `buildPdfPayload()` to gather data and
+ * `buildPdfHtml()` to produce the self-contained HTML string that gets
+ * fed to `webContents.printToPDF()`.
+ *
+ * Why a string template instead of a third Vite renderer entry: the PDF
+ * doesn't need Tailwind, React, or hot-reload. Inline CSS keeps the
+ * artifact self-contained, eliminates a build-config knot (R5 in the
+ * v1.3 plan), and makes the output trivially snapshot-testable.
+ */
+import type Database from 'better-sqlite3'
+import { feeCent, formatEur, formatHoursMinutes, roundMinutes } from '../shared/currency'
+import type { Client, Entry, Settings } from '../shared/types'
+
+export interface PdfRequest {
+  clientId: number
+  /** ISO-date strings, inclusive. e.g. '2026-04-01' to '2026-04-30'. */
+  fromIso: string
+  toIso: string
+}
+
+export interface PdfRow {
+  date: string
+  startTime: string
+  stopTime: string
+  description: string
+  minutes: number
+  feeCent: number | null
+}
+
+export interface PdfPayload {
+  client: Pick<Client, 'id' | 'name' | 'rate_cent'>
+  /** Sender block: pulled from settings.company_name + pdf_sender_address. */
+  sender: { name: string; address: string; taxId: string }
+  /** ISO range echoed back for the header. */
+  fromIso: string
+  toIso: string
+  rows: PdfRow[]
+  totals: {
+    minutes: number
+    /** null when the client has no rate (rate_cent === 0). */
+    feeCent: number | null
+  }
+  accentColor: string
+  footerText: string
+  /** Logo as a `data:image/...;base64,...` URL or empty string. */
+  logoDataUrl: string
+  /** Rounding step in minutes; 0 = no rounding. */
+  roundMinutes: number
+  /** Used for the "erstellt am" footer line. */
+  generatedAtIso: string
+}
+
+const DATE_FMT = new Intl.DateTimeFormat('de-DE', {
+  day: '2-digit',
+  month: '2-digit',
+  year: 'numeric'
+})
+
+const TIME_FMT = new Intl.DateTimeFormat('de-DE', {
+  hour: '2-digit',
+  minute: '2-digit'
+})
+
+function formatDate(iso: string): string {
+  return DATE_FMT.format(new Date(iso))
+}
+
+function formatTime(iso: string): string {
+  return TIME_FMT.format(new Date(iso))
+}
+
+/**
+ * Read entries + client + settings from the DB and shape them into a
+ * fully-resolved PdfPayload. Pure with respect to the DB handle —
+ * doesn't write, doesn't touch the filesystem.
+ *
+ * The `logoDataUrl` is the caller's responsibility (loaded from
+ * `settings.pdf_logo_path` once and base64-encoded) so this stays sync
+ * and testable.
+ */
+export function buildPdfPayload(
+  db: Database.Database,
+  req: PdfRequest,
+  logoDataUrl: string,
+  generatedAtIso: string = new Date().toISOString()
+): PdfPayload {
+  const client = db
+    .prepare(`SELECT id, name, rate_cent FROM clients WHERE id = ?`)
+    .get(req.clientId) as Pick<Client, 'id' | 'name' | 'rate_cent'> | undefined
+  if (!client) {
+    throw new Error(`Kunde mit id=${req.clientId} nicht gefunden`)
+  }
+
+  const settingsRows = db.prepare(`SELECT key, value FROM settings`).all() as Array<{
+    key: string
+    value: string
+  }>
+  const settings = Object.fromEntries(
+    settingsRows.map((r) => [r.key, r.value])
+  ) as unknown as Settings
+
+  const roundStep = parseInt(settings.pdf_round_minutes ?? '0', 10) || 0
+  // Range is inclusive; `to` is the start of the day AFTER `toIso` so we
+  // capture entries that ended at 23:59 of the last day.
+  const fromTs = `${req.fromIso}T00:00:00.000Z`
+  const toExclusive = endOfDayIso(req.toIso)
+
+  const entries = db
+    .prepare(
+      `SELECT * FROM entries
+         WHERE client_id = ?
+           AND deleted_at IS NULL
+           AND stopped_at IS NOT NULL
+           AND started_at >= ?
+           AND started_at < ?
+         ORDER BY started_at ASC, id ASC`
+    )
+    .all(client.id, fromTs, toExclusive) as Entry[]
+
+  const rows: PdfRow[] = entries.map((e) => {
+    const start = new Date(e.started_at)
+    const stop = new Date(e.stopped_at as string)
+    const rawMin = Math.max(0, Math.round((stop.getTime() - start.getTime()) / 60000))
+    const minutes = roundMinutes(rawMin, roundStep)
+    const fee = client.rate_cent > 0 ? feeCent(minutes, client.rate_cent) : null
+    return {
+      date: formatDate(e.started_at),
+      startTime: formatTime(e.started_at),
+      stopTime: formatTime(e.stopped_at as string),
+      description: e.description ?? '',
+      minutes,
+      feeCent: fee
+    }
+  })
+
+  const totalMinutes = rows.reduce((sum, r) => sum + r.minutes, 0)
+  const totalFee = client.rate_cent > 0 ? rows.reduce((sum, r) => sum + (r.feeCent ?? 0), 0) : null
+
+  return {
+    client,
+    sender: {
+      name: settings.company_name ?? '',
+      address: settings.pdf_sender_address ?? '',
+      taxId: settings.pdf_tax_id ?? ''
+    },
+    fromIso: req.fromIso,
+    toIso: req.toIso,
+    rows,
+    totals: { minutes: totalMinutes, feeCent: totalFee },
+    accentColor: settings.pdf_accent_color || '#4f46e5',
+    footerText: settings.pdf_footer_text ?? '',
+    logoDataUrl,
+    roundMinutes: roundStep,
+    generatedAtIso
+  }
+}
+
+/** Inclusive end-of-day → exclusive next-day-start in ISO. */
+function endOfDayIso(dayIso: string): string {
+  const d = new Date(`${dayIso}T00:00:00.000Z`)
+  d.setUTCDate(d.getUTCDate() + 1)
+  return d.toISOString()
+}
+
+/**
+ * Escape user-controlled strings for safe interpolation into the HTML
+ * template. Matches the OWASP basic set; we never output user content
+ * into JS or attribute contexts (only text + a single style attribute
+ * for the accent color, which we restrict to `#RRGGBB` upstream).
+ */
+function esc(s: string): string {
+  return String(s ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+/** Validate `#RRGGBB` accent color and fall back to indigo on bad input. */
+function safeColor(color: string): string {
+  return /^#[0-9a-fA-F]{6}$/.test(color) ? color : '#4f46e5'
+}
+
+/**
+ * Produce a self-contained HTML document for the PDF. All CSS inline,
+ * all assets embedded as data: URLs. Designed for `pageSize: 'A4'`
+ * with `printBackground: true` and 2 cm margins on the printToPDF call
+ * (we don't repeat margins in CSS to avoid double-margins).
+ */
+export function buildPdfHtml(p: PdfPayload): string {
+  const accent = safeColor(p.accentColor)
+  const showFee = p.totals.feeCent !== null
+  const dateRange = `${formatDate(p.fromIso)} – ${formatDate(p.toIso)}`
+  const generated = formatDate(p.generatedAtIso)
+
+  const senderLines = p.sender.address
+    .split('\n')
+    .map((line) => esc(line.trim()))
+    .filter(Boolean)
+    .join('<br />')
+
+  const taxLine = p.sender.taxId ? `<div>Steuernr.: ${esc(p.sender.taxId)}</div>` : ''
+
+  const logoBlock = p.logoDataUrl
+    ? `<img src="${esc(p.logoDataUrl)}" alt="" class="logo" />`
+    : '<div class="logo-placeholder"></div>'
+
+  const tableRows = p.rows
+    .map(
+      (r) => `<tr>
+        <td class="col-date">${esc(r.date)}</td>
+        <td class="col-time">${esc(r.startTime)}</td>
+        <td class="col-time">${esc(r.stopTime)}</td>
+        <td class="col-desc">${esc(r.description)}</td>
+        <td class="col-dur">${esc(formatHoursMinutes(r.minutes))}</td>
+        ${showFee ? `<td class="col-fee">${esc(formatEur(r.feeCent ?? 0))}</td>` : ''}
+      </tr>`
+    )
+    .join('\n')
+
+  const emptyState =
+    p.rows.length === 0
+      ? `<tr class="empty"><td colspan="${showFee ? 6 : 5}">Keine Einträge im gewählten Zeitraum.</td></tr>`
+      : ''
+
+  const totalsRow = `<tr class="total">
+        <td colspan="${showFee ? 4 : 4}">Summe</td>
+        <td class="col-dur">${esc(formatHoursMinutes(p.totals.minutes))}</td>
+        ${showFee ? `<td class="col-fee">${esc(formatEur(p.totals.feeCent ?? 0))}</td>` : ''}
+      </tr>`
+
+  const roundingHint =
+    p.roundMinutes > 0
+      ? `<div class="rounding-hint">Stunden gerundet auf ${p.roundMinutes} Minuten.</div>`
+      : ''
+
+  const footer = p.footerText ? `<div class="footer-text">${esc(p.footerText)}</div>` : ''
+
+  return `<!doctype html>
+<html lang="de">
+<head>
+<meta charset="utf-8" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src data:; style-src 'unsafe-inline'" />
+<title>Stundennachweis</title>
+<style>
+  * { box-sizing: border-box; }
+  html, body {
+    margin: 0;
+    padding: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    color: #0f172a;
+    font-size: 10pt;
+    line-height: 1.45;
+  }
+  .page { padding: 0; }
+  header.doc-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 28px;
+  }
+  .logo { max-height: 60px; max-width: 180px; object-fit: contain; }
+  .logo-placeholder { width: 1px; height: 60px; }
+  .sender {
+    text-align: right;
+    font-size: 9pt;
+    color: #334155;
+  }
+  .sender .name { font-weight: 600; color: #0f172a; }
+  h1.doc-title {
+    font-size: 18pt;
+    font-weight: 600;
+    margin: 0 0 4px 0;
+    color: #0f172a;
+  }
+  .meta-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    margin-bottom: 18px;
+    border-bottom: 2px solid ${accent};
+    padding-bottom: 8px;
+  }
+  .recipient { font-size: 11pt; }
+  .recipient .label { font-size: 8pt; text-transform: uppercase; letter-spacing: 0.05em; color: #64748b; margin-bottom: 2px; }
+  .recipient .name { font-weight: 600; }
+  .range { font-size: 10pt; color: #334155; }
+  .range .label { font-size: 8pt; text-transform: uppercase; letter-spacing: 0.05em; color: #64748b; }
+  .range .value { font-weight: 600; color: #0f172a; }
+  table.entries {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 4px;
+  }
+  table.entries th {
+    background: ${accent};
+    color: #ffffff;
+    font-weight: 600;
+    text-align: left;
+    padding: 7px 8px;
+    font-size: 9pt;
+  }
+  table.entries td {
+    padding: 6px 8px;
+    border-bottom: 1px solid #e2e8f0;
+    vertical-align: top;
+    font-size: 10pt;
+  }
+  table.entries .col-date { white-space: nowrap; width: 76px; }
+  table.entries .col-time { white-space: nowrap; width: 52px; text-align: right; }
+  table.entries .col-desc { word-break: break-word; }
+  table.entries .col-dur { white-space: nowrap; text-align: right; width: 60px; font-variant-numeric: tabular-nums; }
+  table.entries .col-fee { white-space: nowrap; text-align: right; width: 84px; font-variant-numeric: tabular-nums; }
+  table.entries tr.total td {
+    border-top: 2px solid ${accent};
+    border-bottom: none;
+    font-weight: 700;
+    font-size: 11pt;
+    padding-top: 10px;
+  }
+  table.entries tr.empty td {
+    text-align: center;
+    color: #64748b;
+    padding: 24px 8px;
+    font-style: italic;
+  }
+  .rounding-hint { margin-top: 12px; font-size: 9pt; color: #64748b; font-style: italic; }
+  footer.doc-foot {
+    margin-top: 36px;
+    padding-top: 12px;
+    border-top: 1px solid #e2e8f0;
+    font-size: 8.5pt;
+    color: #64748b;
+  }
+  footer.doc-foot .footer-text { white-space: pre-wrap; margin-bottom: 6px; color: #475569; }
+  .signature-row {
+    margin-top: 48px;
+    display: flex;
+    justify-content: space-between;
+    gap: 48px;
+  }
+  .signature-row .sig {
+    flex: 1;
+    border-top: 1px solid #94a3b8;
+    padding-top: 4px;
+    font-size: 9pt;
+    color: #475569;
+    text-align: center;
+  }
+</style>
+</head>
+<body>
+  <div class="page">
+    <header class="doc-head">
+      ${logoBlock}
+      <div class="sender">
+        <div class="name">${esc(p.sender.name)}</div>
+        ${senderLines ? `<div>${senderLines}</div>` : ''}
+        ${taxLine}
+      </div>
+    </header>
+
+    <h1 class="doc-title">Stundennachweis</h1>
+
+    <div class="meta-row">
+      <div class="recipient">
+        <div class="label">Kunde</div>
+        <div class="name">${esc(p.client.name)}</div>
+      </div>
+      <div class="range">
+        <div class="label">Zeitraum</div>
+        <div class="value">${esc(dateRange)}</div>
+      </div>
+    </div>
+
+    <table class="entries">
+      <thead>
+        <tr>
+          <th class="col-date">Datum</th>
+          <th class="col-time">Von</th>
+          <th class="col-time">Bis</th>
+          <th class="col-desc">Tätigkeit</th>
+          <th class="col-dur">Dauer</th>
+          ${showFee ? '<th class="col-fee">Honorar</th>' : ''}
+        </tr>
+      </thead>
+      <tbody>
+        ${tableRows}
+        ${emptyState}
+        ${totalsRow}
+      </tbody>
+    </table>
+
+    ${roundingHint}
+
+    <div class="signature-row">
+      <div class="sig">Datum, Auftragnehmer</div>
+      <div class="sig">Datum, Auftraggeber</div>
+    </div>
+
+    <footer class="doc-foot">
+      ${footer}
+      <div>Erstellt am ${esc(generated)} mit TimeTrack.</div>
+    </footer>
+  </div>
+</body>
+</html>`
+}

--- a/src/main/pdfWindow.ts
+++ b/src/main/pdfWindow.ts
@@ -1,0 +1,88 @@
+/**
+ * Hidden-window PDF renderer.
+ *
+ * Spawns an offscreen `BrowserWindow`, loads a self-contained HTML
+ * string built by `buildPdfHtml()` via a one-shot temp file, calls
+ * `webContents.printToPDF()`, writes the buffer to disk, and tears the
+ * window down.
+ *
+ * Why a temp file instead of a `data:` URL: Electron's `loadURL` with
+ * data: URLs has historically had flaky behaviour around CSP and
+ * relative resource resolution. A `file://` URL to a temp HTML works
+ * everywhere and the file is always cleaned up.
+ *
+ * Why no `webSecurity: false`: the logo is embedded as a base64 data:
+ * URL inside the HTML before the window ever loads. The CSP meta tag
+ * inside the template (`default-src 'none'; img-src data:`) blocks
+ * any other network access by default — defence in depth even though
+ * we control the HTML.
+ */
+import { BrowserWindow } from 'electron'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { pathToFileURL } from 'url'
+
+export interface RenderPdfOptions {
+  /** Self-contained HTML string (from `buildPdfHtml`). */
+  html: string
+  /** A4 portrait by default — override only for tests. */
+  pageSize?: 'A4' | 'A3' | 'Letter'
+}
+
+const PRINT_TIMEOUT_MS = 15_000
+
+/**
+ * Render `opts.html` to a PDF buffer using an offscreen Chromium window.
+ * Throws on timeout or printToPDF failure. Always cleans up the temp
+ * file and the BrowserWindow, even on failure.
+ */
+export async function renderPdfBuffer(opts: RenderPdfOptions): Promise<Buffer> {
+  const tmpDir = mkdtempSync(join(tmpdir(), 'tt-pdf-'))
+  const htmlPath = join(tmpDir, 'document.html')
+  writeFileSync(htmlPath, opts.html, 'utf8')
+  const fileUrl = pathToFileURL(htmlPath).toString()
+
+  const win = new BrowserWindow({
+    show: false,
+    width: 794, // approximate A4 at 96 DPI
+    height: 1123,
+    webPreferences: {
+      sandbox: true,
+      contextIsolation: true,
+      nodeIntegration: false,
+      // We deliberately keep webSecurity ON. Logo is base64-embedded; no
+      // remote resources are needed.
+      webSecurity: true
+    }
+  })
+
+  try {
+    const loaded = win.loadURL(fileUrl)
+    const timer = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('PDF-Render Timeout (15 s)')), PRINT_TIMEOUT_MS)
+    )
+    await Promise.race([loaded, timer])
+
+    const buffer = await Promise.race([
+      win.webContents.printToPDF({
+        pageSize: opts.pageSize ?? 'A4',
+        printBackground: true,
+        margins: {
+          marginType: 'custom',
+          top: 0.79, // ~2 cm in inches
+          bottom: 0.79,
+          left: 0.79,
+          right: 0.79
+        },
+        landscape: false
+      }),
+      timer
+    ])
+
+    return buffer
+  } finally {
+    if (!win.isDestroyed()) win.destroy()
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -74,6 +74,17 @@ declare global {
       exporter: {
         json(): Promise<IpcResult<{ path: string; bytes: number }>>
       }
+      pdf: {
+        export(req: {
+          clientId: number
+          fromIso: string
+          toIso: string
+        }): Promise<IpcResult<{ path: string }>>
+      }
+      logo: {
+        set(): Promise<IpcResult<{ path: string }>>
+        clear(): Promise<IpcResult<void>>
+      }
     }
   }
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -107,6 +107,17 @@ const api = {
   exporter: {
     json: (): Promise<IpcResult<{ path: string; bytes: number }>> =>
       ipcRenderer.invoke('export:json')
+  },
+  pdf: {
+    export: (req: {
+      clientId: number
+      fromIso: string
+      toIso: string
+    }): Promise<IpcResult<{ path: string }>> => ipcRenderer.invoke('pdf:export', req)
+  },
+  logo: {
+    set: (): Promise<IpcResult<{ path: string }>> => ipcRenderer.invoke('logo:set'),
+    clear: (): Promise<IpcResult<void>> => ipcRenderer.invoke('logo:clear')
   }
 }
 

--- a/src/renderer/src/components/PdfExportModal.tsx
+++ b/src/renderer/src/components/PdfExportModal.tsx
@@ -1,0 +1,164 @@
+import { useEffect, useState } from 'react'
+import type { Client } from '../../../shared/types'
+import { Dialog } from './Dialog'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  /** Pre-fills client + range when opened from a CalendarView quick-filter. */
+  prefilledClientId?: number
+  prefilledRange?: { fromIso: string; toIso: string }
+}
+
+/**
+ * PDF-Stundennachweis modal (v1.3 PR C, issues #16 + #19).
+ *
+ * Lets the user pick a client + date range and triggers `pdf:export`,
+ * which in turn opens a Save-Dialog and writes the rendered A4 PDF.
+ *
+ * Quick-filter pills on `CalendarView` open this with `prefilledRange`
+ * already set, so the hero flow ("📄 Letzter Monat als PDF") is one
+ * click away from the actual save dialog.
+ */
+export function PdfExportModal(props: Props): React.JSX.Element {
+  const { open, onClose, prefilledClientId, prefilledRange } = props
+
+  const [clients, setClients] = useState<Client[]>([])
+  const [clientId, setClientId] = useState<number | null>(prefilledClientId ?? null)
+  const [fromIso, setFromIso] = useState(prefilledRange?.fromIso ?? '')
+  const [toIso, setToIso] = useState(prefilledRange?.toIso ?? '')
+  const [busy, setBusy] = useState(false)
+  const [statusMsg, setStatusMsg] = useState<string | null>(null)
+  const [statusKind, setStatusKind] = useState<'info' | 'error' | 'success'>('info')
+
+  // Load clients once when the dialog first opens.
+  useEffect(() => {
+    if (!open || clients.length > 0) return
+    void window.api.clients.getAll().then((res) => {
+      if (res.ok) {
+        setClients(res.data)
+        // If only one client and no pre-fill, auto-select it.
+        if (!prefilledClientId && res.data.length === 1) {
+          setClientId(res.data[0].id)
+        }
+      } else {
+        setStatusKind('error')
+        setStatusMsg(`Kunden laden fehlgeschlagen: ${res.error}`)
+      }
+    })
+  }, [open, clients.length, prefilledClientId])
+
+  async function handleExport(): Promise<void> {
+    if (clientId == null || !fromIso || !toIso) return
+    if (fromIso > toIso) {
+      setStatusKind('error')
+      setStatusMsg('Startdatum liegt nach dem Enddatum.')
+      return
+    }
+    setBusy(true)
+    setStatusMsg('PDF wird erstellt …')
+    setStatusKind('info')
+    const res = await window.api.pdf.export({ clientId, fromIso, toIso })
+    setBusy(false)
+    if (res.ok) {
+      setStatusKind('success')
+      setStatusMsg(`PDF gespeichert: ${res.data.path}`)
+    } else if (res.error === 'Export abgebrochen') {
+      setStatusKind('info')
+      setStatusMsg(null)
+    } else {
+      setStatusKind('error')
+      setStatusMsg(`Fehler: ${res.error}`)
+    }
+  }
+
+  const canExport = clientId != null && fromIso !== '' && toIso !== '' && !busy
+
+  return (
+    <Dialog open={open} onClose={onClose} title="Stundennachweis als PDF" widthClass="w-[520px]">
+      <div className="flex flex-col gap-4">
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="font-medium text-zinc-300">Kunde</span>
+          <select
+            value={clientId ?? ''}
+            onChange={(e) =>
+              setClientId(e.target.value === '' ? null : Number.parseInt(e.target.value, 10))
+            }
+            disabled={busy}
+            className="rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+          >
+            <option value="">— Kunde wählen —</option>
+            {clients.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+                {c.rate_cent > 0 ? ` (${(c.rate_cent / 100).toFixed(2)} €/h)` : ' (kein Tarif)'}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div className="grid grid-cols-2 gap-3">
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-medium text-zinc-300">Von</span>
+            <input
+              type="date"
+              value={fromIso}
+              onChange={(e) => setFromIso(e.target.value)}
+              disabled={busy}
+              className="rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-medium text-zinc-300">Bis</span>
+            <input
+              type="date"
+              value={toIso}
+              onChange={(e) => setToIso(e.target.value)}
+              disabled={busy}
+              className="rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+            />
+          </label>
+        </div>
+
+        {statusMsg && (
+          <div
+            className={
+              statusKind === 'error'
+                ? 'rounded-lg bg-red-900/40 px-3 py-2 text-sm text-red-200'
+                : statusKind === 'success'
+                  ? 'rounded-lg bg-emerald-900/40 px-3 py-2 text-sm text-emerald-200'
+                  : 'rounded-lg bg-zinc-800 px-3 py-2 text-sm text-zinc-300'
+            }
+            role={statusKind === 'error' ? 'alert' : 'status'}
+          >
+            {statusMsg}
+          </div>
+        )}
+
+        <div className="mt-2 flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={busy}
+            className="rounded-lg border border-zinc-700 bg-zinc-800 px-4 py-2 text-sm font-medium text-zinc-200 hover:bg-zinc-700 focus:outline-none focus:ring-2 focus:ring-zinc-500 disabled:opacity-50"
+          >
+            Schließen
+          </button>
+          <button
+            type="button"
+            onClick={() => void handleExport()}
+            disabled={!canExport}
+            className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-300 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {busy ? 'Erstelle …' : 'PDF speichern'}
+          </button>
+        </div>
+
+        <p className="text-xs text-zinc-500">
+          Vorlage anpassen unter{' '}
+          <span className="font-medium text-zinc-400">Einstellungen → PDF-Vorlage</span>.
+        </p>
+      </div>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/views/CalendarView.tsx
+++ b/src/renderer/src/views/CalendarView.tsx
@@ -14,6 +14,7 @@ import { getQuickRange, QUICK_RANGE_LABELS, type QuickRangeKind } from '../../..
 import { useEntriesStore } from '../store/entriesStore'
 import { useTimer } from '../hooks/useTimer'
 import { CalendarDrawer } from '../components/CalendarDrawer'
+import { PdfExportModal } from '../components/PdfExportModal'
 
 /**
  * Month-grid calendar view. 7×N rows, KW column on the left.
@@ -84,15 +85,13 @@ export default function CalendarView(): React.JSX.Element {
     setFocusDay(today)
   }, [])
 
-  /**
-   * Quick-filter pre-selects a date range for the upcoming PDF export modal
-   * (#21). v1.3 PR C wires this into the actual modal; for now we just log
-   * so the buttons are visible + interactable while the data layer lands.
-   */
+  // PDF export modal state — opened by the quick-filter pills with the
+  // selected range pre-filled (#21).
+  const [pdfRange, setPdfRange] = useState<{ fromIso: string; toIso: string } | null>(null)
+
   const onQuickRange = useCallback((kind: QuickRangeKind) => {
     const range = getQuickRange(kind, new Date())
-    // eslint-disable-next-line no-console
-    console.info('[v1.3] PDF quick-range selected:', kind, range)
+    setPdfRange({ fromIso: localDateKey(range.from), toIso: localDateKey(range.to) })
   }, [])
 
   // Keyboard navigation on the grid.
@@ -228,6 +227,13 @@ export default function CalendarView(): React.JSX.Element {
         entries={drawerEntries}
         clients={clients}
         onClose={() => setSelectedDay(null)}
+      />
+
+      <PdfExportModal
+        key={pdfRange ? `${pdfRange.fromIso}-${pdfRange.toIso}` : 'closed'}
+        open={pdfRange !== null}
+        prefilledRange={pdfRange ?? undefined}
+        onClose={() => setPdfRange(null)}
       />
     </div>
   )

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -115,6 +115,29 @@ export default function SettingsView(): React.JSX.Element {
     }
   }
 
+  async function pickLogo(): Promise<void> {
+    setStatusMsg('Logo wird gewählt …')
+    const res = await window.api.logo.set()
+    if (res.ok) {
+      setSettings((prev) => (prev ? { ...prev, pdf_logo_path: res.data.path } : prev))
+      setStatusMsg('Logo gespeichert.')
+    } else if (res.error === 'Auswahl abgebrochen') {
+      setStatusMsg(null)
+    } else {
+      setStatusMsg(`Logo-Fehler: ${res.error}`)
+    }
+  }
+
+  async function clearLogo(): Promise<void> {
+    const res = await window.api.logo.clear()
+    if (res.ok) {
+      setSettings((prev) => (prev ? { ...prev, pdf_logo_path: '' } : prev))
+      setStatusMsg('Logo entfernt.')
+    } else {
+      setStatusMsg(`Fehler: ${res.error}`)
+    }
+  }
+
   if (!settings || !paths) {
     return <div className="text-slate-400">Lade Einstellungen …</div>
   }
@@ -284,6 +307,87 @@ export default function SettingsView(): React.JSX.Element {
           <p className="mt-1 text-xs text-slate-500">
             Lesbares Format zum Backup oder zur Weiterverarbeitung. CSV/PDF folgen.
           </p>
+        </Row>
+      </Section>
+
+      {/* PDF-Vorlage (v1.3 PR C, issues #16 + #19) */}
+      <Section title="PDF-Vorlage">
+        <Row label="Logo" hint="PNG, JPG, SVG oder WebP, max. 1 MB.">
+          <div className="flex items-center gap-3">
+            {settings.pdf_logo_path ? (
+              <code className="flex-1 truncate rounded bg-slate-800 px-3 py-1.5 text-xs text-slate-300">
+                {settings.pdf_logo_path}
+              </code>
+            ) : (
+              <span className="flex-1 text-sm text-slate-500">Kein Logo gesetzt.</span>
+            )}
+            <button type="button" onClick={pickLogo} className={btnSecondaryClass}>
+              Logo wählen …
+            </button>
+            {settings.pdf_logo_path && (
+              <button type="button" onClick={clearLogo} className={btnSecondaryClass}>
+                Entfernen
+              </button>
+            )}
+          </div>
+        </Row>
+        <Row label="Absenderadresse" hint="Erscheint rechts oben im PDF.">
+          <textarea
+            rows={4}
+            value={settings.pdf_sender_address}
+            onChange={(e) => update('pdf_sender_address', e.target.value)}
+            placeholder={'Robin GmbH\nMusterstr. 1\n12345 Berlin'}
+            className={`${inputClass} resize-y font-sans`}
+          />
+        </Row>
+        <Row label="Steuernummer">
+          <input
+            type="text"
+            value={settings.pdf_tax_id}
+            onChange={(e) => update('pdf_tax_id', e.target.value)}
+            placeholder="DE123456789"
+            className={inputClass}
+          />
+        </Row>
+        <Row label="Akzentfarbe" hint="Tabellenkopf, Linien, Hervorhebungen.">
+          <div className="flex items-center gap-3">
+            <input
+              type="color"
+              value={
+                /^#[0-9a-fA-F]{6}$/.test(settings.pdf_accent_color)
+                  ? settings.pdf_accent_color
+                  : '#4f46e5'
+              }
+              onChange={(e) => update('pdf_accent_color', e.target.value)}
+              className="h-10 w-16 cursor-pointer rounded border border-slate-700 bg-slate-800"
+              aria-label="Akzentfarbe wählen"
+            />
+            <code className="rounded bg-slate-800 px-3 py-1.5 text-xs text-slate-300">
+              {settings.pdf_accent_color || '#4f46e5'}
+            </code>
+          </div>
+        </Row>
+        <Row label="Footer-Text" hint="Z. B. Bankverbindung oder Zahlungshinweis.">
+          <textarea
+            rows={3}
+            value={settings.pdf_footer_text}
+            onChange={(e) => update('pdf_footer_text', e.target.value)}
+            placeholder="Bitte überweisen Sie bis zum 15. des Folgemonats."
+            className={`${inputClass} resize-y font-sans`}
+          />
+        </Row>
+        <Row label="Stunden runden auf" hint="Auf Wunsch werden alle Einträge im PDF gerundet.">
+          <select
+            value={settings.pdf_round_minutes || '0'}
+            onChange={(e) => update('pdf_round_minutes', e.target.value)}
+            className={inputClass}
+          >
+            <option value="0">Keine Rundung</option>
+            <option value="5">5 Minuten</option>
+            <option value="10">10 Minuten</option>
+            <option value="15">15 Minuten</option>
+            <option value="30">30 Minuten</option>
+          </select>
         </Row>
       </Section>
 

--- a/src/shared/currency.test.ts
+++ b/src/shared/currency.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { feeCent, formatEur, roundMinutes, formatHoursMinutes } from './currency'
+
+describe('feeCent', () => {
+  it('returns 0 when rate is 0 or minutes are 0', () => {
+    expect(feeCent(60, 0)).toBe(0)
+    expect(feeCent(0, 8500)).toBe(0)
+  })
+
+  it('60 minutes at 85 EUR/h = 8500 cent', () => {
+    expect(feeCent(60, 8500)).toBe(8500)
+  })
+
+  it('30 minutes at 85 EUR/h = 4250 cent', () => {
+    expect(feeCent(30, 8500)).toBe(4250)
+  })
+
+  it('rounds half-up to the nearest cent (84 min × 85 EUR/h)', () => {
+    // (84/60) * 8500 = 11900 exactly — no rounding artifact here
+    expect(feeCent(84, 8500)).toBe(11900)
+    // 1 min at 85 EUR/h = 141.6666… cent → 142
+    expect(feeCent(1, 8500)).toBe(142)
+  })
+
+  it('handles tiny rates without losing pennies', () => {
+    // 7 min at 1 cent/h = 0.1166... → rounds to 0
+    expect(feeCent(7, 1)).toBe(0)
+    // 30 min at 1 cent/h = 0.5 → rounds half-up to 1
+    expect(feeCent(30, 1)).toBe(1)
+  })
+})
+
+describe('formatEur', () => {
+  it('formats common amounts in DE locale', () => {
+    expect(formatEur(0)).toBe('0,00 €')
+    expect(formatEur(50)).toBe('0,50 €')
+    expect(formatEur(123)).toBe('1,23 €')
+    expect(formatEur(8500)).toBe('85,00 €')
+  })
+
+  it('inserts thousand separators (dots in DE)', () => {
+    expect(formatEur(123456)).toBe('1.234,56 €')
+    expect(formatEur(1234567890)).toBe('12.345.678,90 €')
+  })
+
+  it('keeps two decimal places even for round amounts', () => {
+    expect(formatEur(10000)).toBe('100,00 €')
+  })
+
+  it('handles negative cents (refunds, corrections)', () => {
+    expect(formatEur(-123)).toBe('-1,23 €')
+  })
+})
+
+describe('roundMinutes', () => {
+  it('passes through unchanged when step is 0 or negative', () => {
+    expect(roundMinutes(83, 0)).toBe(83)
+    expect(roundMinutes(83, -5)).toBe(83)
+  })
+
+  it('rounds to 5-minute steps (half-up)', () => {
+    expect(roundMinutes(82, 5)).toBe(80)
+    expect(roundMinutes(83, 5)).toBe(85)
+    expect(roundMinutes(85, 5)).toBe(85)
+  })
+
+  it('rounds to 15-minute steps', () => {
+    expect(roundMinutes(7, 15)).toBe(0)
+    expect(roundMinutes(8, 15)).toBe(15)
+    expect(roundMinutes(22, 15)).toBe(15)
+    expect(roundMinutes(23, 15)).toBe(30)
+  })
+})
+
+describe('formatHoursMinutes', () => {
+  it('formats H:MM with two-digit minutes', () => {
+    expect(formatHoursMinutes(0)).toBe('0:00')
+    expect(formatHoursMinutes(5)).toBe('0:05')
+    expect(formatHoursMinutes(84)).toBe('1:24')
+    expect(formatHoursMinutes(600)).toBe('10:00')
+  })
+
+  it('handles negative durations', () => {
+    expect(formatHoursMinutes(-65)).toBe('-1:05')
+  })
+})

--- a/src/shared/currency.ts
+++ b/src/shared/currency.ts
@@ -1,0 +1,58 @@
+/**
+ * Currency formatting and integer-cent arithmetic for the PDF pipeline.
+ *
+ * Rationale: rates and fees are stored as integer cents (`clients.rate_cent`)
+ * to avoid float drift across the rate-times-minutes path. We never multiply
+ * floats — minutes × cents stay integral until the final display step.
+ */
+
+/**
+ * Compute fee in cents for `minutes` worked at `rateCent` per hour.
+ * Half-up rounding to the nearest cent (the format users expect on invoices).
+ *
+ * `Math.round` follows banker-style on .5 in some JS engines for negative
+ * numbers; we never have negatives here (rates >= 0, minutes >= 0), so
+ * standard half-up applies.
+ */
+export function feeCent(minutes: number, rateCent: number): number {
+  if (rateCent <= 0 || minutes <= 0) return 0
+  // (minutes / 60) * rateCent => fractional cents
+  return Math.round((minutes * rateCent) / 60)
+}
+
+/**
+ * Format an integer cent amount as a German currency string with a
+ * thousands separator and the EUR sign suffix. Matches the format users
+ * see on every invoice they receive in DE: "1.234,56 €".
+ */
+export function formatEur(cent: number): string {
+  const sign = cent < 0 ? '-' : ''
+  const abs = Math.abs(cent)
+  const euros = Math.floor(abs / 100).toString()
+  const remainder = (abs % 100).toString().padStart(2, '0')
+  // Insert thousand separators every 3 digits from the right.
+  const withDots = euros.replace(/\B(?=(\d{3})+(?!\d))/g, '.')
+  return `${sign}${withDots},${remainder} €`
+}
+
+/**
+ * Round a duration to a multiple of `step` minutes (half-up). Used by the
+ * PDF pipeline when `pdf_round_minutes` is non-zero. Returns the input
+ * unchanged when `step <= 0` (the "no rounding" sentinel).
+ */
+export function roundMinutes(minutes: number, step: number): number {
+  if (step <= 0) return minutes
+  return Math.round(minutes / step) * step
+}
+
+/**
+ * Format a minute count as `H:MM` (two-digit minutes). Used for entry rows
+ * and totals in the PDF. Examples: 84 → "1:24", 600 → "10:00", 5 → "0:05".
+ */
+export function formatHoursMinutes(minutes: number): string {
+  const sign = minutes < 0 ? '-' : ''
+  const abs = Math.abs(minutes)
+  const h = Math.floor(abs / 60)
+  const m = abs % 60
+  return `${sign}${h}:${m.toString().padStart(2, '0')}`
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -38,6 +38,15 @@ export interface Settings {
   language: string
   auto_start: string
   hotkey_toggle: string
+  // v1.3 PR A — PDF template settings (seeded by migration 004).
+  // All stored as strings in the key-value `settings` table; the renderer
+  // parses pdf_round_minutes back to a number when needed.
+  pdf_logo_path: string
+  pdf_sender_address: string
+  pdf_tax_id: string
+  pdf_accent_color: string
+  pdf_footer_text: string
+  pdf_round_minutes: string
 }
 
 export interface CreateClientInput {


### PR DESCRIPTION
## Summary

PR C of v1.3 — the PDF Hero. Closes #16 (PDF-Stundennachweis) and #19
(Settings-Vorlage). Continues directly after #43 (PR A — Stundensatz +
Quick-Filter) and #44 (PR B — Cross-Midnight + JSON-Export) in the v1.3
sequential merge plan.

## What ships

**Hero flow (1 click):** `Calendar → 📄 Letzter Monat als PDF (oder Quick-Filter-Pille)
→ Modal mit vorbelegtem Kunde + Zeitraum → "PDF speichern" → Save-Dialog →
A4-PDF auf der Platte`. The modal is reusable from anywhere with optional
pre-fill.

**The PDF itself:** German Stundennachweis layout — Logo links + Sender
rechts oben, Titel "Stundennachweis", Kunde + Zeitraum, Tabelle mit
Datum/Von/Bis/Tätigkeit/Dauer und optional Honorar-Spalte (nur wenn der
Kunde einen `rate_cent > 0` hat), Summenzeile, Signatur-Zeile, Footer.
Akzentfarbe wird durchgängig angewandt; Stundensummen können optional auf
5/10/15/30 min gerundet werden.

**Settings → PDF-Vorlage:** Logo (Datei-Picker, max. 1 MB; PNG/JPG/SVG/WebP),
Absenderadresse (Multiline), Steuernummer, Akzentfarbe (Color-Picker),
Footer-Text, Stunden-Rundung. Logo wird ins `userData` kopiert
(stabiler Pfad `pdf-logo.<ext>`), beim Rendern als base64 `data:` URL
in die HTML eingebettet.

**Currency helpers** (`src/shared/currency.ts`): integer-cent math
(`feeCent(min, rateCent) = round(min × rateCent / 60)`), DE-Format
(`1.234,56 €`), `formatHoursMinutes(min)` (`H:MM`, negative-safe),
`roundMinutes(min, step)` (half-up; `step <= 0` = passthrough). 14 tests.

## Architectural deviation from the original v1.3 plan

The plan called for a third Vite renderer entry (`src/renderer-pdf/`)
that would render a React template inside a hidden BrowserWindow. I
switched to an **HTML-string template** (`buildPdfHtml(payload)` returns
a self-contained doc that gets written to `os.tmpdir()` and loaded via
`file://`) for two reasons:

1. **R1 eliminated** — the plan worried about needing
   `webSecurity: false` to load the logo. By embedding the logo as a
   base64 `data:` URL, the PDF window keeps `webSecurity: true` AND a
   strict CSP meta tag (`default-src 'none'; img-src data:; style-src
   'unsafe-inline'`).
2. **R5 eliminated** — no Vite multi-entry build config gymnastics; the
   PDF code path doesn't need Tailwind, React, or hot-reload.

Trade-off: the template is plain TS/HTML strings, not JSX. Acceptable
because (a) the layout is simple and unlikely to need component reuse,
(b) the output is trivially snapshot-testable, and (c) we can swap to
React-on-renderer later without changing the IPC contract if the
template ever grows complex.

## Files

**New:**
- `src/shared/currency.ts` + `.test.ts` (14 tests)
- `src/main/pdf.ts` (`buildPdfPayload` + `buildPdfHtml`, pure)
- `src/main/pdf.test.ts` (8 unskipped + 10 DB-skipped pattern matches `jsonExport.test.ts`)
- `src/main/logo.ts` (file-storage helpers, max 1 MB, ext allow-list, `data:` URL renderer)
- `src/main/logo.test.ts` (8 tests, fully unskippable — operates on tmpdirs)
- `src/main/pdfWindow.ts` (hidden-window driver around `printToPDF`)
- `src/renderer/src/components/PdfExportModal.tsx`

**Modified:**
- `src/main/ipc.ts` — three new handlers: `pdf:export`, `logo:set`, `logo:clear`
- `src/preload/index.ts` + `index.d.ts` — `window.api.pdf.*` and `window.api.logo.*` namespaces
- `src/shared/types.ts` — `Settings` extended with `pdf_logo_path`, `pdf_sender_address`, `pdf_tax_id`, `pdf_accent_color`, `pdf_footer_text`, `pdf_round_minutes` (no migration needed; Migration 004 from PR A already seeded them and `settings:getAll` returns the full key-value bag)
- `src/renderer/src/views/CalendarView.tsx` — hero button + 3 quick-filter pills now actually open the modal with `prefilledRange`
- `src/renderer/src/views/SettingsView.tsx` — new "PDF-Vorlage" section between Daten and Über
- `CHANGELOG.md`

## Security notes

- **CSP:** `default-src 'none'; img-src data:; style-src 'unsafe-inline'` —
  no scripts allowed at all in the PDF window.
- **`webSecurity: true`** preserved (no relaxation).
- **HTML escaping:** all user-controlled strings (client name, sender,
  description, footer) flow through `esc()` before interpolation. Test
  coverage: an `<script>` payload in the client name renders as text.
- **Accent color:** validated against `^#[0-9a-fA-F]{6}$`, falls back to
  indigo on bad input. Test verifies a `javascript:` payload is dropped.
- **Logo size cap:** 1 MB (`MAX_LOGO_BYTES`), enforced in both
  `saveLogo()` and `readLogoAsDataUrl()`.
- **Logo extension allow-list:** PNG, JPG/JPEG, SVG, WebP. Anything else
  rejected at save time and ignored at read time.

## Quality gates

- `pnpm typecheck` — green
- `pnpm test` — **89 passed** | 43 skipped (was 59 passed; +30 from PR C:
  14 currency, 8 logo, 8 pdf-pure)
- `pnpm lint` — **21 errors** (baseline maintained, 0 new)
- `npx prettier --write` ran clean on all touched files

## Deferred to PR D (intentionally out of scope)

- **Icon assets** from `timetrack_icon_glass_final.svg` → `build/icon.png`
  + `resources/tray-running.png` + `resources/tray-stopped.png` (the SVG is
  in the working tree but not committed in this PR)
- **Live PDF preview iframe** in the Settings → PDF-Vorlage section
- **Drag-and-drop logo upload** (currently file-picker only)
- **Entry-count preview** in the export modal ("X Einträge, Y Stunden")
- **PDF smoke test** in CI (visual regression / bytes-non-zero check)
- **GitHub Actions v5** upgrade (#42)

## How to test

1. Pull `feat/v1.3-pr-c-pdf`, run `pnpm dev`
2. Settings → PDF-Vorlage → Logo wählen + Adresse + Steuernummer + Akzentfarbe
3. Kalender → "📄 Letzter Monat als PDF" oder eine Pille klicken
4. Modal: Kunde + Zeitraum sind vorbelegt → "PDF speichern"
5. Öffne das PDF — Layout, deutsche Datums-/Zahlenformatierung, Honorar-Spalte
   (nur bei Kunden mit Stundensatz), optionale Rundung
6. Wiederholen mit einem 0-€-Kunden → keine Honorar-Spalte, keine Total-Zeile-€

## Decision log

- HTML-string template > React renderer entry (see "Architectural deviation")
- Logo as base64 `data:` URL > `file://` reference (eliminates R1)
- 1 MB Logo-Cap > unbounded (PDF size, data: URL practicality)
- Modal `key={range}` > `useEffect` reset (avoids cascading-renders lint warning)
- Honorar-Spalte rate-based (`client.rate_cent > 0`) > entry-based — semantic
  match: "this client is billable", not "did this entry happen to bill"
