### PR TITLE
feat(tags): Tags pro Eintrag (#24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,28 @@ All notable changes to TimeTrack are documented here.
     (kein IPC-Polling).
   - Migration 006: seedet `mini_enabled='0'`, `mini_hotkey='Alt+Shift+M'`,
     `mini_x='-1'`, `mini_y='-1'` via `INSERT OR IGNORE`.
+- **Tags pro Eintrag** (#24) — Freitextlabels, die jedem Zeitblock zugeordnet
+  werden können und für schnelles Filtern, Auswerten und PDF-Gruppierung dienen.
+  - Tags werden als `,tag1,tag2,` in einer neuen `entries.tags`-Spalte
+    (Migration 007, `NOT NULL DEFAULT ''`) gespeichert; exakte LIKE-Suche
+    via `,tag,` verhindert Fehlpositive.
+  - **`TagInput`-Komponente** — Chip-Liste + Texteingabe in einem Feld.
+    Tab/Enter/Komma übernimmt den getippten Tag, Backspace entfernt den
+    letzten Chip. Autocomplete-Dropdown mit Vorschlägen aus den letzten
+    90 Tagen (freq-sortiert via `tags:recent` IPC). Deterministische
+    8-Farben-Chip-Palette (Tag-Name → `charCode % 8`). Validierung:
+    Regex `[a-z0-9._-]`, max. 32 Zeichen/Tag, max. 10 Tags/Eintrag.
+  - **`EntryEditForm`** — `TagInput` integriert; `tags`-Feld wird beim
+    Anlegen und Bearbeiten via `entries:create` / `entries:update` gespeichert.
+  - **Kalender-Drawer-Filter** — Jeder Eintrag zeigt Farb-Chips für seine
+    Tags. Über die Tag-Pille-Bar im Header lässt sich die Tagesansicht
+    auf einen einzelnen Tag filtern (Toggle); Zähler wechselt zu
+    „X von Y Einträge" und der Leer-State zeigt „Keine Einträge mit Tag #x".
+  - **PDF-Gruppen-Export** — Neue Checkbox „Nach Tag gruppieren" im
+    PDF-Export-Modal. Bei aktiver Gruppierung rendert das PDF Abschnitte
+    pro Tag (alphabetisch sortiert), jeder mit eigenem Subtotal-Bereich;
+    Einträge ohne Tag landen in der Gruppe „Ohne Tag" (immer am Ende).
+    Silent Fallback auf Flat-Layout wenn kein Eintrag im Zeitraum Tags hat.
 
 ## [1.2.0] — 2026-04-24
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -211,7 +211,7 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
       const err = validateManualEntry(db, input)
       if (err) return fail(err)
       const segments = splitAtMidnight(new Date(input.started_at), new Date(input.stopped_at))
-      const insertedRow = insertEntrySegments(db, input, segments)
+      const insertedRow = insertEntrySegments(db, input, segments, input.tags ?? '')
       return ok(insertedRow)
     } catch (e) {
       return fail(e)
@@ -239,7 +239,7 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
         } else {
           db.prepare(`DELETE FROM entries WHERE id = ?`).run(input.id)
         }
-        return insertEntrySegments(db, input, segments)
+        return insertEntrySegments(db, input, segments, input.tags ?? '')
       })
       const row = tx()
       return ok(row)
@@ -280,6 +280,38 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
       db.prepare(`UPDATE entries SET deleted_at = NULL WHERE id = ?`).run(id)
       const row = db.prepare(`SELECT * FROM entries WHERE id = ?`).get(id) as Entry
       return ok(row)
