### PR TITLE
feat(updater): auto-update via electron-updater (PR B, #28)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ out
 # Locally generated PDF exports (Stundennachweis test outputs).
 # Curated reference PDFs in templates/ stay tracked individually.
 templates/Stundennachweis-*.pdf
+
+# v1.5 PR B — local auto-updater dev config (points at scripts/test-updater.mjs).
+build/dev-app-update.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to TimeTrack are documented here.
 
 ### Added
 
+- **Auto-Update** (#28, PR B) — `electron-updater` prüft beim App-Start auf
+  GitHub-Releases, lädt neue Versionen automatisch im Hintergrund und zeigt
+  ein dezentes Indigo-Banner an, sobald die Installation bereit ist. Der
+  User entscheidet, wann neu gestartet wird — kein Force-Restart, kein
+  Datenverlust bei laufendem Timer. Settings → "Updates" zeigt aktuelle
+  Version, Status und letzte Prüfung; manueller "Jetzt nach Updates suchen"-
+  Button für ungeduldige User. Offline-Toleranz: stiller Fallback ohne rote
+  Fehlerbanner beim ersten Start ohne Internet. Alle Updater-Events fließen
+  in dieselbe Log-Datei wie PR A. Lokales Test-Setup via
+  `scripts/test-updater.mjs` + `build/dev-app-update.yml`.
 - **Crash-Logging** (#34, PR A) — `electron-log` schreibt App-Ereignisse und
   Fehler nach `%AppData%\TimeTrack\logs\main.log` (Windows; analoge Pfade auf
   macOS/Linux). Renderer-`console.*`-Aufrufe werden via IPC in dieselbe Datei

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -29,3 +29,7 @@ nsis:
   createDesktopShortcut: always
   createStartMenuShortcut: true
 npmRebuild: false
+publish:
+  provider: github
+  owner: skoedr
+  repo: time-tracking

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "better-sqlite3": "^12.9.0",
     "date-fns": "^4.1.0",
     "electron-log": "^5.4.3",
+    "electron-updater": "^6.8.3",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       electron-log:
         specifier: ^5.4.3
         version: 5.4.3
+      electron-updater:
+        specifier: ^6.8.3
+        version: 6.8.3
       zustand:
         specifier: ^5.0.12
         version: 5.0.12(@types/react@19.2.14)(react@19.2.5)
@@ -1790,6 +1793,9 @@ packages:
   electron-to-chromium@1.5.343:
     resolution: {integrity: sha512-YHnQ3MXI08icvL9ZKnEBy05F2EQ8ob01UaMOuMbM8l+4UcAq6MPPbBTJBbsBUg3H8JeZNt+O4fjsoWth3p6IFg==}
 
+  electron-updater@6.8.3:
+    resolution: {integrity: sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==}
+
   electron-vite@5.0.0:
     resolution: {integrity: sha512-OHp/vjdlubNlhNkPkL/+3JD34ii5ov7M0GpuXEVdQeqdQ3ulvVR7Dg/rNBLfS5XPIFwgoBLDf9sjjrL+CuDyRQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2532,6 +2538,13 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
@@ -3181,6 +3194,9 @@ packages:
 
   tiny-async-pool@1.3.0:
     resolution: {integrity: sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==}
+
+  tiny-typed-emitter@2.1.0:
+    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -5146,6 +5162,19 @@ snapshots:
 
   electron-to-chromium@1.5.343: {}
 
+  electron-updater@6.8.3:
+    dependencies:
+      builder-util-runtime: 9.5.1
+      fs-extra: 10.1.0
+      js-yaml: 4.1.1
+      lazy-val: 1.0.5
+      lodash.escaperegexp: 4.1.2
+      lodash.isequal: 4.5.0
+      semver: 7.7.4
+      tiny-typed-emitter: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   electron-vite@5.0.0(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)):
     dependencies:
       '@babel/core': 7.29.0
@@ -6059,6 +6088,10 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.escaperegexp@4.1.2: {}
+
+  lodash.isequal@4.5.0: {}
+
   lodash.merge@4.6.2: {}
 
   lodash@4.18.1: {}
@@ -6814,6 +6847,8 @@ snapshots:
   tiny-async-pool@1.3.0:
     dependencies:
       semver: 5.7.2
+
+  tiny-typed-emitter@2.1.0: {}
 
   tinybench@2.9.0: {}
 

--- a/scripts/test-updater.mjs
+++ b/scripts/test-updater.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/**
+ * v1.5 PR B — local update server for testing electron-updater in dev.
+ *
+ * Usage:
+ *   1. Build a real installer with a higher version, e.g. 1.99.0:
+ *        # bump package.json to 1.99.0
+ *        pnpm build:win
+ *   2. Copy `dist/TimeTrack-Setup-1.99.0.exe` and `dist/latest.yml`
+ *      into `scripts/.update-fixtures/`.
+ *   3. Run this script:
+ *        node scripts/test-updater.mjs
+ *   4. Create `build/dev-app-update.yml` (gitignored) with:
+ *        provider: generic
+ *        url: http://localhost:8788
+ *   5. Start the app in dev (`pnpm dev`) — it should detect the update.
+ *
+ * The server logs every request so you can verify the updater client is
+ * polling the expected paths (`latest.yml`, `*.exe`, `*.blockmap`).
+ */
+import { createServer } from 'node:http'
+import { readFile, stat } from 'node:fs/promises'
+import { resolve, join, basename } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url))
+const ROOT = resolve(__dirname, '.update-fixtures')
+const PORT = Number(process.env.UPDATE_PORT ?? 8788)
+
+const MIME = {
+  '.yml': 'text/yaml',
+  '.yaml': 'text/yaml',
+  '.exe': 'application/octet-stream',
+  '.blockmap': 'application/octet-stream'
+}
+
+const server = createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url ?? '/', `http://localhost:${PORT}`)
+    const safe = basename(url.pathname) // strip path traversal
+    const file = join(ROOT, safe)
+    const info = await stat(file)
+    const ext = safe.slice(safe.lastIndexOf('.'))
+    const data = await readFile(file)
+    res.writeHead(200, {
+      'Content-Type': MIME[ext] ?? 'application/octet-stream',
+      'Content-Length': info.size,
+      'Cache-Control': 'no-store'
+    })
+    res.end(data)
+    console.log(`[200] ${req.method} ${url.pathname} (${info.size} bytes)`)
+  } catch (err) {
+    res.writeHead(404, { 'Content-Type': 'text/plain' })
+    res.end('not found')
+    console.log(`[404] ${req.method} ${req.url} — ${err instanceof Error ? err.message : err}`)
+  }
+})
+
+server.listen(PORT, () => {
+  console.log(`Update fixtures server listening on http://localhost:${PORT}`)
+  console.log(`Serving from: ${ROOT}`)
+})

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -18,6 +18,7 @@ import trayRunningIcon from '../../resources/tray-running.png?asset'
 import trayStoppedIcon from '../../resources/tray-stopped.png?asset'
 import { getDb, recoverZombieEntries, MigrationError } from './db'
 import { registerIpcHandlers } from './ipc'
