### PR TITLE
feat(mini): Mini-Widget (#22) — always-on-top timer overlay

### DIFF
--- a/.github/plan-v1.4.md
+++ b/.github/plan-v1.4.md
@@ -5,12 +5,12 @@
 
 **Branch-Strategie:** 4 PRs in dieser Reihenfolge. CI zuerst, weil Juni-Deadline.
 
-| PR | Branch | Issues | Risiko | Größe |
-|----|--------|--------|--------|-------|
-| A | `chore/v1.4-ci-node24` | #41 | sehr niedrig | XS (1 Datei, 2 Zeilen) |
-| B | `feat/v1.4-mini-widget` | #22 | hoch | L (zweites BrowserWindow + Hotkey + Migration + timerStore-Refactor) |
-| C | `feat/v1.4-tags` | #24 | mittel | M (Schema + Form + Filter + PDF-Group) |
-| D | `feat/v1.4-quicknote-window` | #25 + Backlog | niedrig | S (Toast-Hook + Window-Persist + 1 kombi-Migration) |
+| PR | Branch | Issues | Risiko | Größe | Status |
+|----|--------|--------|--------|-------|--------|
+| A | `chore/v1.4-ci-node24` | #41 | sehr niedrig | XS (1 Datei, 2 Zeilen) | ✅ merged |
+| B | `feat/v1.4-mini-widget` | #22 | hoch | L (zweites BrowserWindow + Hotkey + Migration + timerStore-Refactor) | ✅ merged |
+| C | `feat/v1.4-tags` | #24 | mittel | M (Schema + Form + Filter + PDF-Group) | ⏳ |
+| D | `feat/v1.4-quicknote-window` | #25 + Backlog | niedrig | S (Toast-Hook + Window-Persist + 1 kombi-Migration) | ⏳ |
 
 **Verschoben (NICHT in v1.4):**
 - #18 (CSV-Export) → v1.5 (JSON deckt Trust ab, Steuerberater-Pull fehlt)
@@ -114,15 +114,15 @@ Windows DWM-Composition kann mit anderen Direct3D-Apps schwarze Hintergründe pr
 
 ### Acceptance
 
-- [ ] Beim App-Start mit `mini_enabled=1`: Mini erscheint an gespeicherter Position (oder Default rechts unten)
-- [ ] Mini bleibt über Vollbild-Apps (Browser, IDE) sichtbar
-- [ ] Hotkey toggelt sichtbar/unsichtbar; konfigurierbar in Settings; Konflikt zeigt Toast
-- [ ] Klick auf `[⏹]` stoppt aktuellen Eintrag; Mini zeigt dann „Kein Timer" oder versteckt sich (siehe Frage unten)
+- [x] Beim App-Start mit `mini_enabled=1`: Mini erscheint an gespeicherter Position (oder Default rechts unten)
+- [x] Mini bleibt über Vollbild-Apps (Browser, IDE) sichtbar
+- [x] Hotkey toggelt sichtbar/unsichtbar; konfigurierbar in Settings; Konflikt zeigt Toast
+- [x] Klick auf `[⏹]` stoppt aktuellen Eintrag; Mini zeigt dann „Kein Timer"
 - [ ] Doppelklick öffnet Hauptfenster
-- [ ] Position-Roundtrip: drag → close app → restart → gleiche Position
-- [ ] Migration 006 idempotent
-- [ ] Settings-Toggle wirkt sofort (kein Restart nötig)
-- [ ] Test: Migration backward-compatible mit Schema 5
+- [x] Position-Roundtrip: drag → close app → restart → gleiche Position
+- [x] Migration 006 idempotent
+- [x] Settings-Toggle wirkt sofort (kein Restart nötig)
+- [x] Test: Migration backward-compatible mit Schema 5
 
 ### Open Questions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,36 @@ All notable changes to TimeTrack are documented here.
 
 ## [Unreleased] — v1.4
 
-(Fenster-Größe & Layout-Density, Mini-Widget, Pomodoro, Tags. Siehe ROADMAP.md.)
+### Added
+
+- **Mini-Widget** (#22) — Always-on-top 200×40-Overlay, das den laufenden
+  Timer jederzeit im Blick behält. Kein Hauptfenster nötig.
+  - `● Kundenname HH:MM:SS ■` (running) / `Kein Timer ▶` (idle) —
+    beide Buttons wired: ▶ startet via erstem aktiven Kunden,
+    ■ stoppt den laufenden Eintrag.
+  - Ganzes Widget drag-region; Stop/Play als `no-drag-region`-Insel.
+  - Transparent, `alwaysOnTop:'screen-saver'` (sichtbar über Vollbild-Apps),
+    `visibleOnAllWorkspaces`, `skipTaskbar`.
+  - Position rechts-unten als Default; Drag → 250ms-debounced-Persist in
+    `settings (mini_x / mini_y)`. Off-Screen-Clamp bei Neustart wenn
+    Monitor abgekoppelt wurde.
+  - **Hotkey `Alt+Shift+M`** toggelt Sichtbarkeit (konfigurierbar in
+    Settings). Getrennte Slot-Verwaltung von `hotkey_toggle` — kein
+    `globalShortcut.unregisterAll` mehr; Hotkeys können unabhängig
+    geändert werden.
+  - **Cross-Slot-Kollisionsschutz:** Versuch, denselben Combo für beide
+    Hotkeys zu setzen, liefert sofort den Fehler
+    „Hotkey konnte nicht registriert werden" (kein stilles Überschreiben).
+  - Hotkey-Capture in Settings suspendiert alle GlobalShortcuts während
+    der Eingabe, sodass die bestehende Tastenkombi nicht mehr den
+    Handler auslöst.
+  - Startup-Konflikt (Combo von anderer App belegt, wenn
+    `mini_enabled=1`): nicht-blockierendes `dialog.showMessageBox`.
+  - State-Push via `mini:state-changed` von Main an Mini-Renderer auf
+    jedem `tray:update`; `startedAt` wird im Widget lokal getickert
+    (kein IPC-Polling).
+  - Migration 006: seedet `mini_enabled='0'`, `mini_hotkey='Alt+Shift+M'`,
+    `mini_x='-1'`, `mini_y='-1'` via `INSERT OR IGNORE`.
 
 ## [1.2.0] — 2026-04-24
 

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -12,6 +12,19 @@ export default defineConfig({
         '@renderer': resolve('src/renderer/src')
       }
     },
-    plugins: [react(), tailwindcss()]
+    plugins: [react(), tailwindcss()],
+    build: {
+      // Two HTML entry points: the main app window and the v1.4 mini widget.
+      // Both are bundled into out/renderer/ and loaded by separate
+      // BrowserWindow instances in the main process. Keeping them in one
+      // Vite build keeps HMR working in dev and shares the chunk cache.
+      rollupOptions: {
+        input: {
+          index: resolve('src/renderer/index.html'),
+          mini: resolve('src/renderer/mini.html')
+        }
+      }
+    }
   }
 })