+    } catch (e) {
+      return fail(e)
+    }
+  })
+
+  /**
+   * Return distinct tag names used in entries from the last 90 days,
+   * sorted by frequency descending. Used for TagInput autocomplete.
+   * Only non-empty tags columns are considered.
+   */
+  ipcMain.handle('tags:recent', (): IpcResult<string[]> => {
+    try {
+      const cutoff = new Date(Date.now() - 90 * 24 * 3600 * 1000).toISOString()
+      const rows = db
+        .prepare(
+          `SELECT tags FROM entries
+           WHERE deleted_at IS NULL
+             AND tags != ''
+             AND started_at >= ?`
+        )
+        .all(cutoff) as Array<{ tags: string }>
+
+      const freq = new Map<string, number>()
+      for (const { tags } of rows) {
+        for (const tag of tags.split(',').filter((t: string) => t.length > 0)) {
+          freq.set(tag, (freq.get(tag) ?? 0) + 1)
+        }
+      }
+      const sorted = [...freq.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .map(([tag]) => tag)
+      return ok(sorted)
     } catch (e) {
       return fail(e)
     }
@@ -714,13 +746,14 @@ function validateManualEntry(
 function insertEntrySegments(
   db: ReturnType<typeof getDb>,
   input: { client_id: number; description: string },
-  segments: Array<{ start: Date; stop: Date }>
+  segments: Array<{ start: Date; stop: Date }>,
+  tags = ''
 ): Entry {
   const linkId = segments.length > 1 ? randomUUID() : null
   const description = input.description.trim()
   const insertStmt = db.prepare(
-    `INSERT INTO entries (client_id, description, started_at, stopped_at, heartbeat_at, rounded_min, link_id)
-     VALUES (?, ?, ?, ?, ?, ?, ?)`
+    `INSERT INTO entries (client_id, description, started_at, stopped_at, heartbeat_at, rounded_min, link_id, tags)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
   )
   const tx = db.transaction((): Entry => {
     let firstId = 0
@@ -734,7 +767,8 @@ function insertEntrySegments(
         stoppedAt,
         stoppedAt,
         Math.round((seg.stop.getTime() - seg.start.getTime()) / 60000),
-        linkId
+        linkId,
+        tags
       )
       if (firstId === 0) firstId = Number(info.lastInsertRowid)
     }

--- a/src/main/jsonExport.test.ts
+++ b/src/main/jsonExport.test.ts
@@ -66,7 +66,7 @@ describe('buildJsonExportPayload', () => {
 
   it('emits meta with current schema version + appVersion + ISO exportedAt', () => {
     const payload = buildJsonExportPayload(db, '1.3.0')
-    expect(payload.meta.schemaVersion).toBe(6)
+    expect(payload.meta.schemaVersion).toBe(7)
     expect(payload.meta.appVersion).toBe('1.3.0')
     expect(payload.meta.exportedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
   })

--- a/src/main/migrations/007-v14-tags.ts
+++ b/src/main/migrations/007-v14-tags.ts
@@ -1,0 +1,18 @@
+import type { Migration } from './index'
+
+/**
+ * v1.4 PR C — Tags per entry.
+ *
+ * Adds a `tags` column to `entries`. Format: comma-separated lowercase
+ * tokens with leading and trailing commas when non-empty, e.g. `,bug,ux,`
+ * so that LIKE `%,bug,%` gives an exact substring match without false
+ * positives for prefixes/suffixes (e.g. `bugfix` won't match `bug`).
+ *
+ * Empty string (NOT NULL) is the default so existing rows behave as
+ * "untagged" without any backfill.
+ */
+export const migration007: Migration = {
+  version: 7,
+  name: 'v1.4-tags',
+  up: `ALTER TABLE entries ADD COLUMN tags TEXT NOT NULL DEFAULT ''`
+}

--- a/src/main/migrations/index.ts
+++ b/src/main/migrations/index.ts
@@ -4,6 +4,7 @@ import { migration003 } from './003-v12-data'
 import { migration004 } from './004-v13-pdf-template'
 import { migration005 } from './005-v13-link-id'
 import { migration006 } from './006-v14-mini-widget'
+import { migration007 } from './007-v14-tags'
 
 export interface Migration {
   /** Monotonically increasing integer. Never reused, never reordered. */
@@ -24,5 +25,6 @@ export const migrations: Migration[] = [
   migration003,
   migration004,
   migration005,
-  migration006
+  migration006,
+  migration007
 ].sort((a, b) => a.version - b.version)

--- a/src/main/migrations/migrations.test.ts
+++ b/src/main/migrations/migrations.test.ts
@@ -355,6 +355,76 @@ describe('migration SQL execution', () => {
     expect(linked).toHaveLength(2)
   })
 
+  it('migration 006 seeds mini-widget settings keys', () => {
+    applyAll()
+    const keys = (
+      db.prepare("SELECT key FROM settings WHERE key LIKE 'mini_%' ORDER BY key").all() as Array<{
+        key: string
+      }>
+    ).map((r) => r.key)
+    expect(keys).toEqual(['mini_enabled', 'mini_hotkey', 'mini_x', 'mini_y'])
+    const enabled = db.prepare("SELECT value FROM settings WHERE key='mini_enabled'").get() as {
+      value: string
+    }
+    expect(enabled.value).toBe('0')
+  })
+
+  it('migration 007 adds entries.tags column (NOT NULL, default empty string)', () => {
+    applyAll()
+    const cols = db.prepare(`PRAGMA table_info(entries)`).all() as Array<{
+      name: string
+      notnull: number
+      dflt_value: string | null
+      type: string
+    }>
+    const tagsCol = cols.find((c) => c.name === 'tags')
+    expect(tagsCol).toBeDefined()
+    expect(tagsCol?.notnull).toBe(1)
+    expect(tagsCol?.dflt_value).toBe("''")
+    expect(tagsCol?.type.toUpperCase()).toBe('TEXT')
+  })
+
+  it('migration 007 — existing entries have empty tags by default', () => {
+    applyAll()
+    db.prepare(`INSERT INTO clients (id, name) VALUES (1, 'Acme')`).run()
+    db.prepare(
+      `INSERT INTO entries (client_id, started_at, stopped_at)
+       VALUES (1, '2026-05-01T08:00:00Z', '2026-05-01T09:00:00Z')`
+    ).run()
+    const row = db.prepare('SELECT tags FROM entries').get() as { tags: string }
+    expect(row.tags).toBe('')
+  })
+
+  it('migration 007 — tags column stores comma-delimited values', () => {
+    applyAll()
+    db.prepare(`INSERT INTO clients (id, name) VALUES (1, 'Acme')`).run()
+    db.prepare(
+      `INSERT INTO entries (client_id, started_at, stopped_at, tags)
+       VALUES (1, '2026-05-01T08:00:00Z', '2026-05-01T09:00:00Z', ',bug,ux,')`
+    ).run()
+    const row = db.prepare('SELECT tags FROM entries').get() as { tags: string }
+    expect(row.tags).toBe(',bug,ux,')
+  })
+
+  it('migration 007 — LIKE search finds exact tag match without false positives', () => {
+    applyAll()
+    db.prepare(`INSERT INTO clients (id, name) VALUES (1, 'Acme')`).run()
+    db.prepare(
+      `INSERT INTO entries (client_id, started_at, stopped_at, tags)
+       VALUES (1, '2026-05-01T08:00:00Z', '2026-05-01T09:00:00Z', ',bugfix,ux,')`
+    ).run()
+    db.prepare(
+      `INSERT INTO entries (client_id, started_at, stopped_at, tags)
+       VALUES (1, '2026-05-02T08:00:00Z', '2026-05-02T09:00:00Z', ',bug,feature,')`
+    ).run()
+    // Searching for 'bug' should only match the second row, not 'bugfix'
+    const rows = db
+      .prepare(`SELECT id FROM entries WHERE tags LIKE '%,bug,%' ORDER BY id`)
+      .all() as Array<{ id: number }>
+    expect(rows).toHaveLength(1)
+    expect(rows[0].id).toBe(2)
+  })
+
   it('rolls back migration on SQL failure (transactional)', () => {
     applyAll()
     const beforeCount = db

--- a/src/main/pdf.test.ts
+++ b/src/main/pdf.test.ts
@@ -262,6 +262,7 @@ describe('buildPdfHtml', () => {
       logoDataUrl: '',
       roundMinutes: 0,
       generatedAtIso: '2026-04-24T12:00:00.000Z',
+      groups: null,
       ...overrides
     }
   }

--- a/src/main/pdf.ts
+++ b/src/main/pdf.ts
@@ -13,6 +13,7 @@
  */
 import type Database from 'better-sqlite3'
 import { feeCent, formatEur, formatHoursMinutes, roundMinutes } from '../shared/currency'
+import { deserializeTags } from '../shared/tags'
 import type { Client, Entry, Settings } from '../shared/types'
 
 export interface PdfRequest {
@@ -27,6 +28,13 @@ export interface PdfRequest {
    * looks like an unfinished template. Toggled per-export from the modal.
    */
   includeSignatures?: boolean
+  /**
+   * Group rows by tag in the rendered PDF. Each distinct tag gets its
+   * own section with a subtotal. Entries without any tag appear under
+   * "Ohne Tag" at the end. Falls back to flat layout when no entry has
+   * a tag (silent fallback). Default false.
+   */
+  groupByTag?: boolean
 }
 
 export interface PdfRow {
@@ -36,6 +44,16 @@ export interface PdfRow {
   description: string
   minutes: number
   feeCent: number | null
+  /** Raw serialized tags string from the DB column (`,bug,ux,` format). Optional — only needed for `groupByTag`. */
+  tags?: string
+}
+
+/** One group when `groupByTag` is true. tag='' means "Ohne Tag". */
+export interface PdfGroup {
+  tag: string
+  rows: PdfRow[]
+  totalMinutes: number
+  totalFeeCent: number | null
 }
 
 export interface PdfPayload {
@@ -65,6 +83,11 @@ export interface PdfPayload {
   includeSignatures?: boolean
   /** Used for the "erstellt am" footer line. */
   generatedAtIso: string
+  /**
+   * When non-null, rows are organised into tag-groups for the HTML
+   * renderer. null = flat layout (default). Empty `tag` = "Ohne Tag".
+   */
+  groups: PdfGroup[] | null
 }
 
 const DATE_FMT = new Intl.DateTimeFormat('de-DE', {
@@ -195,12 +218,45 @@ export function buildPdfPayload(
       stopTime,
       description: e.description ?? '',
       minutes,
-      feeCent: fee
+      feeCent: fee,
+      tags: e.tags ?? ''
     }
   })
 
   const totalMinutes = rows.reduce((sum, r) => sum + r.minutes, 0)
   const totalFee = client.rate_cent > 0 ? rows.reduce((sum, r) => sum + (r.feeCent ?? 0), 0) : null
+
+  // Build tag groups when requested AND at least one row has tags.
+  let groups: PdfGroup[] | null = null
+  if (req.groupByTag && rows.some((r) => r.tags && r.tags !== '')) {
+    const groupMap = new Map<string, PdfRow[]>()
+    for (const row of rows) {
+      const rowTags = deserializeTags(row.tags ?? '')
+      if (rowTags.length === 0) {
+        const bucket = groupMap.get('') ?? []
+        bucket.push(row)
+        groupMap.set('', bucket)
+      } else {
+        for (const tag of rowTags) {
+          const bucket = groupMap.get(tag) ?? []
+          bucket.push(row)
+          groupMap.set(tag, bucket)
+        }
+      }
+    }
+    // Sort: named tags alphabetically, then '' (Ohne Tag) last.
+    const sortedKeys = [...groupMap.keys()].sort((a, b) => {
+      if (a === '') return 1
+      if (b === '') return -1
+      return a.localeCompare(b)
+    })
+    groups = sortedKeys.map((tag) => {
+      const groupRows = groupMap.get(tag)!
+      const gMinutes = groupRows.reduce((s, r) => s + r.minutes, 0)
+      const gFee = client.rate_cent > 0 ? groupRows.reduce((s, r) => s + (r.feeCent ?? 0), 0) : null
+      return { tag, rows: groupRows, totalMinutes: gMinutes, totalFeeCent: gFee }
+    })
+  }
 
   return {
     client,
@@ -218,7 +274,8 @@ export function buildPdfPayload(
     logoDataUrl,
     roundMinutes: roundStep,
     includeSignatures: req.includeSignatures === true,
-    generatedAtIso
+    generatedAtIso,
+    groups
   }
 }
 
@@ -273,9 +330,10 @@ export function buildPdfHtml(p: PdfPayload): string {
     ? `<img src="${esc(p.logoDataUrl)}" alt="" class="logo" />`
     : '<div class="logo-placeholder"></div>'
 
-  const tableRows = p.rows
-    .map(
-      (r) => `<tr>
+  function renderRows(rows: PdfRow[]): string {
+    return rows
+      .map(
+        (r) => `<tr>
         <td class="col-date">${esc(r.date)}</td>
         <td class="col-time">${esc(r.startTime)}</td>
         <td class="col-time">${esc(r.stopTime)}</td>
@@ -283,19 +341,51 @@ export function buildPdfHtml(p: PdfPayload): string {
         <td class="col-dur">${esc(formatHoursMinutes(r.minutes))}</td>
         ${showFee ? `<td class="col-fee">${esc(formatEur(r.feeCent ?? 0))}</td>` : ''}
       </tr>`
-    )
-    .join('\n')
+      )
+      .join('\n')
+  }
 
-  const emptyState =
-    p.rows.length === 0
-      ? `<tr class="empty"><td colspan="${showFee ? 6 : 5}">Keine Einträge im gewählten Zeitraum.</td></tr>`
-      : ''
+  let tableBody: string
+  if (p.groups !== null && p.groups.length > 0) {
+    // Grouped layout: each tag gets a group-header row + data rows + subtotal.
+    const groupSections = p.groups
+      .map((g) => {
+        const label = g.tag ? `#${esc(g.tag)}` : 'Ohne Tag'
+        const subtotalFee = showFee
+          ? `<td class="col-fee">${esc(formatEur(g.totalFeeCent ?? 0))}</td>`
+          : ''
+        return `<tr class="group-header">
+          <td colspan="${showFee ? 6 : 5}" class="col-group">${label}</td>
+        </tr>
+        ${renderRows(g.rows)}
+        <tr class="subtotal">
+          <td colspan="${showFee ? 4 : 4}">Zwischensumme ${label}</td>
+          <td class="col-dur">${esc(formatHoursMinutes(g.totalMinutes))}</td>
+          ${subtotalFee}
+        </tr>`
+      })
+      .join('\n')
 
-  const totalsRow = `<tr class="total">
+    const totalsRowGrouped = `<tr class="total">
+        <td colspan="${showFee ? 4 : 4}">Gesamtsumme</td>
+        <td class="col-dur">${esc(formatHoursMinutes(p.totals.minutes))}</td>
+        ${showFee ? `<td class="col-fee">${esc(formatEur(p.totals.feeCent ?? 0))}</td>` : ''}
+      </tr>`
+
+    tableBody = groupSections + '\n' + totalsRowGrouped
+  } else {
+    const tableRows = renderRows(p.rows)
+    const emptyState =
+      p.rows.length === 0
+        ? `<tr class="empty"><td colspan="${showFee ? 6 : 5}">Keine Einträge im gewählten Zeitraum.</td></tr>`
+        : ''
+    const totalsRow = `<tr class="total">
         <td colspan="${showFee ? 4 : 4}">Summe</td>
         <td class="col-dur">${esc(formatHoursMinutes(p.totals.minutes))}</td>
         ${showFee ? `<td class="col-fee">${esc(formatEur(p.totals.feeCent ?? 0))}</td>` : ''}
       </tr>`
+    tableBody = tableRows + '\n' + emptyState + '\n' + totalsRow
+  }
 
   // No visible rounding hint in the PDF: the recipient should never
   // notice that times were rounded. The displayed Von/Bis times are
@@ -402,6 +492,23 @@ export function buildPdfHtml(p: PdfPayload): string {
     padding: 24px 8px;
     font-style: italic;
   }
+  table.entries tr.group-header td.col-group {
+    background: #f1f5f9;
+    color: #334155;
+    font-weight: 700;
+    font-size: 9.5pt;
+    border-top: 2px solid ${accent};
+    border-bottom: none;
+    padding: 6px 8px;
+  }
+  table.entries tr.subtotal td {
+    border-top: 1px solid #cbd5e1;
+    border-bottom: 2px solid ${accent};
+    font-weight: 600;
+    font-size: 10pt;
+    color: #334155;
+    padding: 5px 8px;
+  }
   footer.doc-foot {
     margin-top: 36px;
     padding-top: 12px;
@@ -462,9 +569,7 @@ export function buildPdfHtml(p: PdfPayload): string {
         </tr>
       </thead>
       <tbody>
-        ${tableRows}
-        ${emptyState}
-        ${totalsRow}
+        ${tableBody}
       </tbody>
     </table>
 

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -94,12 +94,16 @@ declare global {
       exporter: {
         json(): Promise<IpcResult<{ path: string; bytes: number }>>
       }
+      tags: {
+        recent(): Promise<IpcResult<string[]>>
+      }
       pdf: {
         export(req: {
           clientId: number
           fromIso: string
           toIso: string
           includeSignatures?: boolean
+          groupByTag?: boolean
         }): Promise<IpcResult<{ path: string }>>
       }
       logo: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -133,12 +133,16 @@ const api = {
     json: (): Promise<IpcResult<{ path: string; bytes: number }>> =>
       ipcRenderer.invoke('export:json')
   },
+  tags: {
+    recent: (): Promise<IpcResult<string[]>> => ipcRenderer.invoke('tags:recent')
+  },
   pdf: {
     export: (req: {
       clientId: number
       fromIso: string
       toIso: string
       includeSignatures?: boolean
+      groupByTag?: boolean
     }): Promise<IpcResult<{ path: string }>> => ipcRenderer.invoke('pdf:export', req)
   },
   logo: {

--- a/src/renderer/src/components/CalendarDrawer.tsx
+++ b/src/renderer/src/components/CalendarDrawer.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type { Client, Entry } from '../../../shared/types'
+import { deserializeTags, entryHasTag } from '../../../shared/tags'
 import { useEntriesStore } from '../store/entriesStore'
 import { useToastStore } from '../store/toastStore'
 import { ConfirmDialog } from './ConfirmDialog'
@@ -32,6 +33,7 @@ export function CalendarDrawer({
   onClose
 }: Props): React.ReactElement | null {
   const showToast = useToastStore((s) => s.show)
+  const [tagFilter, setTagFilter] = useState<string | null>(null)
   const [editingId, setEditingId] = useState<number | null>(null)
   const [creating, setCreating] = useState(false)
   const [deleteCandidate, setDeleteCandidate] = useState<Entry | null>(null)
@@ -66,6 +68,23 @@ export function CalendarDrawer({
     return m
   }, [clients])
 
+  // Collect all unique tags from today's entries for the filter pill bar.
+  const allDayTags = useMemo(() => {
+    const seen = new Set<string>()
+    for (const e of entries) {
+      for (const t of deserializeTags(e.tags)) seen.add(t)
+    }
+    return [...seen].sort()
+  }, [entries])
+
+  const filteredEntries = useMemo(
+    () =>
+      tagFilter
+        ? entries.filter((e) => entryHasTag(e.tags, tagFilter))
+        : entries,
+    [entries, tagFilter]
+  )
+
   if (!open) return null
 
   async function confirmDelete(entry: Entry): Promise<void> {
@@ -84,7 +103,7 @@ export function CalendarDrawer({
   }
 
   const dateLabel = formatHumanDate(dateISO)
-  const totalSeconds = entries.reduce((sum, e) => sum + durationSeconds(e), 0)
+  const totalSeconds = filteredEntries.reduce((sum, e) => sum + durationSeconds(e), 0)
 
   return (
     <>
@@ -104,9 +123,31 @@ export function CalendarDrawer({
             <h2 className="text-base font-semibold text-slate-100">Einträge für {dateLabel}</h2>
             {entries.length > 0 && (
               <p className="mt-0.5 text-xs text-slate-400">
-                {entries.length} Eintrag{entries.length === 1 ? '' : 'e'} ·{' '}
-                {formatHHMM(totalSeconds)}
+                {filteredEntries.length !== entries.length
+                  ? `${filteredEntries.length} von ${entries.length} Eintrag${entries.length === 1 ? '' : 'e'}`
+                  : `${entries.length} Eintrag${entries.length === 1 ? '' : 'e'}`}{' '}
+                · {formatHHMM(totalSeconds)}
               </p>
+            )}
+            {allDayTags.length > 0 && (
+              <div className="mt-1.5 flex flex-wrap gap-1">
+                {allDayTags.map((tag) => (
+                  <button
+                    key={tag}
+                    type="button"
+                    onClick={() => setTagFilter(tagFilter === tag ? null : tag)}
+                    className={`rounded-full border px-2 py-0.5 text-xs font-medium transition-colors focus:outline-none focus:ring-1 focus:ring-indigo-400 ${
+                      tagFilter === tag
+                        ? 'border-indigo-500 bg-indigo-600 text-white'
+                        : 'border-slate-600 bg-slate-800 text-slate-300 hover:border-slateigo-500 hover:bg-slate-700'
+                    }`}
+                    aria-pressed={tagFilter === tag}
+                    title={tagFilter === tag ? 'Filter entfernen' : `Nach #${tag} filtern`}
+                  >
+                    #{tag}
+                  </button>
+                ))}
+              </div>
             )}
           </div>
           <button
@@ -121,15 +162,20 @@ export function CalendarDrawer({
 
         {/* Scroll body */}
         <div className="flex-1 overflow-y-auto p-3">
-          {entries.length === 0 && !creating && (
+          {filteredEntries.length === 0 && !creating && (
             <div className="mt-8 text-center text-sm text-slate-500">
-              <p>Kein Eintrag an diesem Tag.</p>
+              {tagFilter ? (
+                <p>Keine Einträge mit Tag <span className="font-medium text-slate-400">#{tagFilter}</span>.</p>
+              ) : (
+                <p>Kein Eintrag an diesem Tag.</p>
+              )}
             </div>
           )}
           <ul className="flex flex-col gap-2">
-            {entries.map((e) => {
+            {filteredEntries.map((e) => {
               const client = clientsById.get(e.client_id)
               const isEditing = editingId === e.id
+              const entryTags = deserializeTags(e.tags)
               return (
                 <li key={e.id} className="rounded-lg border border-slate-700 bg-slate-800/60">
                   {!isEditing && (
@@ -153,6 +199,18 @@ export function CalendarDrawer({
                           >
                             {e.description}
                           </p>
+                        )}
+                        {entryTags.length > 0 && (
+                          <div className="mt-1 flex flex-wrap gap-1">
+                            {entryTags.map((tag) => (
+                              <span
+                                key={tag}
+                                className="rounded-full bg-slate-700 px-1.5 py-px text-xs text-slate-400"
+                              >
+                                #{tag}
+                              </span>
+                            ))}
+                          </div>
                         )}
                       </div>
                       <span className="font-mono text-xs tabular-nums text-slate-300">

--- a/src/renderer/src/components/EntryEditForm.tsx
+++ b/src/renderer/src/components/EntryEditForm.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import type { Client, Entry } from '../../../shared/types'
 import { formatTimeHHMM, parseTimeToDate } from '../../../shared/date'
 import { useEntriesStore } from '../store/entriesStore'
+import { TagInput } from './TagInput'
 
 interface Props {
   /** Existing entry to edit; omit for create-mode. */
@@ -52,6 +53,7 @@ export function EntryEditForm({
   const [stopTime, setStopTime] = useState(formatTimeHHMM(initialStop))
   const [clientId, setClientId] = useState<number>(entry?.client_id ?? clients[0]?.id ?? 0)
   const [description, setDescription] = useState(entry?.description ?? '')
+  const [tags, setTags] = useState(entry?.tags ?? '')
   const [state, setState] = useState<FormState>('idle')
   const [error, setError] = useState<string | null>(null)
   const bumpVersion = useEntriesStore((s) => s.bumpVersion)
@@ -104,13 +106,15 @@ export function EntryEditForm({
           client_id: clientId,
           description: description.trim(),
           started_at: start,
-          stopped_at: stop
+          stopped_at: stop,
+          tags
         })
       : await window.api.entries.create({
           client_id: clientId,
           description: description.trim(),
           started_at: start,
-          stopped_at: stop
+          stopped_at: stop,
+          tags
         })
     if (!res.ok) {
       setState('idle')
@@ -193,6 +197,18 @@ export function EntryEditForm({
           disabled={isSaving}
         />
       </label>
+
+      <div className="flex flex-col gap-1">
+        <span className="text-xs text-zinc-400">Tags</span>
+        <TagInput
+          value={tags}
+          onChange={(serialized) => setTags(serialized)}
+          disabled={isSaving}
+        />
+        <span className="text-xs text-zinc-600">
+          Tab, Enter oder Komma zum Hinzufügen · Backspace zum Entfernen
+        </span>
+      </div>
 
       {visibleError && (
         <p role="alert" className="text-xs text-red-400">

--- a/src/renderer/src/components/PdfExportModal.tsx
+++ b/src/renderer/src/components/PdfExportModal.tsx
@@ -31,6 +31,7 @@ export function PdfExportModal(props: Props): React.JSX.Element {
   // signature row at the foot of the document looks like an unfinished
   // template to the recipient.
   const [includeSignatures, setIncludeSignatures] = useState(false)
+  const [groupByTag, setGroupByTag] = useState(false)
   const [busy, setBusy] = useState(false)
   const [statusMsg, setStatusMsg] = useState<string | null>(null)
   const [statusKind, setStatusKind] = useState<'info' | 'error' | 'success'>('info')
@@ -62,7 +63,7 @@ export function PdfExportModal(props: Props): React.JSX.Element {
     setBusy(true)
     setStatusMsg('PDF wird erstellt …')
     setStatusKind('info')
-    const res = await window.api.pdf.export({ clientId, fromIso, toIso, includeSignatures })
+    const res = await window.api.pdf.export({ clientId, fromIso, toIso, includeSignatures, groupByTag })
     setBusy(false)
     if (res.ok) {
       setStatusKind('success')
@@ -123,6 +124,22 @@ export function PdfExportModal(props: Props): React.JSX.Element {
             />
           </label>
         </div>
+
+        <label className="flex items-start gap-2 text-sm text-zinc-300">
+          <input
+            type="checkbox"
+            checked={groupByTag}
+            onChange={(e) => setGroupByTag(e.target.checked)}
+            disabled={busy}
+            className="mt-0.5 h-4 w-4 rounded border-zinc-600 bg-zinc-800 text-indigo-500 focus:ring-indigo-400 focus:ring-offset-0"
+          />
+          <span>
+            Nach Tag gruppieren
+            <span className="block text-xs text-zinc-500">
+              Einträge mit Tags werden in separaten Abschnitten zusammengefasst.
+            </span>
+          </span>
+        </label>
 
         <label className="flex items-start gap-2 text-sm text-zinc-300">
           <input

--- a/src/renderer/src/components/TagInput.tsx
+++ b/src/renderer/src/components/TagInput.tsx
@@ -1,0 +1,208 @@
+import { useEffect, useRef, useState } from 'react'
+import { deserializeTags, parseTagInput, serializeTags } from '../../../shared/tags'
+
+interface Props {
+  /** Serialized tags value from the DB (`,bug,ux,` format). */
+  value: string
+  onChange: (serialized: string) => void
+  disabled?: boolean
+}
+
+/**
+ * 8-color deterministic palette for tag chips.
+ * Color is derived from the first character code so the same tag always
+ * gets the same color across sessions.
+ */
+const CHIP_COLORS: string[] = [
+  'bg-indigo-900/60 text-indigo-300 border-indigo-700',
+  'bg-emerald-900/60 text-emerald-300 border-emerald-700',
+  'bg-amber-900/60 text-amber-300 border-amber-700',
+  'bg-rose-900/60 text-rose-300 border-rose-700',
+  'bg-violet-900/60 text-violet-300 border-violet-700',
+  'bg-sky-900/60 text-sky-300 border-sky-700',
+  'bg-lime-900/60 text-lime-300 border-lime-700',
+  'bg-orange-900/60 text-orange-300 border-orange-700'
+]
+
+function chipColor(tag: string): string {
+  const code = tag.charCodeAt(0) || 0
+  return CHIP_COLORS[code % CHIP_COLORS.length]
+}
+
+/**
+ * Tag chip list + text input with Tab/Enter/comma to add, Backspace to
+ * remove, and autocomplete dropdown populated from `tags:recent` IPC.
+ *
+ * Stores tags as the serialized DB format (`,tag1,tag2,`) via `onChange`.
+ */
+export function TagInput({ value, onChange, disabled = false }: Props): React.ReactElement {
+  const tags = deserializeTags(value)
+  const [inputValue, setInputValue] = useState('')
+  const [suggestions, setSuggestions] = useState<string[]>([])
+  const [allRecent, setAllRecent] = useState<string[]>([])
+  const [dropdownOpen, setDropdownOpen] = useState(false)
+  const [highlightedIndex, setHighlightedIndex] = useState(-1)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // Load recent tags once on mount
+  useEffect(() => {
+    window.api.tags.recent().then((res) => {
+      if (res.ok) setAllRecent(res.data)
+    })
+  }, [])
+
+  // Filter suggestions based on current input
+  useEffect(() => {
+    const q = inputValue.trim().toLowerCase().replace(/^#/, '')
+    if (!q) {
+      setSuggestions(allRecent.filter((t) => !tags.includes(t)).slice(0, 8))
+    } else {
+      setSuggestions(
+        allRecent
+          .filter((t) => t.startsWith(q) && !tags.includes(t))
+          .slice(0, 8)
+      )
+    }
+    setHighlightedIndex(-1)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inputValue, allRecent, value])
+
+  function commitInput(raw: string): void {
+    const parsed = parseTagInput(raw)
+    if (parsed.length === 0) {
+      setInputValue('')
+      return
+    }
+    const next = [...tags]
+    for (const t of parsed) {
+      if (!next.includes(t) && next.length < 10) next.push(t)
+    }
+    onChange(serializeTags(next))
+    setInputValue('')
+    setDropdownOpen(false)
+  }
+
+  function removeTag(tag: string): void {
+    onChange(serializeTags(tags.filter((t) => t !== tag)))
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>): void {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setDropdownOpen(true)
+      setHighlightedIndex((i) => Math.min(i + 1, suggestions.length - 1))
+      return
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setHighlightedIndex((i) => Math.max(i - 1, -1))
+      return
+    }
+    if ((e.key === 'Enter' || e.key === 'Tab' || e.key === ',') && inputValue.trim()) {
+      e.preventDefault()
+      if (highlightedIndex >= 0 && suggestions[highlightedIndex]) {
+        commitInput(suggestions[highlightedIndex])
+      } else {
+        commitInput(inputValue)
+      }
+      return
+    }
+    if (e.key === 'Escape') {
+      setDropdownOpen(false)
+      setHighlightedIndex(-1)
+      return
+    }
+    if (e.key === 'Backspace' && inputValue === '' && tags.length > 0) {
+      removeTag(tags[tags.length - 1])
+      return
+    }
+  }
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    function handlePointerDown(e: PointerEvent): void {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setDropdownOpen(false)
+      }
+    }
+    document.addEventListener('pointerdown', handlePointerDown)
+    return () => document.removeEventListener('pointerdown', handlePointerDown)
+  }, [])
+
+  const showDropdown = dropdownOpen && suggestions.length > 0 && !disabled
+
+  return (
+    <div ref={containerRef} className="relative">
+      <div
+        className={`flex min-h-[36px] flex-wrap items-center gap-1 rounded border border-zinc-700 bg-zinc-900 px-2 py-1.5 focus-within:border-indigo-500 ${disabled ? 'opacity-50' : ''}`}
+        onClick={() => inputRef.current?.focus()}
+      >
+        {tags.map((tag) => (
+          <span
+            key={tag}
+            className={`inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-xs font-medium ${chipColor(tag)}`}
+          >
+            #{tag}
+            {!disabled && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  removeTag(tag)
+                }}
+                className="leading-none opacity-60 hover:opacity-100 focus:outline-none"
+                aria-label={`Tag ${tag} entfernen`}
+              >
+                ×
+              </button>
+            )}
+          </span>
+        ))}
+        <input
+          ref={inputRef}
+          type="text"
+          value={inputValue}
+          onChange={(e) => {
+            setInputValue(e.target.value)
+            setDropdownOpen(true)
+          }}
+          onFocus={() => setDropdownOpen(true)}
+          onKeyDown={handleKeyDown}
+          disabled={disabled}
+          placeholder={tags.length === 0 ? 'Tags hinzufügen…' : ''}
+          className="min-w-[80px] flex-1 bg-transparent text-xs text-zinc-100 placeholder-zinc-600 focus:outline-none"
+          aria-label="Tag eingeben"
+          aria-autocomplete="list"
+          aria-expanded={showDropdown}
+        />
+      </div>
+
+      {showDropdown && (
+        <ul
+          role="listbox"
+          className="absolute z-50 mt-1 max-h-48 w-full overflow-auto rounded border border-zinc-700 bg-zinc-900 py-1 shadow-xl"
+        >
+          {suggestions.map((s, i) => (
+            <li
+              key={s}
+              role="option"
+              aria-selected={i === highlightedIndex}
+              onPointerDown={(e) => {
+                e.preventDefault()
+                commitInput(s)
+              }}
+              className={`cursor-pointer px-3 py-1 text-xs ${
+                i === highlightedIndex
+                  ? 'bg-indigo-600 text-white'
+                  : 'text-zinc-300 hover:bg-zinc-800'
+              }`}
+            >
+              #{s}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/shared/tags.test.ts
+++ b/src/shared/tags.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest'
+import { parseTagInput, serializeTags, deserializeTags, entryHasTag, validateTags } from './tags'
+
+describe('parseTagInput', () => {
+  it('lowercases input', () => {
+    expect(parseTagInput('Bug')).toEqual(['bug'])
+  })
+
+  it('strips # prefix', () => {
+    expect(parseTagInput('#feature #ux')).toEqual(['feature', 'ux'])
+  })
+
+  it('splits on commas and spaces', () => {
+    expect(parseTagInput('bug, ux, feature')).toEqual(['bug', 'ux', 'feature'])
+  })
+
+  it('deduplicates tags (first occurrence wins)', () => {
+    expect(parseTagInput('bug bug ux bug')).toEqual(['bug', 'ux'])
+  })
+
+  it('ignores empty tokens', () => {
+    expect(parseTagInput('  ,  ,  ')).toEqual([])
+  })
+
+  it('caps at 10 tags', () => {
+    const input = Array.from({ length: 15 }, (_, i) => `tag${i}`).join(' ')
+    expect(parseTagInput(input)).toHaveLength(10)
+  })
+
+  it('silently truncates tokens longer than 32 chars', () => {
+    const long = 'a'.repeat(40)
+    const result = parseTagInput(long)
+    expect(result[0]).toHaveLength(32)
+  })
+
+  it('rejects tokens with invalid characters (uppercase after lowercase)', () => {
+    // After lowercasing 'Tag' becomes 'tag' — valid
+    expect(parseTagInput('Tag')).toEqual(['tag'])
+    // Tokens with special chars are dropped
+    expect(parseTagInput('tag!')).toEqual([])
+    expect(parseTagInput('tag@name')).toEqual([])
+  })
+
+  it('accepts hyphens, underscores, dots', () => {
+    expect(parseTagInput('my-tag my_tag v1.0')).toEqual(['my-tag', 'my_tag', 'v1.0'])
+  })
+
+  it('returns empty array for empty input', () => {
+    expect(parseTagInput('')).toEqual([])
+  })
+})
+
+describe('serializeTags', () => {
+  it('wraps with leading and trailing commas', () => {
+    expect(serializeTags(['bug', 'ux'])).toBe(',bug,ux,')
+  })
+
+  it('returns empty string for empty array', () => {
+    expect(serializeTags([])).toBe('')
+  })
+
+  it('single tag', () => {
+    expect(serializeTags(['bug'])).toBe(',bug,')
+  })
+})
+
+describe('deserializeTags', () => {
+  it('parses comma-delimited DB format', () => {
+    expect(deserializeTags(',bug,ux,')).toEqual(['bug', 'ux'])
+  })
+
+  it('returns empty array for empty string', () => {
+    expect(deserializeTags('')).toEqual([])
+  })
+
+  it('returns empty array for null/undefined', () => {
+    expect(deserializeTags(null)).toEqual([])
+    expect(deserializeTags(undefined)).toEqual([])
+  })
+})
+
+describe('entryHasTag', () => {
+  it('returns true for exact tag match', () => {
+    expect(entryHasTag(',bug,ux,', 'bug')).toBe(true)
+  })
+
+  it('returns false for substring match (bugfix does not match bug)', () => {
+    expect(entryHasTag(',bugfix,ux,', 'bug')).toBe(false)
+  })
+
+  it('returns false when tag is absent', () => {
+    expect(entryHasTag(',bug,ux,', 'feature')).toBe(false)
+  })
+
+  it('returns false for empty serialized', () => {
+    expect(entryHasTag('', 'bug')).toBe(false)
+  })
+
+  it('is case-insensitive via lowercase normalization', () => {
+    // Tags are stored lowercase; caller should pass lowercase tag
+    expect(entryHasTag(',bug,', 'bug')).toBe(true)
+  })
+})
+
+describe('validateTags', () => {
+  it('returns null for valid tags', () => {
+    expect(validateTags(['bug', 'ux'])).toBeNull()
+  })
+
+  it('rejects more than 10 tags', () => {
+    const tags = Array.from({ length: 11 }, (_, i) => `tag${i}`)
+    expect(validateTags(tags)).toMatch(/10/)
+  })
+
+  it('returns null for empty array', () => {
+    expect(validateTags([])).toBeNull()
+  })
+})

--- a/src/shared/tags.ts
+++ b/src/shared/tags.ts
@@ -1,0 +1,93 @@
+/**
+ * Tag utilities for v1.4 PR C.
+ *
+ * Storage format: leading + trailing comma, e.g. `,bug,ux,`
+ * This lets SQLite match exact tags with LIKE `%,bug,%` without false
+ * positives for partial substrings (e.g. `bugfix` won't match a search
+ * for `bug`). An empty/untagged entry stores an empty string `''`.
+ *
+ * Rules enforced at parse time:
+ *  - All-lowercase (input is lowercased automatically)
+ *  - Max 32 characters per tag (silently truncated on parse, rejected on validate)
+ *  - Max 10 tags per entry
+ *  - Duplicates are silently removed (first occurrence wins)
+ *  - Tags may contain letters, digits, hyphens, underscores, and dots
+ *  - Empty tokens are ignored
+ */
+
+const MAX_TAG_LEN = 32
+const MAX_TAGS = 10
+
+/** Regex for a valid single tag: 1-32 lowercase alphanumeric + - _ . */
+const TAG_RE = /^[a-z0-9._-]{1,32}$/
+
+/**
+ * Parse a raw user input string into a normalised tag array.
+ * Splits on commas, spaces, and the `#` prefix character.
+ * Lowercases, deduplicates, and silently drops invalid/empty tokens.
+ * The resulting array is capped at MAX_TAGS entries.
+ */
+export function parseTagInput(raw: string): string[] {
+  const tokens = raw
+    .toLowerCase()
+    .split(/[\s,#]+/)
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0)
+    .map((t) => t.slice(0, MAX_TAG_LEN))
+    .filter((t) => TAG_RE.test(t))
+
+  // Deduplicate preserving first occurrence
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const t of tokens) {
+    if (!seen.has(t)) {
+      seen.add(t)
+      result.push(t)
+    }
+    if (result.length >= MAX_TAGS) break
+  }
+  return result
+}
+
+/**
+ * Serialize a tag array to the DB storage format (`,tag1,tag2,`).
+ * Returns an empty string for an empty/null array.
+ */
+export function serializeTags(tags: string[]): string {
+  if (!tags || tags.length === 0) return ''
+  return `,${tags.join(',')},`
+}
+
+/**
+ * Deserialize the DB storage format back to an array of tag strings.
+ * Returns an empty array for an empty/null string.
+ */
+export function deserializeTags(stored: string | null | undefined): string[] {
+  if (!stored) return []
+  return stored
+    .split(',')
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0)
+}
+
+/**
+ * Return true when the serialized `tags` column value contains `tag`
+ * as an exact whole-word match (not a substring of another tag).
+ */
+export function entryHasTag(serialized: string, tag: string): boolean {
+  if (!serialized || !tag) return false
+  return serialized.includes(`,${tag.toLowerCase()},`)
+}
+
+/**
+ * Validate a raw tag array (post-parse). Returns an error message string
+ * when the array is invalid, or null when valid.
+ */
+export function validateTags(tags: string[]): string | null {
+  if (tags.length > MAX_TAGS) return `Maximal ${MAX_TAGS} Tags pro Eintrag`
+  for (const t of tags) {
+    if (t.length > MAX_TAG_LEN) return `Tag "${t}" ist zu lang (max ${MAX_TAG_LEN} Zeichen)`
+    if (!TAG_RE.test(t)) return `Tag "${t}" enthält ungültige Zeichen`
+  }
+  return null
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -26,6 +26,12 @@ export interface Entry {
    * when the user deletes a row with a non-null link_id.
    */
   link_id: string | null
+  /**
+   * v1.4 PR C: comma-delimited serialized tags, e.g. `,bug,ux,`.
+   * Empty string means untagged. Use `deserializeTags` from shared/tags.ts
+   * to convert to an array for UI consumption.
+   */
+  tags: string
 }
 
 export interface Settings {
@@ -91,6 +97,8 @@ export interface CreateManualEntryInput {
   description: string
   started_at: string
   stopped_at: string
+  /** Serialized tags string (e.g. `,bug,ux,`). Optional — defaults to '' */
+  tags?: string
 }
 
 export interface UpdateEntryInput {
@@ -99,6 +107,8 @@ export interface UpdateEntryInput {
   description: string
   started_at: string
   stopped_at: string
+  /** Serialized tags string (e.g. `,bug,ux,`). Optional — defaults to '' */
+  tags?: string
 }
 
 export interface MonthQuery {


### PR DESCRIPTION
## Tags pro Eintrag

Closes #24

### Was wurde geliefert

**C1 — Schema + Daten-Layer**
- Migration 007: `entries.tags TEXT NOT NULL DEFAULT ''` — serialisiert als `,tag1,tag2,` für exakte LIKE-Suche
- `shared/tags.ts`: `parseTagInput`, `serializeTags`, `deserializeTags`, `entryHasTag`, `validateTags`
- `types.ts`: `Entry.tags`, `CreateManualEntryInput.tags?`, `UpdateEntryInput.tags?`
- `ipc.ts`: `insertEntrySegments` mit tags-Parameter; neuer `tags:recent`-Handler (90 Tage, freq-sortiert)
- Preload: `tags.recent()` + `pdf.export` mit `groupByTag?`

**C2 — UI + PDF**
- `TagInput.tsx`: Chip-Liste + Texteingabe; Tab/Enter/Komma fügt Tag hinzu; Backspace entfernt letzten Chip; Autocomplete-Dropdown (freq-sortiert); 8-Farben-Palette deterministisch via `charCode % 8`; Validierung: `[a-z0-9._-]`, max 32 Zeichen, max 10 Tags
- `EntryEditForm`: TagInput integriert, tags bei create + update gespeichert
- `CalendarDrawer`: Tag-Chips pro Eintrag; Tag-Filter-Pill-Bar im Header (Toggle); Zähler `X von Y Einträge`; kontext-sensitiver Leer-State
- `pdf.ts`: `PdfGroup`-Typ; `buildPdfPayload` baut Groups bei `groupByTag=true`; `buildPdfHtml` rendert Group-Header + Subtotal-Zeilen; Silent Fallback auf Flat-Layout
- `PdfExportModal`: Checkbox „Nach Tag gruppieren"

### Tests
- 17 neue Unit-Tests in `shared/tags.test.ts`
- 4 neue Migrations-Tests in `migrations.test.ts`
- Gesamt: **114 passed | 51 skipped** ✅
- TypeCheck ✅ | Lint: keine neuen Fehler ✅
