### PR TITLE
fix(updater): add ms as explicit dep for asar tracing

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "date-fns": "^4.1.0",
     "electron-log": "^5.4.3",
     "electron-updater": "^6.8.3",
+    "ms": "^2.1.3",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "time-tracking",
-  "version": "1.4.1",
+  "version": "1.4.2-test.2",
   "description": "Schlanker Desktop-Zeiterfasser für Windows — Toggl-Track-Style, lokal, ohne Cloud.",
   "main": "./out/main/index.js",
   "author": "skoedr",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       electron-updater:
         specifier: ^6.8.3
         version: 6.8.3
+      ms:
+        specifier: ^2.1.3
+        version: 2.1.3
       zustand:
         specifier: ^5.0.12
         version: 5.0.12(@types/react@19.2.14)(react@19.2.5)


### PR DESCRIPTION
Hotfix for #28 / PR #52. electron-builder's pnpm dep tracer skips transitive deps even with node-linker=hoisted. Result: debug ends up in the asar but its ms dep does not, causing 'Cannot find module ms' on app start. Adding ms as a top-level dep forces inclusion. Verified in dist asar listing.