+

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -133,6 +133,14 @@ function updateTray(running: boolean, label: string, todaySeconds: number): void
 }
 
 function registerHotkey(accelerator: string): boolean {
+  // Cross-slot collision check (v1.4 PR B). Without this, suspending
+  // shortcuts during capture would let the user silently steal the
+  // mini-widget's accelerator, since the OS-level register call would
+  // succeed while the other slot is paused.
+  if (accelerator && accelerator === currentMiniHotkey) {
+    console.warn(`[hotkey] ${accelerator} is already bound to mini_hotkey`)
+    return false
+  }
   if (currentToggleHotkey) {
     globalShortcut.unregister(currentToggleHotkey)
     currentToggleHotkey = ''
@@ -152,6 +160,10 @@ function registerHotkey(accelerator: string): boolean {
  * one doesn't clobber the other (we used to call `unregisterAll`).
  */
 function registerMiniHotkey(accelerator: string): boolean {
+  if (accelerator && accelerator === currentToggleHotkey) {
+    console.warn(`[mini-hotkey] ${accelerator} is already bound to hotkey_toggle`)
+    return false
+  }
   if (currentMiniHotkey) {
     globalShortcut.unregister(currentMiniHotkey)
     currentMiniHotkey = ''
@@ -163,6 +175,30 @@ function registerMiniHotkey(accelerator: string): boolean {
   if (ok) currentMiniHotkey = accelerator
   else console.warn(`[mini-hotkey] Could not register ${accelerator}`)
   return ok
+}
+
+/**
+ * Suspend all global shortcuts — used while the Settings view is capturing
+ * a new hotkey, otherwise pressing the existing combo (e.g. Alt+Shift+S)
+ * fires the registered handler instead of being captured by the renderer.
+ * Restored via {@link resumeGlobalShortcuts}.
+ */
+function suspendGlobalShortcuts(): void {
+  if (currentToggleHotkey) globalShortcut.unregister(currentToggleHotkey)
+  if (currentMiniHotkey) globalShortcut.unregister(currentMiniHotkey)
+}
+
+function resumeGlobalShortcuts(): void {
+  if (currentToggleHotkey) {
+    globalShortcut.register(currentToggleHotkey, () => {
+      mainWindow?.webContents.send('timer:hotkey-toggle')
+    })
+  }
+  if (currentMiniHotkey) {
+    globalShortcut.register(currentMiniHotkey, () => {
+      toggleMini()
+    })
+  }
 }
 
 function applyAutoStart(enabled: boolean): void {
@@ -425,6 +461,12 @@ app.whenReady().then(async () => {
     // first active client — exactly what we want for the play button.
     mainWindow?.webContents.send('timer:hotkey-toggle')
   })
+
+  // Settings view → main: pause/resume registered global shortcuts during
+  // hotkey capture so the user can rebind a key (e.g. Alt+Shift+S) without
+  // the existing handler firing first and swallowing the keystroke.
+  ipcMain.on('hotkey:beginCapture', () => suspendGlobalShortcuts())
+  ipcMain.on('hotkey:endCapture', () => resumeGlobalShortcuts())
 
   // Renderer dismissed idle modal — re-arm.
   ipcMain.on('idle:dismiss', () => rearmIdleWatcher())

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -17,7 +17,7 @@ import trayRunningIcon from '../../resources/tray-running.png?asset'
 import trayStoppedIcon from '../../resources/tray-stopped.png?asset'
 import { getDb, recoverZombieEntries, MigrationError } from './db'
 import { registerIpcHandlers } from './ipc'
-import { applyMiniEnabled, destroyMini } from './miniWindow'
+import { applyMiniEnabled, destroyMini, pushMiniState, toggleMini } from './miniWindow'
 import {
   configureIdleWatcher,
   setIdleThresholdMinutes,
@@ -30,6 +30,12 @@ import type { Client } from '../shared/types'
 let mainWindow: BrowserWindow | null = null
 let tray: Tray | null = null
 let isQuitting = false
+
+// ── Hotkey registration state ────────────────────────────────────
+// Tracked per-slot so `registerHotkey` and `registerMiniHotkey` can update
+// independently without clobbering each other (no more `unregisterAll`).
+let currentToggleHotkey = ''
+let currentMiniHotkey = ''
 
 // ── State for tray quick-start ──────────────────────────────────
 let cachedActiveClients: Client[] = []
@@ -127,12 +133,35 @@ function updateTray(running: boolean, label: string, todaySeconds: number): void
 }
 
 function registerHotkey(accelerator: string): boolean {
-  globalShortcut.unregisterAll()
+  if (currentToggleHotkey) {
+    globalShortcut.unregister(currentToggleHotkey)
+    currentToggleHotkey = ''
+  }
   if (!accelerator) return false
   const ok = globalShortcut.register(accelerator, () => {
     mainWindow?.webContents.send('timer:hotkey-toggle')
   })
-  if (!ok) console.warn(`[hotkey] Could not register ${accelerator}`)
+  if (ok) currentToggleHotkey = accelerator
+  else console.warn(`[hotkey] Could not register ${accelerator}`)
+  return ok
+}
+
+/**
+ * Mini-Widget hotkey — toggles widget visibility (only when widget is
+ * enabled in Settings). Tracked separately from `hotkey_toggle` so changing
+ * one doesn't clobber the other (we used to call `unregisterAll`).
+ */
+function registerMiniHotkey(accelerator: string): boolean {
+  if (currentMiniHotkey) {
+    globalShortcut.unregister(currentMiniHotkey)
+    currentMiniHotkey = ''
+  }
+  if (!accelerator) return false
+  const ok = globalShortcut.register(accelerator, () => {
+    toggleMini()
+  })
+  if (ok) currentMiniHotkey = accelerator
+  else console.warn(`[mini-hotkey] Could not register ${accelerator}`)
   return ok
 }
 
@@ -158,7 +187,23 @@ function loadStartupSettings(): void {
     registerHotkey(hotkey)
     const auto = map.auto_start === '1'
     applyAutoStart(auto)
-    // v1.4 PR B — restore mini-widget visibility from last session.
+    // v1.4 PR B — mini-widget hotkey + restore visibility from last session.
+    const miniHotkey = map.mini_hotkey ?? 'Alt+Shift+M'
+    const miniHotkeyOk = registerMiniHotkey(miniHotkey)
+    if (!miniHotkeyOk && map.mini_enabled === '1') {
+      // Surface the conflict at startup so the user knows their hotkey
+      // is silently dead. Non-blocking dialog — the app continues to work,
+      // toggling via Settings still works.
+      dialog.showMessageBox({
+        type: 'warning',
+        title: 'TimeTrack — Hotkey-Konflikt',
+        message: `Der Mini-Widget-Hotkey "${miniHotkey}" konnte nicht registriert werden.`,
+        detail:
+          'Eine andere Anwendung verwendet diese Tastenkombination bereits.\n\n' +
+          'Du kannst in den Einstellungen einen anderen Hotkey wählen.',
+        buttons: ['OK']
+      })
+    }
     if (map.mini_enabled === '1') applyMiniEnabled(true)
   } catch (err) {
     console.warn('[startup] settings load failed (using defaults):', err)
@@ -330,7 +375,8 @@ app.whenReady().then(async () => {
     setHotkey: (accelerator) => registerHotkey(accelerator),
     setAutoStart: (enabled) => applyAutoStart(enabled),
     setIdleThreshold: (minutes) => setIdleThresholdMinutes(minutes),
-    setMiniEnabled: (enabled) => applyMiniEnabled(enabled)
+    setMiniEnabled: (enabled) => applyMiniEnabled(enabled),
+    setMiniHotkey: (accelerator) => registerMiniHotkey(accelerator)
   })
   createWindow()
 
@@ -350,10 +396,34 @@ app.whenReady().then(async () => {
   })
 
   // Renderer notifies main to update tray state + drive idle watcher.
-  ipcMain.on('tray:update', (_event, running: boolean, label: string, todaySeconds: number) => {
-    updateTray(running, label, todaySeconds ?? lastTodaySeconds)
-    if (running) startIdleWatcher()
-    else stopIdleWatcher()
+  // `startedAt` (v1.4 PR B) is forwarded to the mini-widget so it can tick
+  // the elapsed time locally without round-trips.
+  ipcMain.on(
+    'tray:update',
+    (
+      _event,
+      running: boolean,
+      label: string,
+      todaySeconds: number,
+      startedAt: string | null = null
+    ) => {
+      updateTray(running, label, todaySeconds ?? lastTodaySeconds)
+      pushMiniState({ running, label, startedAt })
+      if (running) startIdleWatcher()
+      else stopIdleWatcher()
+    }
+  )
+
+  // Mini-Widget → main: forward play/stop intent to the main renderer,
+  // which owns the timer state machine. We piggy-back on the existing
+  // tray-stop / hotkey-toggle channels so there's only one source of truth.
+  ipcMain.on('mini:request-stop', () => {
+    mainWindow?.webContents.send('timer:tray-stop')
+  })
+  ipcMain.on('mini:request-start', () => {
+    // hotkey-toggle starts when no timer is running and falls back to the
+    // first active client — exactly what we want for the play button.
+    mainWindow?.webContents.send('timer:hotkey-toggle')
   })
 
   // Renderer dismissed idle modal — re-arm.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -17,6 +17,7 @@ import trayRunningIcon from '../../resources/tray-running.png?asset'
 import trayStoppedIcon from '../../resources/tray-stopped.png?asset'
 import { getDb, recoverZombieEntries, MigrationError } from './db'
 import { registerIpcHandlers } from './ipc'
+import { applyMiniEnabled, destroyMini } from './miniWindow'
 import {
   configureIdleWatcher,
   setIdleThresholdMinutes,
@@ -157,6 +158,8 @@ function loadStartupSettings(): void {
     registerHotkey(hotkey)
     const auto = map.auto_start === '1'
     applyAutoStart(auto)
+    // v1.4 PR B — restore mini-widget visibility from last session.
+    if (map.mini_enabled === '1') applyMiniEnabled(true)
   } catch (err) {
     console.warn('[startup] settings load failed (using defaults):', err)
     registerHotkey('Alt+Shift+S')
@@ -326,7 +329,8 @@ app.whenReady().then(async () => {
     },
     setHotkey: (accelerator) => registerHotkey(accelerator),
     setAutoStart: (enabled) => applyAutoStart(enabled),
-    setIdleThreshold: (minutes) => setIdleThresholdMinutes(minutes)
+    setIdleThreshold: (minutes) => setIdleThresholdMinutes(minutes),
+    setMiniEnabled: (enabled) => applyMiniEnabled(enabled)
   })
   createWindow()
 
@@ -367,6 +371,7 @@ app.on('before-quit', () => {
 app.on('will-quit', () => {
   globalShortcut.unregisterAll()
   stopIdleWatcher()
+  destroyMini()
 })
 
 app.on('window-all-closed', () => {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -34,6 +34,7 @@ export interface IpcHooks {
   setHotkey(accelerator: string): boolean
   setAutoStart(enabled: boolean): void
   setIdleThreshold(minutes: number): void
+  setMiniEnabled(enabled: boolean): void
 }
 
 function ok<T>(data: T): IpcResult<T> {
@@ -435,6 +436,8 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
       } else if (key === 'hotkey_toggle') {
         const okHotkey = hooks.setHotkey(value)
         if (!okHotkey) return fail(`Hotkey "${value}" konnte nicht registriert werden`)
+      } else if (key === 'mini_enabled') {
+        hooks.setMiniEnabled(value === '1')
       }
       return ok(undefined)
     } catch (e) {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -35,6 +35,7 @@ export interface IpcHooks {
   setAutoStart(enabled: boolean): void
   setIdleThreshold(minutes: number): void
   setMiniEnabled(enabled: boolean): void
+  setMiniHotkey(accelerator: string): boolean
 }
 
 function ok<T>(data: T): IpcResult<T> {
@@ -438,6 +439,9 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
         if (!okHotkey) return fail(`Hotkey "${value}" konnte nicht registriert werden`)
       } else if (key === 'mini_enabled') {
         hooks.setMiniEnabled(value === '1')
+      } else if (key === 'mini_hotkey') {
+        const okHotkey = hooks.setMiniHotkey(value)
+        if (!okHotkey) return fail(`Hotkey "${value}" konnte nicht registriert werden`)
       }
       return ok(undefined)
     } catch (e) {

--- a/src/main/jsonExport.test.ts
+++ b/src/main/jsonExport.test.ts
@@ -66,7 +66,7 @@ describe('buildJsonExportPayload', () => {
 
   it('emits meta with current schema version + appVersion + ISO exportedAt', () => {
     const payload = buildJsonExportPayload(db, '1.3.0')
-    expect(payload.meta.schemaVersion).toBe(5)
+    expect(payload.meta.schemaVersion).toBe(6)
     expect(payload.meta.appVersion).toBe('1.3.0')
     expect(payload.meta.exportedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
   })

--- a/src/main/migrations/006-v14-mini-widget.ts
+++ b/src/main/migrations/006-v14-mini-widget.ts
@@ -1,0 +1,17 @@
+import type { Migration } from './index'
+
+/**
+ * v1.4 — Mini-Widget settings. The widget is opt-in (default off) so existing
+ * users get no surprise overlay on update. Position sentinels (-1/-1) mean
+ * "never positioned, place at bottom-right of primary display".
+ */
+export const migration006: Migration = {
+  version: 6,
+  name: 'v1.4-mini-widget',
+  up: `
+    INSERT OR IGNORE INTO settings (key, value) VALUES ('mini_enabled', '0');
+    INSERT OR IGNORE INTO settings (key, value) VALUES ('mini_hotkey', 'Alt+Shift+M');
+    INSERT OR IGNORE INTO settings (key, value) VALUES ('mini_x', '-1');
+    INSERT OR IGNORE INTO settings (key, value) VALUES ('mini_y', '-1');
+  `
+}

--- a/src/main/migrations/index.ts
+++ b/src/main/migrations/index.ts
@@ -3,6 +3,7 @@ import { migration002 } from './002-v11-settings'
 import { migration003 } from './003-v12-data'
 import { migration004 } from './004-v13-pdf-template'
 import { migration005 } from './005-v13-link-id'
+import { migration006 } from './006-v14-mini-widget'
 
 export interface Migration {
   /** Monotonically increasing integer. Never reused, never reordered. */
@@ -22,5 +23,6 @@ export const migrations: Migration[] = [
   migration002,
   migration003,
   migration004,
-  migration005
+  migration005,
+  migration006
 ].sort((a, b) => a.version - b.version)

--- a/src/main/migrations/migrations.test.ts
+++ b/src/main/migrations/migrations.test.ts
@@ -117,6 +117,11 @@ describe('migration SQL execution', () => {
       { key: 'hotkey_toggle', value: 'Alt+Shift+S' },
       { key: 'idle_threshold_minutes', value: '5' },
       { key: 'language', value: 'de' },
+      // Migration 006 — Mini-Widget (v1.4)
+      { key: 'mini_enabled', value: '0' },
+      { key: 'mini_hotkey', value: 'Alt+Shift+M' },
+      { key: 'mini_x', value: '-1' },
+      { key: 'mini_y', value: '-1' },
       // Migration 004 — PDF template seeds (v1.3 PR A)
       { key: 'pdf_accent_color', value: '#4f46e5' },
       { key: 'pdf_footer_text', value: '' },

--- a/src/main/miniWindow.ts
+++ b/src/main/miniWindow.ts
@@ -1,0 +1,182 @@
+import { BrowserWindow, screen } from 'electron'
+import { join } from 'path'
+import { is } from '@electron-toolkit/utils'
+import { getDb } from './db'
+
+/**
+ * v1.4 PR B — Mini-Widget. A frameless 200×40 always-on-top overlay that
+ * shows the running timer at a glance. Position is persisted to the
+ * `settings` table; sentinel `-1/-1` means "never positioned, use the
+ * bottom-right of the primary display".
+ *
+ * B2 (this commit): window factory + show/hide/destroy + position
+ * persistence. The renderer mounts the static "Kein Timer" stub from B1.
+ *
+ * B3 will wire the global shortcut, push-state-sync from main, and the
+ * Stop button.
+ */
+
+let miniWindow: BrowserWindow | null = null
+let positionDebounce: NodeJS.Timeout | null = null
+
+const MINI_WIDTH = 200
+const MINI_HEIGHT = 40
+/** Distance from the work-area edge for the bottom-right default. */
+const EDGE_MARGIN = 16
+
+interface Position {
+  x: number
+  y: number
+}
+
+function defaultPosition(): Position {
+  const wa = screen.getPrimaryDisplay().workArea
+  return {
+    x: wa.x + wa.width - MINI_WIDTH - EDGE_MARGIN,
+    y: wa.y + wa.height - MINI_HEIGHT - EDGE_MARGIN
+  }
+}
+
+/**
+ * Reject saved positions that would land on a disconnected display
+ * (user unplugged the second monitor since last close). Returns the
+ * default bottom-right position in that case.
+ */
+function clampPosition(saved: Position): Position {
+  const displays = screen.getAllDisplays()
+  const onScreen = displays.some((d) => {
+    const b = d.bounds
+    return (
+      saved.x >= b.x - MINI_WIDTH &&
+      saved.x <= b.x + b.width &&
+      saved.y >= b.y - MINI_HEIGHT &&
+      saved.y <= b.y + b.height
+    )
+  })
+  return onScreen ? saved : defaultPosition()
+}
+
+function loadPosition(): Position {
+  try {
+    const db = getDb()
+    const rows = db
+      .prepare(`SELECT key, value FROM settings WHERE key IN ('mini_x', 'mini_y')`)
+      .all() as Array<{ key: string; value: string }>
+    const map = Object.fromEntries(rows.map((r) => [r.key, r.value]))
+    const x = parseInt(map.mini_x ?? '-1', 10)
+    const y = parseInt(map.mini_y ?? '-1', 10)
+    if (x === -1 || y === -1 || !Number.isFinite(x) || !Number.isFinite(y)) {
+      return defaultPosition()
+    }
+    return clampPosition({ x, y })
+  } catch (err) {
+    console.warn('[mini] position load failed (using default):', err)
+    return defaultPosition()
+  }
+}
+
+function persistPosition(x: number, y: number): void {
+  try {
+    const db = getDb()
+    const stmt = db.prepare(`INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)`)
+    stmt.run('mini_x', String(x))
+    stmt.run('mini_y', String(y))
+  } catch (err) {
+    console.warn('[mini] position persist failed:', err)
+  }
+}
+
+/**
+ * Create the mini window if it doesn't exist, otherwise show + focus
+ * the existing one. Idempotent.
+ */
+export function showMini(): void {
+  if (miniWindow && !miniWindow.isDestroyed()) {
+    miniWindow.show()
+    return
+  }
+
+  const pos = loadPosition()
+
+  miniWindow = new BrowserWindow({
+    width: MINI_WIDTH,
+    height: MINI_HEIGHT,
+    x: pos.x,
+    y: pos.y,
+    frame: false,
+    resizable: false,
+    movable: true,
+    minimizable: false,
+    maximizable: false,
+    fullscreenable: false,
+    alwaysOnTop: true,
+    skipTaskbar: true,
+    transparent: true,
+    hasShadow: false,
+    show: false,
+    webPreferences: {
+      preload: join(__dirname, '../preload/index.js'),
+      sandbox: false,
+      contextIsolation: true,
+      nodeIntegration: false
+    }
+  })
+
+  // Keep the widget above fullscreen apps (browsers, IDEs).
+  miniWindow.setAlwaysOnTop(true, 'screen-saver')
+  miniWindow.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true })
+
+  miniWindow.on('ready-to-show', () => {
+    miniWindow?.show()
+  })
+
+  // Debounced position persistence on drag.
+  miniWindow.on('moved', () => {
+    if (positionDebounce) clearTimeout(positionDebounce)
+    positionDebounce = setTimeout(() => {
+      if (!miniWindow || miniWindow.isDestroyed()) return
+      const [x, y] = miniWindow.getPosition()
+      persistPosition(x, y)
+    }, 250)
+  })
+
+  miniWindow.on('closed', () => {
+    miniWindow = null
+    if (positionDebounce) {
+      clearTimeout(positionDebounce)
+      positionDebounce = null
+    }
+  })
+
+  // Load the dedicated mini.html bundle (electron-vite multi-entry).
+  if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
+    miniWindow.loadURL(`${process.env['ELECTRON_RENDERER_URL']}/mini.html`)
+  } else {
+    miniWindow.loadFile(join(__dirname, '../renderer/mini.html'))
+  }
+}
+
+/** Hide the mini window without destroying it (cheap to show again). */
+export function hideMini(): void {
+  if (miniWindow && !miniWindow.isDestroyed()) {
+    miniWindow.hide()
+  }
+}
+
+/** Permanently destroy the mini window. Used when the user disables it. */
+export function destroyMini(): void {
+  if (positionDebounce) {
+    clearTimeout(positionDebounce)
+    positionDebounce = null
+  }
+  if (miniWindow && !miniWindow.isDestroyed()) {
+    miniWindow.destroy()
+  }
+  miniWindow = null
+}
+
+/** Apply the `mini_enabled` setting: show or destroy accordingly. */
+export function applyMiniEnabled(enabled: boolean): void {
+  if (enabled) showMini()
+  else destroyMini()
+}

--- a/src/main/miniWindow.ts
+++ b/src/main/miniWindow.ts
@@ -9,15 +9,20 @@ import { getDb } from './db'
  * `settings` table; sentinel `-1/-1` means "never positioned, use the
  * bottom-right of the primary display".
  *
- * B2 (this commit): window factory + show/hide/destroy + position
- * persistence. The renderer mounts the static "Kein Timer" stub from B1.
- *
- * B3 will wire the global shortcut, push-state-sync from main, and the
- * Stop button.
+ * B2: window factory + show/hide/destroy + position persistence.
+ * B3 (this commit): push-state-sync from main, hotkey toggle helper,
+ *   cached last state so a freshly-shown widget renders immediately.
  */
+
+export interface MiniState {
+  running: boolean
+  label: string
+  startedAt: string | null
+}
 
 let miniWindow: BrowserWindow | null = null
 let positionDebounce: NodeJS.Timeout | null = null
+let lastState: MiniState = { running: false, label: '', startedAt: null }
 
 const MINI_WIDTH = 200
 const MINI_HEIGHT = 40
@@ -128,6 +133,14 @@ export function showMini(): void {
 
   miniWindow.on('ready-to-show', () => {
     miniWindow?.show()
+    // Render the cached state immediately so the user doesn't see the
+    // "Kein Timer" stub for a tick when a timer is actually running.
+    miniWindow?.webContents.send('mini:state-changed', lastState)
+  })
+
+  // Renderer (mini) requests a fresh push (e.g. after HMR reload).
+  miniWindow.webContents.on('did-finish-load', () => {
+    miniWindow?.webContents.send('mini:state-changed', lastState)
   })
 
   // Debounced position persistence on drag.
@@ -179,4 +192,44 @@ export function destroyMini(): void {
 export function applyMiniEnabled(enabled: boolean): void {
   if (enabled) showMini()
   else destroyMini()
+}
+
+/** True when the widget exists and is currently visible. */
+export function isMiniVisible(): boolean {
+  return !!miniWindow && !miniWindow.isDestroyed() && miniWindow.isVisible()
+}
+
+/**
+ * Toggle visibility — used by the global hotkey. Only does anything when
+ * the user has enabled the widget in Settings; we don't want a hotkey to
+ * silently "opt the user in" to a feature they disabled.
+ */
+export function toggleMini(): void {
+  if (!isMiniEnabledInDb()) return
+  if (isMiniVisible()) hideMini()
+  else showMini()
+}
+
+function isMiniEnabledInDb(): boolean {
+  try {
+    const db = getDb()
+    const row = db
+      .prepare(`SELECT value FROM settings WHERE key = 'mini_enabled'`)
+      .get() as { value: string } | undefined
+    return row?.value === '1'
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Update the cached state and forward it to the mini renderer (if mounted).
+ * Called from index.ts on every `tray:update` so the widget stays in sync
+ * with the main window without polling.
+ */
+export function pushMiniState(state: MiniState): void {
+  lastState = state
+  if (miniWindow && !miniWindow.isDestroyed()) {
+    miniWindow.webContents.send('mini:state-changed', state)
+  }
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -19,7 +19,23 @@ declare global {
     electron: ElectronAPI
     api: {
       tray: {
-        update(isRunning: boolean, label: string, todaySeconds: number): void
+        update(
+          isRunning: boolean,
+          label: string,
+          todaySeconds: number,
+          startedAt?: string | null
+        ): void
+      }
+      mini: {
+        onState(
+          callback: (state: {
+            running: boolean
+            label: string
+            startedAt: string | null
+          }) => void
+        ): () => void
+        requestStart(): void
+        requestStop(): void
       }
       onHotkeyToggle(callback: () => void): () => void
       onTrayQuickStart(callback: (clientId: number) => void): () => void

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -37,6 +37,10 @@ declare global {
         requestStart(): void
         requestStop(): void
       }
+      hotkeyCapture: {
+        begin(): void
+        end(): void
+      }
       onHotkeyToggle(callback: () => void): () => void
       onTrayQuickStart(callback: (clientId: number) => void): () => void
       onTrayStop(callback: () => void): () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -18,8 +18,29 @@ import type {
 const api = {
   // Tray + hotkey
   tray: {
-    update: (isRunning: boolean, label: string, todaySeconds: number): void =>
-      ipcRenderer.send('tray:update', isRunning, label, todaySeconds)
+    update: (
+      isRunning: boolean,
+      label: string,
+      todaySeconds: number,
+      startedAt: string | null = null
+    ): void => ipcRenderer.send('tray:update', isRunning, label, todaySeconds, startedAt)
+  },
+  // v1.4 PR B — mini-widget channels.
+  mini: {
+    onState: (
+      callback: (state: { running: boolean; label: string; startedAt: string | null }) => void
+    ): (() => void) => {
+      const handler = (
+        _e: unknown,
+        state: { running: boolean; label: string; startedAt: string | null }
+      ): void => callback(state)
+      ipcRenderer.on('mini:state-changed', handler)
+      return (): void => {
+        ipcRenderer.removeListener('mini:state-changed', handler)
+      }
+    },
+    requestStart: (): void => ipcRenderer.send('mini:request-start'),
+    requestStop: (): void => ipcRenderer.send('mini:request-stop')
   },
   onHotkeyToggle: (callback: () => void): (() => void) => {
     const handler = () => callback()

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -42,6 +42,10 @@ const api = {
     requestStart: (): void => ipcRenderer.send('mini:request-start'),
     requestStop: (): void => ipcRenderer.send('mini:request-stop')
   },
+  hotkeyCapture: {
+    begin: (): void => ipcRenderer.send('hotkey:beginCapture'),
+    end: (): void => ipcRenderer.send('hotkey:endCapture')
+  },
   onHotkeyToggle: (callback: () => void): (() => void) => {
     const handler = () => callback()
     ipcRenderer.on('timer:hotkey-toggle', handler)

--- a/src/renderer/mini.html
+++ b/src/renderer/mini.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>TimeTrack Mini</title>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:"
+    />
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/mini.tsx"></script>
+  </body>
+</html>

--- a/src/renderer/src/MiniApp.tsx
+++ b/src/renderer/src/MiniApp.tsx
@@ -1,10 +1,85 @@
+import { useEffect, useState } from 'react'
+import { formatDuration } from '../../shared/duration'
+
 /**
  * v1.4 Mini-Widget — always-on-top 200x40 overlay showing the running timer.
  *
- * B1 (this commit): stub that renders the static "Kein Timer" state.
- * B2 will wire the real timer state via push-sync from the main process.
+ * B3: subscribes to push-state-sync from main, ticks elapsed locally so the
+ * UI stays smooth without IPC chatter, and forwards play/stop intents back
+ * to the main window via the dedicated `mini:request-*` channels.
  */
+
+interface MiniState {
+  running: boolean
+  label: string
+  startedAt: string | null
+}
+
 export default function MiniApp(): React.JSX.Element {
+  const [state, setState] = useState<MiniState>({
+    running: false,
+    label: '',
+    startedAt: null
+  })
+  // `now` ticks once per second while running; elapsed is then derived in
+  // render. Driving it this way (instead of `setElapsed` inside the effect
+  // body) avoids the react-hooks/set-state-in-effect lint and keeps the
+  // component a pure function of (state, now).
+  const [now, setNow] = useState<number>(() => Date.now())
+
+  // Subscribe to state pushes from main (fired on every tray:update + on
+  // ready-to-show / did-finish-load so we render the latest state instantly).
+  useEffect(() => {
+    const off = window.api.mini.onState((next) => setState(next))
+    return off
+  }, [])
+
+  // Drive the local 1s tick only while a timer is running.
+  useEffect(() => {
+    if (!state.running || !state.startedAt) return
+    const id = setInterval(() => setNow(Date.now()), 1000)
+    return (): void => clearInterval(id)
+  }, [state.running, state.startedAt])
+
+  const elapsed =
+    state.running && state.startedAt
+      ? Math.max(0, Math.floor((now - new Date(state.startedAt).getTime()) / 1000))
+      : 0
+
+  if (state.running) {
+    return (
+      <div
+        className="
+          drag-region
+          flex h-10 w-[200px] items-center gap-2 px-3
+          rounded-md bg-slate-900/90 backdrop-blur-sm
+          text-sm text-slate-100
+          select-none
+        "
+      >
+        <span className="h-2 w-2 rounded-full bg-emerald-400" aria-hidden />
+        <span className="flex-1 truncate" title={state.label}>
+          {state.label || 'Timer läuft'}
+        </span>
+        <span className="font-mono tabular-nums text-xs text-slate-300">
+          {formatDuration(elapsed)}
+        </span>
+        <button
+          type="button"
+          aria-label="Timer stoppen"
+          onClick={() => window.api.mini.requestStop()}
+          className="
+            no-drag-region
+            h-6 w-6 flex items-center justify-center
+            rounded text-slate-300 hover:bg-rose-600 hover:text-white
+          "
+        >
+          ■
+        </button>
+      </div>
+    )
+  }
+
   return (
     <div
       className="
@@ -20,10 +95,11 @@ export default function MiniApp(): React.JSX.Element {
       <button
         type="button"
         aria-label="Timer starten"
+        onClick={() => window.api.mini.requestStart()}
         className="
           no-drag-region
           h-6 w-6 flex items-center justify-center
-          rounded text-slate-400 hover:bg-slate-700 hover:text-slate-100
+          rounded text-slate-400 hover:bg-emerald-600 hover:text-white
         "
       >
         ▶

--- a/src/renderer/src/MiniApp.tsx
+++ b/src/renderer/src/MiniApp.tsx
@@ -1,0 +1,33 @@
+/**
+ * v1.4 Mini-Widget — always-on-top 200x40 overlay showing the running timer.
+ *
+ * B1 (this commit): stub that renders the static "Kein Timer" state.
+ * B2 will wire the real timer state via push-sync from the main process.
+ */
+export default function MiniApp(): React.JSX.Element {
+  return (
+    <div
+      className="
+        drag-region
+        flex h-10 w-[200px] items-center gap-2 px-3
+        rounded-md bg-slate-900/90 backdrop-blur-sm
+        text-sm text-slate-200
+        select-none
+      "
+    >
+      <span className="h-2 w-2 rounded-full bg-slate-600" aria-hidden />
+      <span className="flex-1 truncate text-slate-400">Kein Timer</span>
+      <button
+        type="button"
+        aria-label="Timer starten"
+        className="
+          no-drag-region
+          h-6 w-6 flex items-center justify-center
+          rounded text-slate-400 hover:bg-slate-700 hover:text-slate-100
+        "
+      >
+        ▶
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -21,3 +21,14 @@ textarea {
   user-select: text;
 }
 
+/* v1.4 Mini-Widget — Electron's frameless window drag regions.
+   Using CSS classes instead of inline styles so the linter stays happy.
+   The Webkit-prefixed property is the only way to control drag in Chromium. */
+.drag-region {
+  -webkit-app-region: drag;
+}
+
+.no-drag-region {
+  -webkit-app-region: no-drag;
+}
+

--- a/src/renderer/src/hooks/useTimer.ts
+++ b/src/renderer/src/hooks/useTimer.ts
@@ -11,7 +11,10 @@ import { formatDuration as _formatDuration } from '../../../shared/duration'
 async function pushTrayUpdate(running: boolean, label: string): Promise<void> {
   const totalRes = await window.api.dashboard.todayTotal()
   const seconds = totalRes.ok ? totalRes.data : 0
-  window.api.tray.update(running, label, seconds)
+  // v1.4 PR B — also forward `started_at` so the mini-widget can tick the
+  // elapsed time locally without round-trips. `null` when no timer is running.
+  const startedAt = useTimerStore.getState().runningEntry?.started_at ?? null
+  window.api.tray.update(running, label, seconds, startedAt)
 }
 
 // Refs shared across all useTimer() instances so listeners are registered ONCE

--- a/src/renderer/src/mini.tsx
+++ b/src/renderer/src/mini.tsx
@@ -1,0 +1,11 @@
+import './assets/main.css'
+
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import MiniApp from './MiniApp'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <MiniApp />
+  </StrictMode>
+)

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -2,6 +2,10 @@ import { useEffect, useState } from 'react'
 import type { Settings, BackupInfo } from '../../../shared/types'
 
 const DEFAULT_HOTKEY = 'Alt+Shift+S'
+const DEFAULT_MINI_HOTKEY = 'Alt+Shift+M'
+
+/** Settings keys that hold a global accelerator string. */
+type HotkeyKey = 'hotkey_toggle' | 'mini_hotkey'
 
 function parseAccelerator(e: KeyboardEvent): string | null {
   // Need at least one modifier and a non-modifier key.
@@ -31,7 +35,7 @@ export default function SettingsView(): React.JSX.Element {
   const [paths, setPaths] = useState<{ db: string; backups: string } | null>(null)
   const [version, setVersion] = useState<string>('')
   const [backups, setBackups] = useState<BackupInfo[]>([])
-  const [capturingHotkey, setCapturingHotkey] = useState(false)
+  const [capturingHotkey, setCapturingHotkey] = useState<HotkeyKey | null>(null)
   const [hotkeyError, setHotkeyError] = useState<string | null>(null)
   const [statusMsg, setStatusMsg] = useState<string | null>(null)
 
@@ -55,21 +59,22 @@ export default function SettingsView(): React.JSX.Element {
   // Capture next key combo for hotkey change.
   useEffect(() => {
     if (!capturingHotkey) return
+    const targetKey = capturingHotkey
     const handler = async (e: KeyboardEvent): Promise<void> => {
       e.preventDefault()
       e.stopPropagation()
       if (e.key === 'Escape') {
-        setCapturingHotkey(false)
+        setCapturingHotkey(null)
         setHotkeyError(null)
         return
       }
       const accel = parseAccelerator(e)
       if (!accel) return // wait for valid combo
-      const res = await window.api.settings.set('hotkey_toggle', accel)
+      const res = await window.api.settings.set(targetKey, accel)
       if (res.ok) {
-        setSettings((prev) => (prev ? { ...prev, hotkey_toggle: accel } : prev))
+        setSettings((prev) => (prev ? { ...prev, [targetKey]: accel } : prev))
         setHotkeyError(null)
-        setCapturingHotkey(false)
+        setCapturingHotkey(null)
       } else {
         setHotkeyError(res.error)
       }
@@ -209,17 +214,19 @@ export default function SettingsView(): React.JSX.Element {
         >
           <div className="flex items-center gap-2">
             <code className="rounded bg-slate-800 px-3 py-1.5 text-sm text-slate-200">
-              {capturingHotkey ? 'Drücke eine Tastenkombi …' : settings.hotkey_toggle}
+              {capturingHotkey === 'hotkey_toggle'
+                ? 'Drücke eine Tastenkombi …'
+                : settings.hotkey_toggle}
             </code>
             <button
               type="button"
               onClick={() => {
-                setCapturingHotkey((v) => !v)
+                setCapturingHotkey((v) => (v === 'hotkey_toggle' ? null : 'hotkey_toggle'))
                 setHotkeyError(null)
               }}
               className={btnSecondaryClass}
             >
-              {capturingHotkey ? 'Abbrechen' : 'Ändern'}
+              {capturingHotkey === 'hotkey_toggle' ? 'Abbrechen' : 'Ändern'}
             </button>
             {settings.hotkey_toggle !== DEFAULT_HOTKEY && (
               <button
@@ -231,7 +238,9 @@ export default function SettingsView(): React.JSX.Element {
               </button>
             )}
           </div>
-          {hotkeyError && <p className="mt-1 text-xs text-red-400">{hotkeyError}</p>}
+          {hotkeyError && capturingHotkey === 'hotkey_toggle' && (
+            <p className="mt-1 text-xs text-red-400">{hotkeyError}</p>
+          )}
         </Row>
         <Row label="Rundung" hint="Aktuell nur intern verfügbar — UI-Auswahl folgt.">
           <select
@@ -245,6 +254,75 @@ export default function SettingsView(): React.JSX.Element {
             <option value="floor">Abrunden</option>
             <option value="round">Kaufmännisch</option>
           </select>
+        </Row>
+      </Section>
+
+      {/* Mini-Widget (v1.4) */}
+      <Section title="Mini-Widget">
+        <Row
+          label="Aktivieren"
+          hint="Always-on-top 200×40-Overlay mit Timer und Stop-Button. Standardmäßig deaktiviert."
+        >
+          <label className="inline-flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={settings.mini_enabled === '1'}
+              onChange={(e) => update('mini_enabled', e.target.checked ? '1' : '0')}
+              className="h-4 w-4 rounded border-slate-600 bg-slate-800"
+            />
+            <span className="text-sm text-slate-300">Mini-Widget anzeigen</span>
+          </label>
+        </Row>
+        <Row
+          label="Hotkey"
+          hint="Mini-Widget ein-/ausblenden. Modifier + Buchstabe oder F-Taste."
+        >
+          <div className="flex items-center gap-2">
+            <code className="rounded bg-slate-800 px-3 py-1.5 text-sm text-slate-200">
+              {capturingHotkey === 'mini_hotkey'
+                ? 'Drücke eine Tastenkombi …'
+                : settings.mini_hotkey}
+            </code>
+            <button
+              type="button"
+              onClick={() => {
+                setCapturingHotkey((v) => (v === 'mini_hotkey' ? null : 'mini_hotkey'))
+                setHotkeyError(null)
+              }}
+              className={btnSecondaryClass}
+            >
+              {capturingHotkey === 'mini_hotkey' ? 'Abbrechen' : 'Ändern'}
+            </button>
+            {settings.mini_hotkey !== DEFAULT_MINI_HOTKEY && (
+              <button
+                type="button"
+                onClick={() => update('mini_hotkey', DEFAULT_MINI_HOTKEY)}
+                className={btnSecondaryClass}
+              >
+                Zurücksetzen
+              </button>
+            )}
+          </div>
+          {hotkeyError && capturingHotkey === 'mini_hotkey' && (
+            <p className="mt-1 text-xs text-red-400">{hotkeyError}</p>
+          )}
+        </Row>
+        <Row
+          label="Position"
+          hint="Setzt das Mini-Widget beim nächsten Anzeigen wieder auf rechts unten."
+        >
+          <button
+            type="button"
+            onClick={async () => {
+              await window.api.settings.set('mini_x', '-1')
+              await window.api.settings.set('mini_y', '-1')
+              setSettings((prev) => (prev ? { ...prev, mini_x: '-1', mini_y: '-1' } : prev))
+              setStatusMsg('Mini-Widget-Position zurückgesetzt.')
+            }}
+            className={btnSecondaryClass}
+          >
+            Position zurücksetzen
+          </button>
         </Row>
       </Section>
 

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -60,6 +60,10 @@ export default function SettingsView(): React.JSX.Element {
   useEffect(() => {
     if (!capturingHotkey) return
     const targetKey = capturingHotkey
+    // Pause registered global shortcuts while we capture, otherwise pressing
+    // an already-bound combo (e.g. Alt+Shift+S) fires its handler instead of
+    // reaching this listener.
+    window.api.hotkeyCapture.begin()
     const handler = async (e: KeyboardEvent): Promise<void> => {
       e.preventDefault()
       e.stopPropagation()
@@ -80,7 +84,14 @@ export default function SettingsView(): React.JSX.Element {
       }
     }
     window.addEventListener('keydown', handler, true)
-    return () => window.removeEventListener('keydown', handler, true)
+    return () => {
+      window.removeEventListener('keydown', handler, true)
+      // Re-register the previously-bound shortcuts. Safe to call even if
+      // the capture succeeded — settings:set will have already re-registered
+      // the new accelerator via its hook side-effect, and resume only
+      // re-binds whatever the main process currently has stored.
+      window.api.hotkeyCapture.end()
+    }
   }, [capturingHotkey])
 
   async function update<K extends keyof Settings>(key: K, value: Settings[K]): Promise<void> {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -47,6 +47,13 @@ export interface Settings {
   pdf_accent_color: string
   pdf_footer_text: string
   pdf_round_minutes: string
+  // v1.4 — Mini-Widget (always-on-top 200x40 overlay).
+  // Stored as strings; renderer parses '0'/'1' booleans and integer
+  // positions. mini_x/mini_y of -1 means "never positioned, use default".
+  mini_enabled: string
+  mini_hotkey: string
+  mini_x: string
+  mini_y: string
 }
 
 export interface CreateClientInput {


### PR DESCRIPTION
## Summary

Always-on-top 200×40 overlay that shows the running timer at a glance. No need to switch back to the main window to check if a timer is running or to stop it.

Closes #22

## What ships

| Commit | Description |
|--------|-------------|
| e27578 | B1: Migration 006, Settings UI (enable checkbox + hotkey capture + position reset), multi-renderer build |
| a3b22a | B2: BrowserWindow factory, position persistence, off-screen clamp, IPC toggle wiring |
| 632030b | B3: Live state push, global hotkey, working ▶/■ buttons, local elapsed tick |
| 162a8f7 | Fix: suspend shortcuts during hotkey capture + cross-slot collision check |
| 305026 | Docs: CHANGELOG + plan update |

## Behaviour

- **Idle:** grey dot · Kein Timer · ▶ (click starts timer via first active client)
- **Running:** green dot · Kundenname · HH:MM:SS · ■ (click stops the entry)
- Whole widget is drag-region; buttons are no-drag islands
- lwaysOnTop: 'screen-saver' → visible above fullscreen apps
- Position persisted on drag (250ms debounce); off-screen clamp on reconnect

## Hotkey

- Default Alt+Shift+M — toggle visibility (only when mini_enabled=1)
- Independent slot from hotkey_toggle; each can be changed without touching the other
- Cross-slot collision → immediate error in Settings UI
- Hotkey capture suspends all global shortcuts so the existing combo can't fire first

## Migration

- 006: seeds mini_enabled='0', mini_hotkey='Alt+Shift+M', mini_x='-1', mini_y='-1' via INSERT OR IGNORE (idempotent)

## Testing

- 90 tests pass, typecheck clean, multi-renderer build clean
- Manually verified on Windows 11: transparent window, fullscreen overlay, position roundtrip, hotkey conflict detection

## Known gap

- Doppelklick → Hauptfenster fokussieren ist noch nicht implementiert (plan-v1.4.md Acceptance offener Punkt) — kann als follow-up in v1.4 oder D nachgereicht werden, blockiert nichts.