### PR TITLE
feat(logging): crash logging via electron-log (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to TimeTrack are documented here.
 
+## [Unreleased] — v1.5
+
+### Added
+
+- **Crash-Logging** (#34, PR A) — `electron-log` schreibt App-Ereignisse und
+  Fehler nach `%AppData%\TimeTrack\logs\main.log` (Windows; analoge Pfade auf
+  macOS/Linux). Renderer-`console.*`-Aufrufe werden via IPC in dieselbe Datei
+  gespiegelt, sodass Bug-Reports ein vollständiges Bild liefern. Globale
+  Handler für `uncaughtException` und `unhandledRejection` erfassen Crashes,
+  die sonst silent verschwinden würden. Log-Datei rotiert automatisch bei 5 MB.
+  Settings → "Diagnose" zeigt den Pfad und bietet Buttons "Im Explorer zeigen"
+  + "Ordner öffnen" zum schnellen Anhängen an Issue-Reports.
+
 ## [1.3.0] — 2026-04-25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@electron-toolkit/utils": "^4.0.0",
     "better-sqlite3": "^12.9.0",
     "date-fns": "^4.1.0",
+    "electron-log": "^5.4.3",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      electron-log:
+        specifier: ^5.4.3
+        version: 5.4.3
       zustand:
         specifier: ^5.0.12
         version: 5.0.12(@types/react@19.2.14)(react@19.2.5)
@@ -1776,6 +1779,10 @@ packages:
     resolution: {integrity: sha512-uWhx1r74NGpCagG0ULs/P9Nqv2nsoo+7eo4fLUOB8L8MdWltq9odW/uuLXMFCDGnPafknYLZgjNX0ZIFRzOQAw==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  electron-log@5.4.3:
+    resolution: {integrity: sha512-sOUsM3LjZdugatazSQ/XTyNcw8dfvH1SYhXWiJyfYodAAKOZdHs0txPiLDXFzOZbhXgAgshQkshH2ccq0feyLQ==}
+    engines: {node: '>= 14'}
 
   electron-publish@26.8.1:
     resolution: {integrity: sha512-q+jrSTIh/Cv4eGZa7oVR+grEJo/FoLMYBAnSL5GCtqwUpr1T+VgKB/dn1pnzxIxqD8S/jP1yilT9VrwCqINR4w==}
@@ -5121,6 +5128,8 @@ snapshots:
     transitivePeerDependencies:
       - electron-builder-squirrel-windows
       - supports-color
+
+  electron-log@5.4.3: {}
 
   electron-publish@26.8.1:
     dependencies:

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,6 +9,7 @@ import {
   dialog,
   type MenuItemConstructorOptions
 } from 'electron'
+import log from 'electron-log/main'
 import { join } from 'path'
 import { writeFileSync } from 'fs'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
@@ -26,6 +27,27 @@ import {
   rearmIdleWatcher
 } from './idle'
 import type { Client } from '../shared/types'
+
+// ── Logging (v1.5 PR A) ─────────────────────────────────────────
+// electron-log writes to %AppData%\TimeTrack\logs\main.log on Windows
+// (~/Library/Logs/TimeTrack on macOS, ~/.config/TimeTrack/logs on Linux).
+// `spyRendererConsole: true` mirrors renderer console.* into the same
+// file via IPC — no separate channel needed. `Object.assign(console, …)`
+// routes main-process console.* through the logger too, so existing
+// console.error/warn/info calls in db.ts/ipc.ts/etc. land in the file
+// without code changes.
+log.initialize({ preload: true, spyRendererConsole: true })
+log.transports.file.level = 'info'
+log.transports.file.maxSize = 5 * 1024 * 1024 // 5 MB, rotates to .old
+Object.assign(console, log.functions)
+
+// Catch-all for crashes that escape try/catch.
+process.on('uncaughtException', (err) => {
+  log.error('uncaughtException:', err)
+})
+process.on('unhandledRejection', (reason) => {
+  log.error('unhandledRejection:', reason)
+})
 
 let mainWindow: BrowserWindow | null = null
 let tray: Tray | null = null

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -2,6 +2,8 @@ import { ipcMain, shell } from 'electron'
 import { app } from 'electron'
 import { dialog } from 'electron'
 import { writeFileSync } from 'fs'
+import { dirname } from 'path'
+import log from 'electron-log/main'
 import { randomUUID } from 'crypto'
 import { getDb, getDbPath } from './db'
 import { getBackupsDir } from './backup'
@@ -535,9 +537,20 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
   })
 
   // ── Paths (for Settings-View) ──────────────────────────
-  ipcMain.handle('paths:get', (): IpcResult<{ db: string; backups: string }> => {
-    return ok({ db: getDbPath(), backups: getBackupsDir() })
-  })
+  ipcMain.handle(
+    'paths:get',
+    (): IpcResult<{ db: string; backups: string; logs: string; logFile: string }> => {
+      // electron-log returns a File transport whose `getFile()` resolves
+      // the on-disk log path lazily; the directory is its parent.
+      const logFile = log.transports.file.getFile().path
+      return ok({
+        db: getDbPath(),
+        backups: getBackupsDir(),
+        logs: dirname(logFile),
+        logFile
+      })
+    }
+  )
 
   ipcMain.handle('app:getVersion', (): IpcResult<string> => {
     return ok(app.getVersion())

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -89,7 +89,7 @@ declare global {
         showItemInFolder(path: string): Promise<IpcResult<void>>
       }
       paths: {
-        get(): Promise<IpcResult<{ db: string; backups: string }>>
+        get(): Promise<IpcResult<{ db: string; backups: string; logs: string; logFile: string }>>
       }
       exporter: {
         json(): Promise<IpcResult<{ path: string; bytes: number }>>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -127,7 +127,8 @@ const api = {
       ipcRenderer.invoke('shell:showItemInFolder', path)
   },
   paths: {
-    get: (): Promise<IpcResult<{ db: string; backups: string }>> => ipcRenderer.invoke('paths:get')
+    get: (): Promise<IpcResult<{ db: string; backups: string; logs: string; logFile: string }>> =>
+      ipcRenderer.invoke('paths:get')
   },
   exporter: {
     json: (): Promise<IpcResult<{ path: string; bytes: number }>> =>

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -1,4 +1,7 @@
 import './assets/main.css'
+// v1.5 PR A — route renderer console.* through main-process electron-log
+// (which is initialized with spyRendererConsole: true). Picked up via IPC.
+import 'electron-log/renderer'
 
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -32,7 +32,12 @@ function parseAccelerator(e: KeyboardEvent): string | null {
 
 export default function SettingsView(): React.JSX.Element {
   const [settings, setSettings] = useState<Settings | null>(null)
-  const [paths, setPaths] = useState<{ db: string; backups: string } | null>(null)
+  const [paths, setPaths] = useState<{
+    db: string
+    backups: string
+    logs: string
+    logFile: string
+  } | null>(null)
   const [version, setVersion] = useState<string>('')
   const [backups, setBackups] = useState<BackupInfo[]>([])
   const [capturingHotkey, setCapturingHotkey] = useState<HotkeyKey | null>(null)
@@ -395,6 +400,37 @@ export default function SettingsView(): React.JSX.Element {
           </div>
           <p className="mt-1 text-xs text-slate-500">
             Lesbares Format zum Backup oder zur Weiterverarbeitung. CSV/PDF folgen.
+          </p>
+        </Row>
+      </Section>
+
+      {/* Diagnose (v1.5 PR A, issue #34) */}
+      <Section title="Diagnose">
+        <Row
+          label="Log-Datei"
+          hint="Bei Problemen: Datei kopieren und beim Bug-Report anhängen."
+        >
+          <div className="flex items-center gap-2">
+            <code className="flex-1 truncate rounded bg-slate-800 px-3 py-1.5 text-xs text-slate-300">
+              {paths.logFile}
+            </code>
+            <button
+              type="button"
+              onClick={() => window.api.shell.showItemInFolder(paths.logFile)}
+              className={btnSecondaryClass}
+            >
+              Im Explorer zeigen
+            </button>
+            <button
+              type="button"
+              onClick={() => window.api.shell.openPath(paths.logs)}
+              className={btnSecondaryClass}
+            >
+              Ordner öffnen
+            </button>
+          </div>
+          <p className="mt-1 text-xs text-slate-500">
+            Rotiert automatisch bei 5 MB. Enthält App-Ereignisse und Fehler aus Main- und Renderer-Process.
           </p>
         </Row>
       </Section>


### PR DESCRIPTION
Schliesst #34. Erste PR der v1.5-Serie (Plan: .github/plan-v1.5.md).

## Was

- electron-log (5.4.3) initialisiert in main mit `preload: true, spyRendererConsole: true`.
- Renderer-Side: `import 'electron-log/renderer'` in main.tsx -> Renderer-console.* wird per IPC in dieselbe Logdatei gespiegelt.
- Globale Handler fuer `uncaughtException` + `unhandledRejection` schreiben Stacks ins Log.
- Auto-Rotation bei 5 MB (electron-log default).
- `paths:get` IPC um `logs` + `logFile` erweitert.
- SettingsView: neue Sektion **Diagnose** mit Pfad-Anzeige + Buttons 'Im Explorer zeigen' / 'Ordner oeffnen'.

## Wo liegt das Log

- Windows: `%AppData%\TimeTrack\logs\main.log`
- macOS: `~/Library/Logs/TimeTrack/main.log`
- Linux: `~/.config/TimeTrack/logs/main.log`

## Tests

- `pnpm typecheck` gruen
- `pnpm test` 114/114 (51 DB-Tests skipped lokal, laufen in CI)
- Lint-Errors unveraendert (vorbestehend)

## Foundation

Fundament fuer PR B (Auto-Update) — der Updater nutzt diesen Logger via `autoUpdater.logger = log`.