+import { initAutoUpdater } from './updater'
 import { applyMiniEnabled, destroyMini, pushMiniState, toggleMini } from './miniWindow'
 import {
   configureIdleWatcher,
@@ -437,6 +438,10 @@ app.whenReady().then(async () => {
     setMiniHotkey: (accelerator) => registerMiniHotkey(accelerator)
   })
   createWindow()
+
+  // v1.5 PR B — init auto-updater after the main window exists so events
+  // can be broadcast to the renderer immediately.
+  initAutoUpdater({ isDev: is.dev })
 
   refreshActiveClients()
   configureIdleWatcher({ getWindow: () => mainWindow })

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Status-transition reducer tests for the auto-update flow.
+ *
+ * We don't boot electron-updater here — instead we exercise a pure
+ * reducer that mirrors the lifecycle the renderer-side store cares
+ * about. Same shape as `src/main/updater.ts` UpdateStatus, but
+ * driven by named events to keep the test self-contained.
+ */
+import { describe, it, expect } from 'vitest'
+
+type Status =
+  | { status: 'idle' }
+  | { status: 'checking' }
+  | { status: 'available'; version: string }
+  | { status: 'downloading'; version: string; progress: number }
+  | { status: 'ready'; version: string }
+  | { status: 'not-available'; checkedAt: string }
+  | { status: 'error'; message: string }
+
+type Event =
+  | { type: 'check' }
+  | { type: 'available'; version: string }
+  | { type: 'progress'; percent: number }
+  | { type: 'downloaded'; version: string }
+  | { type: 'not-available' }
+  | { type: 'error'; message: string }
+
+function reduce(prev: Status, event: Event): Status {
+  switch (event.type) {
+    case 'check':
+      return { status: 'checking' }
+    case 'available':
+      return { status: 'available', version: event.version }
+    case 'progress': {
+      const version =
+        prev.status === 'available' || prev.status === 'downloading' ? prev.version : ''
+      return { status: 'downloading', version, progress: Math.round(event.percent) }
+    }
+    case 'downloaded':
+      return { status: 'ready', version: event.version }
+    case 'not-available':
+      return { status: 'not-available', checkedAt: '2026-04-25T00:00:00Z' }
+    case 'error':
+      return { status: 'error', message: event.message }
+  }
+}
+
+describe('updater status reducer', () => {
+  it('starts idle', () => {
+    const s: Status = { status: 'idle' }
+    expect(s.status).toBe('idle')
+  })
+
+  it('idle -> checking -> available -> downloading -> ready', () => {
+    let s: Status = { status: 'idle' }
+    s = reduce(s, { type: 'check' })
+    expect(s.status).toBe('checking')
+
+    s = reduce(s, { type: 'available', version: '1.5.1' })
+    expect(s).toEqual({ status: 'available', version: '1.5.1' })
+
+    s = reduce(s, { type: 'progress', percent: 42.7 })
+    expect(s).toEqual({ status: 'downloading', version: '1.5.1', progress: 43 })
+
+    s = reduce(s, { type: 'progress', percent: 99.1 })
+    expect(s).toEqual({ status: 'downloading', version: '1.5.1', progress: 99 })
+
+    s = reduce(s, { type: 'downloaded', version: '1.5.1' })
+    expect(s).toEqual({ status: 'ready', version: '1.5.1' })
+  })
+
+  it('progress before available falls back to empty version', () => {
+    let s: Status = { status: 'checking' }
+    s = reduce(s, { type: 'progress', percent: 10 })
+    expect(s).toEqual({ status: 'downloading', version: '', progress: 10 })
+  })
+
+  it('error overrides any prior status', () => {
+    let s: Status = { status: 'available', version: '1.5.1' }
+    s = reduce(s, { type: 'error', message: 'ENOTFOUND' })
+    expect(s).toEqual({ status: 'error', message: 'ENOTFOUND' })
+  })
+
+  it('not-available records the check time', () => {
+    let s: Status = { status: 'checking' }
+    s = reduce(s, { type: 'not-available' })
+    expect(s.status).toBe('not-available')
+    if (s.status === 'not-available') {
+      expect(s.checkedAt).toBeTruthy()
+    }
+  })
+
+  it('progress percent is rounded', () => {
+    const s = reduce(
+      { status: 'available', version: '2.0.0' },
+      { type: 'progress', percent: 33.499 }
+    )
+    expect(s).toEqual({ status: 'downloading', version: '2.0.0', progress: 33 })
+  })
+})

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -1,0 +1,134 @@
+/**
+ * v1.5 PR B — Auto-Update via electron-updater (#33).
+ *
+ * Bridge between electron-updater events and the renderer UI:
+ * - Subscribes to all updater lifecycle events.
+ * - Pushes a normalized `UpdateStatus` to all open windows via IPC.
+ * - Provides imperative IPC handlers for "check now" and "install now".
+ *
+ * Offline policy: errors during the initial silent check are logged but
+ * NOT pushed as an `error` status — we don't want a red banner on every
+ * offline app start. Errors triggered by an explicit user "check now"
+ * are surfaced (so the Settings UI can show "no connection").
+ */
+import { app, BrowserWindow, ipcMain } from 'electron'
+import log from 'electron-log/main'
+import pkg from 'electron-updater'
+const { autoUpdater } = pkg
+import type { IpcResult, UpdateStatus } from '../shared/types'
+
+export type { UpdateStatus }
+
+let lastStatus: UpdateStatus = { status: 'idle' }
+let lastCheckIso: string | null = null
+let suppressNextError = false // for offline-tolerant initial check
+
+function ok<T>(data: T): IpcResult<T> {
+  return { ok: true, data }
+}
+function fail(error: unknown): IpcResult<never> {
+  return { ok: false, error: String(error) }
+}
+
+function broadcast(status: UpdateStatus): void {
+  lastStatus = status
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) {
+      win.webContents.send('update:status', status)
+    }
+  }
+}
+
+/**
+ * Initialize the updater. Must be called after `app.whenReady()`.
+ *
+ * In dev mode (no packaged app) this is a no-op except for IPC handler
+ * registration — `autoUpdater.checkForUpdates()` would error otherwise.
+ */
+export function initAutoUpdater(opts: { isDev: boolean }): void {
+  // Wire up logger from PR A so updater events land in main.log.
+  autoUpdater.logger = log
+  autoUpdater.autoDownload = true
+  autoUpdater.autoInstallOnAppQuit = false // we surface a button instead
+
+  autoUpdater.on('checking-for-update', () => {
+    broadcast({ status: 'checking' })
+  })
+
+  autoUpdater.on('update-available', (info: { version: string }) => {
+    broadcast({ status: 'available', version: info.version })
+  })
+
+  autoUpdater.on('update-not-available', (info: { version: string }) => {
+    lastCheckIso = new Date().toISOString()
+    broadcast({ status: 'not-available', checkedAt: lastCheckIso })
+    log.info(`No update available (current: ${info.version})`)
+  })
+
+  autoUpdater.on(
+    'download-progress',
+    (p: { percent: number; transferred: number; total: number }) => {
+      const version =
+        lastStatus.status === 'available' || lastStatus.status === 'downloading'
+          ? lastStatus.version
+          : ''
+      broadcast({ status: 'downloading', version, progress: Math.round(p.percent) })
+    }
+  )
+
+  autoUpdater.on('update-downloaded', (info: { version: string }) => {
+    broadcast({ status: 'ready', version: info.version })
+  })
+
+  autoUpdater.on('error', (err: Error) => {
+    if (suppressNextError) {
+      suppressNextError = false
+      log.warn('Update check failed (suppressed, likely offline):', err.message)
+      broadcast({ status: 'idle' })
+      return
+    }
+    broadcast({ status: 'error', message: err.message })
+  })
+
+  // ── IPC handlers ───────────────────────────────────────────
+  ipcMain.handle('update:getStatus', (): IpcResult<UpdateStatus> => ok(lastStatus))
+  ipcMain.handle(
+    'update:getLastCheck',
+    (): IpcResult<string | null> => ok(lastCheckIso)
+  )
+  ipcMain.handle('update:getVersion', (): IpcResult<string> => ok(app.getVersion()))
+
+  ipcMain.handle('update:check', async (): Promise<IpcResult<void>> => {
+    if (opts.isDev) {
+      return fail('Update-Check ist im Entwicklungsmodus deaktiviert.')
+    }
+    try {
+      lastCheckIso = new Date().toISOString()
+      await autoUpdater.checkForUpdates()
+      return ok(undefined)
+    } catch (err) {
+      return fail((err as Error).message)
+    }
+  })
+
+  ipcMain.handle('update:install', (): IpcResult<void> => {
+    try {
+      // quitAndInstall(isSilent=false, isForceRunAfter=true)
+      // — shows the NSIS installer UI, then re-launches TimeTrack.
+      autoUpdater.quitAndInstall(false, true)
+      return ok(undefined)
+    } catch (err) {
+      return fail((err as Error).message)
+    }
+  })
+
+  // ── Initial silent check ──────────────────────────────────
+  // Don't surface errors here — offline app starts shouldn't show a banner.
+  if (!opts.isDev) {
+    suppressNextError = true
+    lastCheckIso = new Date().toISOString()
+    autoUpdater.checkForUpdatesAndNotify().catch((err) => {
+      log.warn('Initial update check failed:', err.message)
+    })
+  }
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -11,7 +11,8 @@ import type {
   Settings,
   IpcResult,
   BackupInfo,
-  DashboardSummary
+  DashboardSummary,
+  UpdateStatus
 } from '../shared/types'
 
 declare global {
@@ -109,6 +110,14 @@ declare global {
       logo: {
         set(): Promise<IpcResult<{ path: string }>>
         clear(): Promise<IpcResult<void>>
+      }
+      update: {
+        getStatus(): Promise<IpcResult<UpdateStatus>>
+        getLastCheck(): Promise<IpcResult<string | null>>
+        getVersion(): Promise<IpcResult<string>>
+        check(): Promise<IpcResult<void>>
+        install(): Promise<IpcResult<void>>
+        onStatus(callback: (status: UpdateStatus) => void): () => void
       }
     }
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -12,7 +12,8 @@ import type {
   Settings,
   IpcResult,
   BackupInfo,
-  DashboardSummary
+  DashboardSummary,
+  UpdateStatus
 } from '../shared/types'
 
 const api = {
@@ -149,6 +150,22 @@ const api = {
   logo: {
     set: (): Promise<IpcResult<{ path: string }>> => ipcRenderer.invoke('logo:set'),
     clear: (): Promise<IpcResult<void>> => ipcRenderer.invoke('logo:clear')
+  },
+  // v1.5 PR B — auto-updater
+  update: {
+    getStatus: (): Promise<IpcResult<UpdateStatus>> => ipcRenderer.invoke('update:getStatus'),
+    getLastCheck: (): Promise<IpcResult<string | null>> =>
+      ipcRenderer.invoke('update:getLastCheck'),
+    getVersion: (): Promise<IpcResult<string>> => ipcRenderer.invoke('update:getVersion'),
+    check: (): Promise<IpcResult<void>> => ipcRenderer.invoke('update:check'),
+    install: (): Promise<IpcResult<void>> => ipcRenderer.invoke('update:install'),
+    onStatus: (callback: (status: UpdateStatus) => void): (() => void) => {
+      const handler = (_e: unknown, status: UpdateStatus): void => callback(status)
+      ipcRenderer.on('update:status', handler)
+      return (): void => {
+        ipcRenderer.removeListener('update:status', handler)
+      }
+    }
   }
 }
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -7,6 +7,7 @@ import SettingsView from './views/SettingsView'
 import { IdleModal } from './components/IdleModal'
 import { QuickNoteModal } from './components/QuickNoteModal'
 import { ToastTray } from './components/Toast'
+import { UpdateBanner } from './components/UpdateBanner'
 import { useTimer } from './hooks/useTimer'
 
 type View = 'today' | 'timer' | 'calendar' | 'clients' | 'settings'
@@ -26,6 +27,7 @@ function App(): React.JSX.Element {
 
   return (
     <div className="h-screen bg-slate-900 text-slate-100 flex flex-col overflow-hidden">
+      <UpdateBanner />
       {/* Nav */}
       <nav className="flex gap-1 px-3 py-2 bg-slate-800 border-b border-slate-700 shrink-0">
         {(['today', 'timer', 'calendar', 'clients', 'settings'] as View[]).map((v) => (

--- a/src/renderer/src/components/UpdateBanner.tsx
+++ b/src/renderer/src/components/UpdateBanner.tsx
@@ -1,0 +1,98 @@
+import { useEffect } from 'react'
+import { useUpdateStore } from '../store/updateStore'
+
+/**
+ * v1.5 PR B — slim banner above the main app surface.
+ *
+ * Visible only for non-idle states. Color choices follow the design-review
+ * decision: indigo for passive info (available/downloading/ready), amber
+ * for errors (NOT red — we don't want to alarm users).
+ *
+ * `idle` and `not-available` collapse the banner entirely.
+ */
+export function UpdateBanner(): React.JSX.Element | null {
+  const { status, dismissed, dismissReady, installNow } = useUpdateStore()
+
+  useEffect(() => {
+    void useUpdateStore.getState().init()
+  }, [])
+
+  if (status.status === 'idle' || status.status === 'not-available') return null
+  if (status.status === 'ready' && dismissed) return null
+
+  let content: React.ReactNode = null
+  let tone: 'info' | 'warn' = 'info'
+
+  switch (status.status) {
+    case 'checking':
+      content = <span className="text-sm">Suche nach Updates …</span>
+      break
+    case 'available':
+      content = (
+        <span className="text-sm">
+          Version <span className="font-semibold">{status.version}</span> verfügbar — wird
+          heruntergeladen …
+        </span>
+      )
+      break
+    case 'downloading':
+      content = (
+        <span className="text-sm">
+          Lade Version <span className="font-semibold">{status.version || '…'}</span>:{' '}
+          {status.progress}%
+        </span>
+      )
+      break
+    case 'ready':
+      content = (
+        <div className="flex w-full items-center justify-between gap-3">
+          <span className="text-sm">
+            Version <span className="font-semibold">{status.version}</span> bereit — App neu
+            starten?
+          </span>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => void installNow()}
+              className="rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-indigo-500"
+            >
+              Jetzt neu starten
+            </button>
+            <button
+              type="button"
+              onClick={dismissReady}
+              className="rounded-md px-2 py-1 text-xs text-indigo-200 transition-colors hover:bg-indigo-500/20"
+              aria-label="Banner ausblenden"
+            >
+              Später
+            </button>
+          </div>
+        </div>
+      )
+      break
+    case 'error':
+      tone = 'warn'
+      content = (
+        <span className="text-sm">
+          Update-Fehler: <span className="font-mono text-xs">{status.message}</span>
+          {' — '}
+          <span className="text-xs opacity-80">Details in den Einstellungen.</span>
+        </span>
+      )
+      break
+  }
+
+  const toneClasses =
+    tone === 'warn'
+      ? 'bg-amber-900/70 text-amber-100 ring-amber-700/50'
+      : 'bg-indigo-900/70 text-indigo-100 ring-indigo-700/50'
+
+  return (
+    <div
+      role="status"
+      className={`flex items-center px-4 py-2 ring-1 ring-inset ${toneClasses}`}
+    >
+      {content}
+    </div>
+  )
+}

--- a/src/renderer/src/store/updateStore.ts
+++ b/src/renderer/src/store/updateStore.ts
@@ -1,0 +1,78 @@
+import { create } from 'zustand'
+import type { UpdateStatus } from '../../../shared/types'
+
+/**
+ * v1.5 PR B — auto-update store.
+ *
+ * Mirrors the main-process updater state. Subscribes to `update:status`
+ * IPC events on first use; calls the imperative `update:check` /
+ * `update:install` IPC handlers via the methods below.
+ */
+interface UpdateStore {
+  status: UpdateStatus
+  appVersion: string
+  lastCheckedAt: string | null
+  /** Whether the user has dismissed the current `ready` banner. */
+  dismissed: boolean
+  setStatus: (status: UpdateStatus) => void
+  setAppVersion: (v: string) => void
+  setLastCheckedAt: (iso: string | null) => void
+  dismissReady: () => void
+  /** Initialize the store: subscribe to events + fetch initial state. */
+  init: () => Promise<void>
+  /** Trigger a manual update check from Settings. */
+  checkNow: () => Promise<void>
+  /** Quit and run the installer. */
+  installNow: () => Promise<void>
+}
+
+let unsubscribe: (() => void) | null = null
+
+export const useUpdateStore = create<UpdateStore>((set, get) => ({
+  status: { status: 'idle' },
+  appVersion: '',
+  lastCheckedAt: null,
+  dismissed: false,
+
+  setStatus: (status) => {
+    // New `ready` event resets the dismissed flag so we show it again.
+    set((prev) => ({
+      status,
+      dismissed: status.status === 'ready' && prev.status.status !== 'ready' ? false : prev.dismissed
+    }))
+  },
+  setAppVersion: (v) => set({ appVersion: v }),
+  setLastCheckedAt: (iso) => set({ lastCheckedAt: iso }),
+  dismissReady: () => set({ dismissed: true }),
+
+  init: async () => {
+    if (unsubscribe) return
+    unsubscribe = window.api.update.onStatus((status) => {
+      get().setStatus(status)
+      // Persist last-check timestamp on terminal events.
+      if (status.status === 'not-available') {
+        get().setLastCheckedAt(status.checkedAt)
+      }
+    })
+    const [ver, st, last] = await Promise.all([
+      window.api.update.getVersion(),
+      window.api.update.getStatus(),
+      window.api.update.getLastCheck()
+    ])
+    if (ver.ok) get().setAppVersion(ver.data)
+    if (st.ok) get().setStatus(st.data)
+    if (last.ok) get().setLastCheckedAt(last.data)
+  },
+
+  checkNow: async () => {
+    set({ status: { status: 'checking' } })
+    const res = await window.api.update.check()
+    if (!res.ok) {
+      set({ status: { status: 'error', message: res.error } })
+    }
+  },
+
+  installNow: async () => {
+    await window.api.update.install()
+  }
+}))

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import type { Settings, BackupInfo } from '../../../shared/types'
+import { useUpdateStore } from '../store/updateStore'
 
 const DEFAULT_HOTKEY = 'Alt+Shift+S'
 const DEFAULT_MINI_HOTKEY = 'Alt+Shift+M'
@@ -435,6 +436,9 @@ export default function SettingsView(): React.JSX.Element {
         </Row>
       </Section>
 
+      {/* Updates (v1.5 PR B, issue #28) */}
+      <UpdatesSection />
+
       {/* PDF-Vorlage (v1.3 PR C, issues #16 + #19) */}
       <Section title="PDF-Vorlage">
         <Row label="Logo" hint="PNG, JPG, SVG oder WebP, max. 1 MB.">
@@ -566,5 +570,92 @@ function Row({
       {children}
       {hint && <p className="text-xs text-slate-500">{hint}</p>}
     </div>
+  )
+}
+
+/**
+ * v1.5 PR B — Updates section. Reads + drives state from useUpdateStore.
+ * The store auto-initializes on first mount via UpdateBanner; we still call
+ * `init()` here defensively in case Settings is opened before the banner
+ * has appeared in some future layout change.
+ */
+function UpdatesSection(): React.JSX.Element {
+  const { status, appVersion, lastCheckedAt, checkNow, installNow, init } = useUpdateStore()
+  useEffect(() => {
+    void init()
+  }, [init])
+
+  const busy = status.status === 'checking' || status.status === 'downloading'
+  const lastCheckedLabel = lastCheckedAt
+    ? new Date(lastCheckedAt).toLocaleString('de-DE')
+    : 'noch nicht geprüft'
+
+  let statusLabel = ''
+  switch (status.status) {
+    case 'idle':
+      statusLabel = 'Bereit'
+      break
+    case 'checking':
+      statusLabel = 'Suche nach Updates …'
+      break
+    case 'available':
+      statusLabel = `Version ${status.version} wird heruntergeladen …`
+      break
+    case 'downloading':
+      statusLabel = `Lade Version ${status.version || '…'}: ${status.progress}%`
+      break
+    case 'ready':
+      statusLabel = `Version ${status.version} bereit zur Installation`
+      break
+    case 'not-available':
+      statusLabel = 'Du verwendest die aktuelle Version.'
+      break
+    case 'error':
+      statusLabel = `Fehler: ${status.message}`
+      break
+  }
+
+  return (
+    <Section title="Updates">
+      <Row label="Aktuelle Version">
+        <code className="inline-block w-fit rounded bg-slate-800 px-3 py-1.5 text-xs text-slate-300">
+          {appVersion || '—'}
+        </code>
+      </Row>
+      <Row label="Status" hint={`Letzte Prüfung: ${lastCheckedLabel}`}>
+        <p
+          className={`text-sm ${
+            status.status === 'error' ? 'text-amber-300' : 'text-slate-200'
+          }`}
+        >
+          {statusLabel}
+        </p>
+      </Row>
+      <Row label="Aktionen">
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={() => void checkNow()}
+            disabled={busy}
+            className={`${btnSecondaryClass} disabled:cursor-not-allowed disabled:opacity-50`}
+          >
+            Jetzt nach Updates suchen
+          </button>
+          {status.status === 'ready' && (
+            <button
+              type="button"
+              onClick={() => void installNow()}
+              className="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            >
+              Jetzt neu starten und installieren
+            </button>
+          )}
+        </div>
+        <p className="mt-1 text-xs text-slate-500">
+          Updates werden bei App-Start automatisch geprüft und im Hintergrund geladen. Du
+          entscheidest, wann installiert wird.
+        </p>
+      </Row>
+    </Section>
   )
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -128,6 +128,18 @@ export interface BackupInfo {
   sizeBytes: number
 }
 
+/**
+ * v1.5 PR B — auto-update lifecycle status broadcast over `update:status` IPC.
+ */
+export type UpdateStatus =
+  | { status: 'idle' }
+  | { status: 'checking' }
+  | { status: 'available'; version: string }
+  | { status: 'downloading'; version: string; progress: number }
+  | { status: 'ready'; version: string }
+  | { status: 'not-available'; checkedAt: string }
+  | { status: 'error'; message: string }
+
 /** Aggregated dashboard view returned by `dashboard:summary`. */
 export interface DashboardSummary {
   todaySeconds: number


### PR DESCRIPTION
## v1.5 PR B — Auto-Update via electron-updater

Closes #28. Plan: `.github/plan-v1.5.md` PR B section.

### Was drin ist
- `electron-updater` 6.8.3 mit GitHub-Provider (`skoedr/time-tracking`) in `electron-builder.yml`.
- Neuer Main-Service `src/main/updater.ts`: discriminated `UpdateStatus`-Union (idle/checking/available/downloading/ready/not-available/error), Push via `update:status` IPC, Handler für `update:check` / `update:install` / `update:getStatus` / `update:getLastCheck` / `update:getVersion`.
- Offline-Toleranz: erster automatischer Check unterdrückt Error-UI (`suppressNextError`-Flag); manueller Check zeigt Fehler weiterhin.
- Renderer:
  - `useUpdateStore` (zustand) abonniert Status-Events.
  - `UpdateBanner` über der Nav: dezent indigo für info, amber für error (kein rot).
  - `SettingsView` -> neue Section **Updates** mit Version, Status, Letzter Prüfung, `Jetzt nach Updates suchen`-Button und Install-Button bei Ready.
- Logger-Bridge zu PR A: `autoUpdater.logger = log` -> alle Updater-Events landen in der Diagnose-Logdatei.
- Lokales Testing: `scripts/test-updater.mjs` (HTTP-Server für `latest.yml` + Installer) + `build/dev-app-update.yml` (gitignored).

### Acceptance criteria
- [x] electron-updater installiert + konfiguriert
- [x] Background-Download mit User-controlled Install
- [x] Passive Banner-UI (kein nervender Modal)
- [x] Offline-tolerant (kein Schreckmoment beim Start)
- [x] Settings-Section mit manueller Prüfung
- [x] Bridged in PR-A-Logger
- [x] 6 reducer tests, 120 total passing
- [x] typecheck clean

### Test plan (manuell, nach Merge + Tag)
1. Tag `v1.5.0-test.1` -> CI builds + publishes Release.
2. Lokale 1.4.x-Version starten -> Banner sollte erscheinen.
3. `Jetzt neu starten` -> NSIS-UI -> App relaunched mit neuer Version.
4. Offline-Start: kein Banner, kein roter Fehler. Manueller Check in Settings zeigt Netzwerkfehler.

### Files
`electron-builder.yml`, `src/main/{index.ts,updater.ts,updater.test.ts}`, `src/preload/{index.ts,index.d.ts}`, `src/renderer/src/{App.tsx,components/UpdateBanner.tsx,store/updateStore.ts,views/SettingsView.tsx}`, `src/shared/types.ts`, `scripts/test-updater.mjs`, `CHANGELOG.md`, `.gitignore`, `package.json`, `pnpm-lock.yaml`.