### PR TITLE
feat(quicknote): Schnell-Notiz nach Stop (#25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,8 +163,11 @@ All notable changes to TimeTrack are documented here.
     pro Tag (alphabetisch sortiert), jeder mit eigenem Subtotal-Bereich;
     Einträge ohne Tag landen in der Gruppe „Ohne Tag" (immer am Ende).
     Silent Fallback auf Flat-Layout wenn kein Eintrag im Zeitraum Tags hat.
-
-## [1.2.0] — 2026-04-24
+- **Schnell-Notiz nach Stop** (#25) — Wenn ein Timer mit leerer Beschreibung gestoppt
+  wird, erscheint ein Modal „Was war das?" mit 30s-Countdown-Progressbar.
+  Beschreibung eingeben und Enter drücken — der Eintrag wird sofort aktualisiert.
+  Escape oder Ablauf des Countdowns überspringen das Modal lautlos.
+  TodayView und CalendarDrawer refreshen automatisch nach dem Speichern.
 
 ## [1.2.0] — 2026-04-24
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ A personal Windows desktop time-tracking app for freelancers. Lightweight Toggl 
 - **Kunden-Verwaltung** — Anlegen, bearbeiten, archivieren, löschen, Farbcode + Stundensatz.
 - **Global Hotkey** — `Alt+Shift+S` (konfigurierbar) startet/stoppt den Timer aus jedem Tab.
 - **Tray Icon + Quick-Start** — Rechtsklick auf die Tray öffnet aktive Kunden direkt als Buttons. Tray-Glyph wechselt je nach Timer-State.
+- **Mini-Widget** — Always-on-top 200×40 Overlay (Hotkey `Alt+Shift+M`, konfigurierbar). Zeigt laufenden Timer + Kunde + Stop/Start-Buttons — kein Hauptfenster nötig. Draggable, sichtbar über Vollbild-Apps.
+- **Tags pro Eintrag** — Farbige Chips je Zeitblock. Filter im Kalender-Drawer per Tag-Klick. PDF-Export nach Tag gruppierbar.
+- **Schnell-Notiz nach Stop** — Kein Beschreibungsfeld ausgefüllt? 30s-Modal „Was war das?" erscheint nach dem Stoppen. Enter speichert, Escape überspringt.
 - **Idle-Detection** — PC inaktiv über Schwelle? Modal fragt: behalten, stoppen oder als Pause markieren.
 - **Auto-Backup** — Rollierende 7-Tage-SQLite-Snapshots unter `%AppData%\TimeTrack\backups\`. Manueller Backup + Restore aus Settings.
 - **DB Migrations** — Versioniertes Schema mit Pre-Migration-Backup, sodass Updates nie Daten verlieren.
@@ -23,7 +26,7 @@ A personal Windows desktop time-tracking app for freelancers. Lightweight Toggl 
 
 ### Coming soon
 
-- Mini-Modus always-on-top widget, Pomodoro, Tags — see [v1.4 issues](https://github.com/skoedr/time-tracking/labels/v1.4)
+- Fenster-Größe & Layout-Density — letzte Position/Größe persistieren, Container-Width-Audit — see [v1.4 issues](https://github.com/skoedr/time-tracking/labels/v1.4)
 - Auto-Update + Onboarding-Wizard + Crash-Logging — see [v1.5 issues](https://github.com/skoedr/time-tracking/labels/v1.5)
 
 ## Tech Stack

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -5,6 +5,7 @@ import CalendarView from './views/CalendarView'
 import ClientsView from './views/ClientsView'
 import SettingsView from './views/SettingsView'
 import { IdleModal } from './components/IdleModal'
+import { QuickNoteModal } from './components/QuickNoteModal'
 import { ToastTray } from './components/Toast'
 import { useTimer } from './hooks/useTimer'
 
@@ -20,7 +21,8 @@ const NAV_LABEL: Record<View, string> = {
 
 function App(): React.JSX.Element {
   const [view, setView] = useState<View>('today')
-  const { idleEvent, idleKeep, idleStopAtIdle, idleMarkPause } = useTimer()
+  const { idleEvent, idleKeep, idleStopAtIdle, idleMarkPause, quickNoteEntry, setQuickNoteEntry } =
+    useTimer()
 
   return (
     <div className="h-screen bg-slate-900 text-slate-100 flex flex-col overflow-hidden">
@@ -56,6 +58,9 @@ function App(): React.JSX.Element {
           onStopAtIdle={idleStopAtIdle}
           onMarkPause={idleMarkPause}
         />
+      )}
+      {quickNoteEntry && (
+        <QuickNoteModal entry={quickNoteEntry} onDone={() => setQuickNoteEntry(null)} />
       )}
 
       <ToastTray />

--- a/src/renderer/src/components/QuickNoteModal.tsx
+++ b/src/renderer/src/components/QuickNoteModal.tsx
@@ -61,7 +61,8 @@ export function QuickNoteModal({ entry, onDone }: Props) {
     if (e.key === 'Enter') void save()
   }
 
-  const progressPct = (remaining / TIMEOUT_S) * 100
+  // Bar grows left→right as time elapses (0% = just opened, 100% = time up)
+  const progressPct = ((TIMEOUT_S - remaining) / TIMEOUT_S) * 100
 
   return (
     <div

--- a/src/renderer/src/components/QuickNoteModal.tsx
+++ b/src/renderer/src/components/QuickNoteModal.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useRef, useState } from 'react'
+import type { Entry } from '../../../shared/types'
+import { useEntriesStore } from '../store/entriesStore'
+
+const TIMEOUT_S = 30
+
+interface Props {
+  entry: Entry
+  onDone: () => void
+}
+
+export function QuickNoteModal({ entry, onDone }: Props) {
+  const [text, setText] = useState('')
+  const [remaining, setRemaining] = useState(TIMEOUT_S)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const deadlineRef = useRef(Date.now() + TIMEOUT_S * 1000)
+  const bumpVersion = useEntriesStore((s) => s.bumpVersion)
+
+  // Auto-focus input
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [])
+
+  // Countdown + auto-dismiss
+  useEffect(() => {
+    const tick = setInterval(() => {
+      const r = Math.max(0, Math.round((deadlineRef.current - Date.now()) / 1000))
+      setRemaining(r)
+      if (r <= 0) onDone()
+    }, 250)
+    return () => clearInterval(tick)
+  }, [onDone])
+
+  // Escape = skip
+  useEffect(() => {
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') onDone()
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [onDone])
+
+  const save = async (): Promise<void> => {
+    const desc = text.trim()
+    if (desc) {
+      await window.api.entries.update({
+        id: entry.id,
+        client_id: entry.client_id,
+        description: desc,
+        started_at: entry.started_at,
+        // entry was just stopped so stopped_at is always set here
+        stopped_at: entry.stopped_at!,
+        tags: entry.tags
+      })
+      bumpVersion()
+    }
+    onDone()
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+    if (e.key === 'Enter') void save()
+  }
+
+  const progressPct = (remaining / TIMEOUT_S) * 100
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="quicknote-title"
+    >
+      <div className="w-[420px] rounded-xl bg-zinc-900 p-6 shadow-2xl ring-1 ring-zinc-700">
+        <h2 id="quicknote-title" className="mb-1 text-xl font-semibold text-zinc-100">
+          Was war das?
+        </h2>
+        <p className="mb-4 text-sm text-zinc-400">
+          Kein Eintrag hatte eine Beschreibung. Kurz notieren?
+        </p>
+
+        <input
+          ref={inputRef}
+          type="text"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Beschreibung eingeben …"
+          className="mb-4 w-full rounded-lg bg-zinc-800 px-3 py-2.5 text-sm text-zinc-100
+            placeholder:text-zinc-500 outline-none ring-1 ring-zinc-700
+            focus:ring-2 focus:ring-indigo-500"
+        />
+
+        {/* Progress bar */}
+        <div className="mb-5 h-1 w-full overflow-hidden rounded-full bg-zinc-700">
+          <div
+            className="h-1 rounded-full bg-indigo-500 transition-none"
+            style={{ width: `${progressPct}%` }}
+          />
+        </div>
+
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => void save()}
+            disabled={!text.trim()}
+            className="flex-1 rounded-lg bg-indigo-600 px-4 py-2.5 text-sm font-medium
+              text-white hover:bg-indigo-500 disabled:opacity-40 disabled:cursor-not-allowed
+              focus:outline-none focus:ring-2 focus:ring-indigo-400"
+          >
+            Speichern
+          </button>
+          <button
+            type="button"
+            onClick={onDone}
+            className="rounded-lg bg-zinc-800 px-4 py-2.5 text-sm font-medium text-zinc-300
+              hover:bg-zinc-700 focus:outline-none focus:ring-2 focus:ring-zinc-500"
+          >
+            Überspringen ({remaining}s)
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/hooks/useTimer.ts
+++ b/src/renderer/src/hooks/useTimer.ts
@@ -143,6 +143,8 @@ export function useTimer() {
     setIsLoading(false)
     if (res.ok) {
       setRunningEntry(res.data)
+      // Dismiss quicknote modal if user starts a new timer before answering
+      if (useTimerStore.getState().quickNoteEntry) setQuickNoteEntry(null)
       const clientName = clients.find((c) => c.id === clientId)?.name ?? ''
       await pushTrayUpdate(true, clientName)
     }
@@ -184,6 +186,8 @@ export function useTimer() {
       if (res.ok) {
         setRunningEntry(res.data)
         setDescription('')
+        // Dismiss quicknote modal if user starts a new timer before answering
+        if (useTimerStore.getState().quickNoteEntry) setQuickNoteEntry(null)
         const clientName = clients.find((c) => c.id === clientId)?.name ?? ''
         await pushTrayUpdate(true, clientName)
       }

--- a/src/renderer/src/hooks/useTimer.ts
+++ b/src/renderer/src/hooks/useTimer.ts
@@ -52,13 +52,15 @@ export function useTimer() {
     elapsedSeconds,
     isLoading,
     idleEvent,
+    quickNoteEntry,
     setClients,
     setRunningEntry,
     setSelectedClientId,
     setDescription,
     setElapsedSeconds,
     setIsLoading,
-    setIdleEvent
+    setIdleEvent,
+    setQuickNoteEntry
   } = useTimerStore()
 
   const tickRef = useRef<ReturnType<typeof setInterval> | null>(null)
@@ -148,6 +150,7 @@ export function useTimer() {
 
   const stop = useCallback(async () => {
     if (!runningEntry) return
+    const wasEmpty = runningEntry.description.trim() === ''
     setIsLoading(true)
     const res = await window.api.entries.stop(runningEntry.id)
     setIsLoading(false)
@@ -159,6 +162,10 @@ export function useTimer() {
       if (useTimerStore.getState().idleEvent) {
         setIdleEvent(null)
         window.api.idle.dismiss()
+      }
+      // Prompt for description if the entry had none.
+      if (wasEmpty) {
+        setQuickNoteEntry(res.data)
       }
     }
   }, [runningEntry])
@@ -272,8 +279,10 @@ export function useTimer() {
     elapsedSeconds,
     isLoading,
     idleEvent,
+    quickNoteEntry,
     setSelectedClientId,
     setDescription,
+    setQuickNoteEntry,
     start,
     stop,
     startWithClient,

--- a/src/renderer/src/store/timerStore.ts
+++ b/src/renderer/src/store/timerStore.ts
@@ -15,6 +15,9 @@ interface TimerState {
   // Idle modal
   idleEvent: { idleSince: string; idleSeconds: number } | null
 
+  // Quicknote modal — shown after stop when description was empty
+  quickNoteEntry: Entry | null
+
   // Actions
   setClients: (clients: Client[]) => void
   setRunningEntry: (entry: Entry | null) => void
@@ -23,6 +26,7 @@ interface TimerState {
   setElapsedSeconds: (s: number) => void
   setIsLoading: (v: boolean) => void
   setIdleEvent: (e: { idleSince: string; idleSeconds: number } | null) => void
+  setQuickNoteEntry: (entry: Entry | null) => void
 }
 
 export const useTimerStore = create<TimerState>((set) => ({
@@ -33,6 +37,7 @@ export const useTimerStore = create<TimerState>((set) => ({
   elapsedSeconds: 0,
   isLoading: false,
   idleEvent: null,
+  quickNoteEntry: null,
 
   setClients: (clients) => set({ clients }),
   setRunningEntry: (runningEntry) => set({ runningEntry }),
@@ -40,5 +45,6 @@ export const useTimerStore = create<TimerState>((set) => ({
   setDescription: (description) => set({ description }),
   setElapsedSeconds: (elapsedSeconds) => set({ elapsedSeconds }),
   setIsLoading: (isLoading) => set({ isLoading }),
-  setIdleEvent: (idleEvent) => set({ idleEvent })
+  setIdleEvent: (idleEvent) => set({ idleEvent }),
+  setQuickNoteEntry: (quickNoteEntry) => set({ quickNoteEntry })
 }))


### PR DESCRIPTION
## Schnell-Notiz nach Stop

Closes #25

### Was wurde geliefert

Wenn ein Timer mit **leerer Beschreibung** gestoppt wird, erscheint automatisch ein Modal „Was war das?" mit 30s-Countdown-Progressbar.

**Verhalten:**
- **Enter / Speichern-Button** — Beschreibung wird auf den gestoppten Eintrag gesetzt; TodayView + CalendarDrawer refreshen sofort via `bumpVersion()`
- **Escape / Überspringen** — Modal schließt lautlos, Eintrag bleibt ohne Beschreibung
- **Countdown läuft ab** — Auto-dismiss nach 30s ohne Aktion
- **Neuer Timer gestartet** (Widget oder Hotkey) — Modal wird sofort geschlossen, kein verwaister Eintrag ohne Beschreibung mehr

**Implementierung:**
- `timerStore`: neues `quickNoteEntry: Entry | null` + `setQuickNoteEntry`
- `useTimer.stop()`: prüft `wasEmpty` vor dem Stop; setzt `quickNoteEntry` bei leerem Eintrag
- `useTimer.start()` + `startWithClient()`: clearen `quickNoteEntry` bei neuem Timer-Start
- `QuickNoteModal.tsx`: Input + 30s Progressbar (wächst links→rechts) + Speichern/Überspringen-Buttons
- `App.tsx`: Modal über `ToastTray` gemountet (z-50, gleiche Ebene wie IdleModal)

### Tests
- TypeCheck ✅ | 114 passed | 51 skipped ✅ | keine neuen Lint-Fehler ✅
