### PR TITLE
ci: bump pnpm/action-setup v4 -> v5 (Node 24)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           ref: ${{ inputs.tag || github.ref }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 10
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 10
 


### PR DESCRIPTION
**v1.4 PR A — Closes #41**

Bumps `pnpm/action-setup` from v4 to v5 in both workflows. v5 was released March 2026 and updates the action runtime from Node.js 20 to Node.js 24, resolving the upcoming GitHub Actions deprecation deadline (June 2026).

The app build toolchain (`actions/setup-node` -> `node-version: 22`) is unchanged — this only affects the action's own runtime.

**Changes:**
- `.github/workflows/release.yml` line 24
- `.github/workflows/test.yml` line 14

**Acceptance:**
- [x] Both workflows reference `pnpm/action-setup@v5`
- [x] CI run on this PR passes (test.yml)
- [x] No Node-20 deprecation annotations
- [ ] PDF smoke test still green on next release tag

**Risk:** very low. Rollback is a 1-line revert.

Plan: [.github/plan-v1.4.md](https://github.com/skoedr/time-tracking/blob/main/.github/plan-v1.4.md)