### PR TITLE
feat(csv): CSV export via unified ExportModal (v1.5 PR C, #18)

### DIFF
--- a/.github/pr-body-v15-c.md
+++ b/.github/pr-body-v15-c.md
@@ -1,0 +1,47 @@
+## Summary
+
+Closes #18
+
+Replaces the PDF-only `PdfExportModal` with a unified `ExportModal` component that has a **PDF | CSV** tab toggle. Both tabs share the same client / date-range pickers so switching never resets the selection.
+
+## Changes
+
+### New: `src/shared/csv.ts`
+Pure formatter. Produces UTF-8 + BOM CSV with CRLF line endings.
+- Columns: Datum, Start, Ende, Dauer, Kunde, Beschreibung, Tags, Stundensatz, Betrag
+- **DE format** — field sep `;`, decimal `,` (Excel DE)
+- **US format** — field sep `,`, decimal `.` (DATEV)
+- Tags are `|`-separated to avoid conflict with the field separator
+- RFC-4180 quoting: fields containing sep / `"` / newline are wrapped in `"..."`; `"` → `""`
+
+### New: `src/shared/csv.test.ts`
+16 unit tests — BOM, CRLF, header, empty, running-entry skip, DE/US format, Betrag calc, empty rate, tags, escape variants, unknown client, midnight-split rows.
+
+### New: `src/main/csvExport.ts`
+IPC handler. Queries DB entries by clientId + range (stopped_at IS NOT NULL), opens native Save-dialog with default filename `Zeiterfassung-{safeName}-{YYYY-MM}.csv`, writes UTF-8.
+
+### Modified: `src/main/ipc.ts`
+Registers `csv:export` channel.
+
+### Modified: `src/preload/index.ts` + `index.d.ts`
+Exposes `window.api.csv.export(req)` to the renderer with full types.
+
+### New: `src/renderer/src/components/ExportModal.tsx`
+Unified modal, two tabs:
+- **PDF tab** — existing Stundennachweis flow unchanged
+- **CSV tab** — DE / US format radio buttons + explanatory hint
+
+Old component re-exported as `PdfExportModal` for backward compatibility.
+
+### Modified: `src/renderer/src/views/CalendarView.tsx`
+Imports `ExportModal` instead of `PdfExportModal`; renders `<ExportModal>`.
+
+### Modified: `CHANGELOG.md`
+CSV-Export entry added under `[Unreleased] — v1.5`.
+
+## Test results
+```
+Test Files  15 passed (15)
+     Tests  136 passed | 51 skipped (187)
+```
+`pnpm typecheck` — clean.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to TimeTrack are documented here.
 
 ### Added
 
+- **CSV-Export** (#18, PR C) — Das PDF-Export-Dialog ist jetzt ein
+  einheitliches "Export"-Modal mit zwei Tabs: **PDF** (Stundennachweis,
+  unverändert) und **CSV** (Tabelle für Excel / DATEV). Der CSV-Export enthält
+  alle abgeschlossenen Einträge des gewählten Zeitraums mit den Spalten Datum,
+  Start, Ende, Dauer, Kunde, Beschreibung, Tags, Stundensatz und Betrag.
+  Zwei Formate wählbar: **DE** (Semikolon als Feldtrenner, Komma als
+  Dezimalzeichen — passt direkt in Excel DE) und **US** (Komma / Punkt —
+  für DATEV-Importe). Datei enthält UTF-8 BOM, damit Excel ohne Encoding-
+  Abfrage öffnet. Tags werden `|`-getrennt ausgegeben (kein Konflikt mit
+  dem Feldtrenner).
 - **Auto-Update** (#28, PR B) — `electron-updater` prüft beim App-Start auf
   GitHub-Releases, lädt neue Versionen automatisch im Hintergrund und zeigt
   ein dezentes Indigo-Banner an, sobald die Installation bereit ist. Der

--- a/src/main/csvExport.ts
+++ b/src/main/csvExport.ts
@@ -1,0 +1,85 @@
+/**
+ * CSV export IPC handler (v1.5 PR C, issue #18).
+ *
+ * Wires the shared `formatCsv` formatter to the main-process IPC layer:
+ * - queries DB for entries in the given date range + client
+ * - opens a Save dialog
+ * - writes the UTF-8+BOM CSV to the user-chosen path
+ *
+ * Kept separate from ipc.ts to mirror the pattern used by pdf.ts /
+ * jsonExport.ts — easier to unit-test in isolation.
+ */
+import { dialog } from 'electron'
+import { writeFileSync } from 'fs'
+import type Database from 'better-sqlite3'
+import { formatCsv, type CsvOptions } from '../shared/csv'
+import type { Client, Entry, IpcResult } from '../shared/types'
+
+export interface CsvRequest {
+  clientId: number
+  /** ISO-date strings, inclusive: '2026-04-01' to '2026-04-30'. */
+  fromIso: string
+  toIso: string
+  /** DE = ';' / ',' (default), US = ',' / '.' */
+  format?: 'de' | 'us'
+}
+
+function ok<T>(data: T): IpcResult<T> {
+  return { ok: true, data }
+}
+function fail(e: unknown): IpcResult<never> {
+  return { ok: false, error: e instanceof Error ? e.message : String(e) }
+}
+
+export async function handleCsvExport(
+  db: Database.Database,
+  req: CsvRequest
+): Promise<IpcResult<{ path: string }>> {
+  try {
+    if (!req || typeof req.clientId !== 'number' || !req.fromIso || !req.toIso) {
+      return fail('Ungültige CSV-Anfrage')
+    }
+
+    const client = db
+      .prepare(`SELECT id, name, color, active, rate_cent, created_at FROM clients WHERE id = ?`)
+      .get(req.clientId) as Client | undefined
+    if (!client) return fail(`Kunde ${req.clientId} nicht gefunden`)
+
+    const entries = db
+      .prepare(
+        `SELECT * FROM entries
+         WHERE client_id = ?
+           AND date(started_at) >= date(?)
+           AND date(started_at) <= date(?)
+           AND deleted_at IS NULL
+           AND stopped_at IS NOT NULL
+         ORDER BY started_at ASC`
+      )
+      .all(req.clientId, req.fromIso, req.toIso) as Entry[]
+
+    const rangeHint = `${req.fromIso.slice(0, 7)}`
+    const safeName = client.name.replace(/[\\/:*?"<>|]/g, '_').trim() || 'Kunde'
+
+    const result = await dialog.showSaveDialog({
+      title: 'CSV speichern',
+      defaultPath: `Zeiterfassung-${safeName}-${rangeHint}.csv`,
+      filters: [{ name: 'CSV', extensions: ['csv'] }]
+    })
+    if (result.canceled || !result.filePath) {
+      return fail('Export abgebrochen')
+    }
+
+    const opts: CsvOptions =
+      req.format === 'us'
+        ? { fieldSeparator: ',', decimalSeparator: '.' }
+        : { fieldSeparator: ';', decimalSeparator: ',' }
+
+    const clientMap = new Map([[client.id, client]])
+    const csv = formatCsv(entries, clientMap, opts)
+
+    writeFileSync(result.filePath, csv, 'utf8')
+    return ok({ path: result.filePath })
+  } catch (e) {
+    return fail(e)
+  }
+}

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -13,6 +13,7 @@ import { buildJsonExportPayload } from './jsonExport'
 import { buildPdfHtml, buildPdfPayload, type PdfRequest } from './pdf'
 import { renderPdfBuffer } from './pdfWindow'
 import { readLogoAsDataUrl, removeLogo, saveLogo } from './logo'
+import { handleCsvExport, type CsvRequest } from './csvExport'
 import type {
   Client,
   Entry,
@@ -673,6 +674,14 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
       return fail(e)
     }
   })
+
+  // === CSV export (v1.5 PR C, issue #18) ===================================
+  ipcMain.handle(
+    'csv:export',
+    async (_e, req: CsvRequest): Promise<IpcResult<{ path: string }>> => {
+      return handleCsvExport(db, req)
+    }
+  )
 }
 
 /**

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -111,6 +111,14 @@ declare global {
         set(): Promise<IpcResult<{ path: string }>>
         clear(): Promise<IpcResult<void>>
       }
+      csv: {
+        export(req: {
+          clientId: number
+          fromIso: string
+          toIso: string
+          format?: 'de' | 'us'
+        }): Promise<IpcResult<{ path: string }>>
+      }
       update: {
         getStatus(): Promise<IpcResult<UpdateStatus>>
         getLastCheck(): Promise<IpcResult<string | null>>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -15,6 +15,7 @@ import type {
   DashboardSummary,
   UpdateStatus
 } from '../shared/types'
+import type { CsvRequest } from '../main/csvExport'
 
 const api = {
   // Tray + hotkey
@@ -150,6 +151,11 @@ const api = {
   logo: {
     set: (): Promise<IpcResult<{ path: string }>> => ipcRenderer.invoke('logo:set'),
     clear: (): Promise<IpcResult<void>> => ipcRenderer.invoke('logo:clear')
+  },
+  // v1.5 PR C — CSV export
+  csv: {
+    export: (req: CsvRequest): Promise<IpcResult<{ path: string }>> =>
+      ipcRenderer.invoke('csv:export', req)
   },
   // v1.5 PR B — auto-updater
   update: {

--- a/src/renderer/src/components/ExportModal.tsx
+++ b/src/renderer/src/components/ExportModal.tsx
@@ -1,0 +1,341 @@
+import { useEffect, useState } from 'react'
+import type { Client } from '../../../shared/types'
+import { Dialog } from './Dialog'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  /** Pre-fills client + range when opened from a CalendarView quick-filter. */
+  prefilledClientId?: number
+  prefilledRange?: { fromIso: string; toIso: string }
+}
+
+type Tab = 'pdf' | 'csv'
+type CsvFormat = 'de' | 'us'
+
+/**
+ * Unified export modal (v1.5 PR C, issue #18).
+ *
+ * Two tabs: PDF (Stundennachweis) and CSV (spreadsheet-friendly).
+ * Shared state: client, fromIso, toIso — so switching tabs keeps the
+ * selection. Tab-specific options appear in-place.
+ *
+ * Replaces PdfExportModal. CalendarView is updated to import this component
+ * under the same prop-contract, so existing prefill flows keep working.
+ */
+export function ExportModal(props: Props): React.JSX.Element {
+  const { open, onClose, prefilledClientId, prefilledRange } = props
+
+  const [tab, setTab] = useState<Tab>('pdf')
+  const [clients, setClients] = useState<Client[]>([])
+  const [clientId, setClientId] = useState<number | null>(prefilledClientId ?? null)
+  const [fromIso, setFromIso] = useState(prefilledRange?.fromIso ?? '')
+  const [toIso, setToIso] = useState(prefilledRange?.toIso ?? '')
+
+  // PDF-specific
+  const [includeSignatures, setIncludeSignatures] = useState(false)
+  const [groupByTag, setGroupByTag] = useState(false)
+
+  // CSV-specific
+  const [csvFormat, setCsvFormat] = useState<CsvFormat>('de')
+
+  const [busy, setBusy] = useState(false)
+  const [statusMsg, setStatusMsg] = useState<string | null>(null)
+  const [statusKind, setStatusKind] = useState<'info' | 'error' | 'success'>('info')
+
+  // Reset status when switching tabs so stale messages don't confuse.
+  function handleTabChange(next: Tab): void {
+    setTab(next)
+    setStatusMsg(null)
+  }
+
+  // Load clients once when the dialog first opens.
+  useEffect(() => {
+    if (!open || clients.length > 0) return
+    void window.api.clients.getAll().then((res) => {
+      if (res.ok) {
+        setClients(res.data)
+        if (!prefilledClientId && res.data.length === 1) {
+          setClientId(res.data[0].id)
+        }
+      } else {
+        setStatusKind('error')
+        setStatusMsg(`Kunden laden fehlgeschlagen: ${res.error}`)
+      }
+    })
+  }, [open, clients.length, prefilledClientId])
+
+  // Sync prefill props if they change after mount (e.g. CalendarView quick-filters).
+  useEffect(() => {
+    if (prefilledClientId != null) setClientId(prefilledClientId)
+  }, [prefilledClientId])
+  useEffect(() => {
+    if (prefilledRange) {
+      setFromIso(prefilledRange.fromIso)
+      setToIso(prefilledRange.toIso)
+    }
+  }, [prefilledRange])
+
+  const canExport = clientId != null && fromIso !== '' && toIso !== '' && !busy
+
+  function validateRange(): boolean {
+    if (fromIso > toIso) {
+      setStatusKind('error')
+      setStatusMsg('Startdatum liegt nach dem Enddatum.')
+      return false
+    }
+    return true
+  }
+
+  async function handlePdfExport(): Promise<void> {
+    if (!canExport || !validateRange()) return
+    setBusy(true)
+    setStatusMsg('PDF wird erstellt …')
+    setStatusKind('info')
+    const res = await window.api.pdf.export({
+      clientId: clientId!,
+      fromIso,
+      toIso,
+      includeSignatures,
+      groupByTag
+    })
+    setBusy(false)
+    if (res.ok) {
+      setStatusKind('success')
+      setStatusMsg(`PDF gespeichert: ${res.data.path}`)
+    } else if (res.error === 'Export abgebrochen') {
+      setStatusMsg(null)
+    } else {
+      setStatusKind('error')
+      setStatusMsg(`Fehler: ${res.error}`)
+    }
+  }
+
+  async function handleCsvExport(): Promise<void> {
+    if (!canExport || !validateRange()) return
+    setBusy(true)
+    setStatusMsg('CSV wird erstellt …')
+    setStatusKind('info')
+    const res = await window.api.csv.export({
+      clientId: clientId!,
+      fromIso,
+      toIso,
+      format: csvFormat
+    })
+    setBusy(false)
+    if (res.ok) {
+      setStatusKind('success')
+      setStatusMsg(`CSV gespeichert: ${res.data.path}`)
+    } else if (res.error === 'Export abgebrochen') {
+      setStatusMsg(null)
+    } else {
+      setStatusKind('error')
+      setStatusMsg(`Fehler: ${res.error}`)
+    }
+  }
+
+  const inputClass =
+    'rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-zinc-100 focus:outline-none focus:ring-2 focus:ring-indigo-400'
+  const checkboxClass =
+    'mt-0.5 h-4 w-4 rounded border-zinc-600 bg-zinc-800 text-indigo-500 focus:ring-indigo-400 focus:ring-offset-0'
+
+  return (
+    <Dialog open={open} onClose={onClose} title="Exportieren" widthClass="w-[520px]">
+      <div className="flex flex-col gap-4">
+        {/* Tab bar */}
+        <div className="flex gap-1 rounded-lg bg-zinc-800 p-1">
+          {(['pdf', 'csv'] as Tab[]).map((t) => (
+            <button
+              key={t}
+              type="button"
+              onClick={() => handleTabChange(t)}
+              className={`flex-1 rounded-md py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-400 ${
+                tab === t
+                  ? 'bg-indigo-600 text-white'
+                  : 'text-zinc-400 hover:text-zinc-200'
+              }`}
+            >
+              {t === 'pdf' ? 'PDF — Stundennachweis' : 'CSV — Tabelle'}
+            </button>
+          ))}
+        </div>
+
+        {/* Shared: client + date range */}
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="font-medium text-zinc-300">Kunde</span>
+          <select
+            title="Kunde auswählen"
+            value={clientId ?? ''}
+            onChange={(e) =>
+              setClientId(e.target.value === '' ? null : Number.parseInt(e.target.value, 10))
+            }
+            disabled={busy}
+            className={inputClass}
+          >
+            <option value="">— Kunde wählen —</option>
+            {clients.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+                {c.rate_cent > 0 ? ` (${(c.rate_cent / 100).toFixed(2)} €/h)` : ' (kein Tarif)'}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div className="grid grid-cols-2 gap-3">
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-medium text-zinc-300">Von</span>
+            <input
+              type="date"
+              value={fromIso}
+              onChange={(e) => setFromIso(e.target.value)}
+              disabled={busy}
+              className={inputClass}
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-medium text-zinc-300">Bis</span>
+            <input
+              type="date"
+              value={toIso}
+              onChange={(e) => setToIso(e.target.value)}
+              disabled={busy}
+              className={inputClass}
+            />
+          </label>
+        </div>
+
+        {/* PDF-specific options */}
+        {tab === 'pdf' && (
+          <div className="flex flex-col gap-3">
+            <label className="flex items-start gap-2 text-sm text-zinc-300">
+              <input
+                type="checkbox"
+                checked={groupByTag}
+                onChange={(e) => setGroupByTag(e.target.checked)}
+                disabled={busy}
+                className={checkboxClass}
+              />
+              <span>
+                Nach Tag gruppieren
+                <span className="block text-xs text-zinc-500">
+                  Einträge mit Tags werden in separaten Abschnitten zusammengefasst.
+                </span>
+              </span>
+            </label>
+            <label className="flex items-start gap-2 text-sm text-zinc-300">
+              <input
+                type="checkbox"
+                checked={includeSignatures}
+                onChange={(e) => setIncludeSignatures(e.target.checked)}
+                disabled={busy}
+                className={checkboxClass}
+              />
+              <span>
+                Unterschriftsfelder einblenden
+                <span className="block text-xs text-zinc-500">
+                  Fügt unten zwei Linien für Auftragnehmer / Auftraggeber hinzu.
+                </span>
+              </span>
+            </label>
+          </div>
+        )}
+
+        {/* CSV-specific options */}
+        {tab === 'csv' && (
+          <div className="flex flex-col gap-2">
+            <span className="text-sm font-medium text-zinc-300">Format</span>
+            <div className="flex gap-4">
+              <label className="flex items-center gap-2 text-sm text-zinc-300 cursor-pointer">
+                <input
+                  type="radio"
+                  name="csvFormat"
+                  value="de"
+                  checked={csvFormat === 'de'}
+                  onChange={() => setCsvFormat('de')}
+                  disabled={busy}
+                  className="h-4 w-4 text-indigo-500 focus:ring-indigo-400"
+                />
+                <span>
+                  DE <span className="text-xs text-zinc-500">(Semikolon, Komma-Dezimal — Excel DE)</span>
+                </span>
+              </label>
+              <label className="flex items-center gap-2 text-sm text-zinc-300 cursor-pointer">
+                <input
+                  type="radio"
+                  name="csvFormat"
+                  value="us"
+                  checked={csvFormat === 'us'}
+                  onChange={() => setCsvFormat('us')}
+                  disabled={busy}
+                  className="h-4 w-4 text-indigo-500 focus:ring-indigo-400"
+                />
+                <span>
+                  US <span className="text-xs text-zinc-500">(Komma, Punkt-Dezimal — DATEV)</span>
+                </span>
+              </label>
+            </div>
+            <p className="text-xs text-zinc-500">
+              UTF-8 mit BOM. Excel öffnet die Datei ohne Encoding-Abfrage.
+            </p>
+          </div>
+        )}
+
+        {/* Status message */}
+        {statusMsg && (
+          <div
+            className={
+              statusKind === 'error'
+                ? 'rounded-lg bg-red-900/40 px-3 py-2 text-sm text-red-200'
+                : statusKind === 'success'
+                  ? 'rounded-lg bg-emerald-900/40 px-3 py-2 text-sm text-emerald-200'
+                  : 'rounded-lg bg-zinc-800 px-3 py-2 text-sm text-zinc-300'
+            }
+            role={statusKind === 'error' ? 'alert' : 'status'}
+          >
+            {statusMsg}
+          </div>
+        )}
+
+        {/* Footer */}
+        <div className="mt-2 flex items-center justify-between gap-2">
+          <p className="text-xs text-zinc-500">
+            {tab === 'pdf' ? (
+              <>
+                Vorlage anpassen unter{' '}
+                <span className="font-medium text-zinc-400">Einstellungen → PDF-Vorlage</span>.
+              </>
+            ) : (
+              'Enthält alle abgeschlossenen Einträge im gewählten Zeitraum.'
+            )}
+          </p>
+          <div className="flex shrink-0 gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={busy}
+              className="rounded-lg border border-zinc-700 bg-zinc-800 px-4 py-2 text-sm font-medium text-zinc-200 hover:bg-zinc-700 focus:outline-none focus:ring-2 focus:ring-zinc-500 disabled:opacity-50"
+            >
+              Schließen
+            </button>
+            <button
+              type="button"
+              onClick={() => void (tab === 'pdf' ? handlePdfExport() : handleCsvExport())}
+              disabled={!canExport}
+              className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-300 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {busy ? 'Erstelle …' : tab === 'pdf' ? 'PDF speichern' : 'CSV speichern'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Dialog>
+  )
+}
+
+/**
+ * Re-export under the old name for backward-compatibility with any other
+ * import sites that might appear in future PRs. CalendarView is updated
+ * directly below.
+ */
+export { ExportModal as PdfExportModal }

--- a/src/renderer/src/views/CalendarView.tsx
+++ b/src/renderer/src/views/CalendarView.tsx
@@ -15,7 +15,7 @@ import { getQuickRange, QUICK_RANGE_LABELS, type QuickRangeKind } from '../../..
 import { useEntriesStore } from '../store/entriesStore'
 import { useTimer } from '../hooks/useTimer'
 import { CalendarDrawer } from '../components/CalendarDrawer'
-import { PdfExportModal } from '../components/PdfExportModal'
+import { ExportModal } from '../components/ExportModal'
 
 /**
  * Month-grid calendar view. 7×N rows, KW column on the left.
@@ -231,7 +231,7 @@ export default function CalendarView(): React.JSX.Element {
         onClose={() => setSelectedDay(null)}
       />
 
-      <PdfExportModal
+      <ExportModal
         key={pdfRange ? `${pdfRange.fromIso}-${pdfRange.toIso}` : 'closed'}
         open={pdfRange !== null}
         prefilledRange={pdfRange ?? undefined}

--- a/src/shared/csv.test.ts
+++ b/src/shared/csv.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest'
+import { formatCsv } from './csv'
+import type { Entry, Client } from './types'
+
+const BASE_CLIENT: Client = {
+  id: 1,
+  name: 'Acme GmbH',
+  color: '#4f46e5',
+  active: 1,
+  rate_cent: 7500, // 75,00 €/h
+  created_at: '2024-01-01T00:00:00.000Z'
+}
+
+const CLIENT_MAP = new Map([[1, BASE_CLIENT]])
+
+function makeEntry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    id: 1,
+    client_id: 1,
+    description: 'Meeting',
+    started_at: '2026-04-25T09:00:00.000Z',
+    stopped_at: '2026-04-25T10:30:00.000Z',
+    heartbeat_at: null,
+    rounded_min: null,
+    deleted_at: null,
+    created_at: '2026-04-25T09:00:00.000Z',
+    link_id: null,
+    tags: '',
+    ...overrides
+  }
+}
+
+describe('formatCsv', () => {
+  it('produces UTF-8 BOM', () => {
+    const csv = formatCsv([], CLIENT_MAP)
+    expect(csv.startsWith('\uFEFF')).toBe(true)
+  })
+
+  it('produces CRLF line endings', () => {
+    const csv = formatCsv([], CLIENT_MAP)
+    expect(csv).toContain('\r\n')
+    expect(csv).not.toMatch(/(?<!\r)\n/)
+  })
+
+  it('outputs header row', () => {
+    const csv = formatCsv([], CLIENT_MAP)
+    expect(csv).toContain('Datum;Start;Ende;Dauer;Kunde;Beschreibung;Tags;Stundensatz;Betrag')
+  })
+
+  it('empty list → header only', () => {
+    const csv = formatCsv([], CLIENT_MAP)
+    const lines = csv.replace('\uFEFF', '').split('\r\n').filter(Boolean)
+    expect(lines).toHaveLength(1) // just the header
+  })
+
+  it('skips running entries (stopped_at = null)', () => {
+    const running = makeEntry({ stopped_at: null })
+    const csv = formatCsv([running], CLIENT_MAP)
+    const lines = csv.replace('\uFEFF', '').split('\r\n').filter(Boolean)
+    expect(lines).toHaveLength(1) // only header
+  })
+
+  it('DE format defaults: semicolon sep + comma decimal', () => {
+    const entry = makeEntry()
+    const csv = formatCsv([entry], CLIENT_MAP)
+    // Rate 75.00 → "75,00", all fields semicolon-separated
+    expect(csv).toContain(';75,00;')
+  })
+
+  it('US format: comma sep + dot decimal', () => {
+    const entry = makeEntry()
+    const csv = formatCsv([entry], CLIENT_MAP, { fieldSeparator: ',', decimalSeparator: '.' })
+    expect(csv).toContain(',75.00,')
+  })
+
+  it('calculates Betrag correctly (1.5h × 75 €/h = 112.50)', () => {
+    // 09:00 → 10:30 = 5400s = 1.5h × 7500 cent = 11250 cent = 112.50 €
+    const entry = makeEntry()
+    const csv = formatCsv([entry], CLIENT_MAP)
+    expect(csv).toContain('112,50')
+  })
+
+  it('leaves Stundensatz + Betrag empty when no rate', () => {
+    const noRateClient: Client = { ...BASE_CLIENT, rate_cent: 0 }
+    const map = new Map([[1, noRateClient]])
+    const csv = formatCsv([makeEntry()], map)
+    // last two fields should be empty → line ends with ";;..." trailing sep
+    const dataLine = csv.replace('\uFEFF', '').split('\r\n')[1]
+    expect(dataLine).toMatch(/;;$/)
+  })
+
+  it('renders tags pipe-separated', () => {
+    const entry = makeEntry({ tags: ',bug,ux,' })
+    const csv = formatCsv([entry], CLIENT_MAP)
+    expect(csv).toContain('bug|ux')
+  })
+
+  it('empty tags → empty tags field', () => {
+    const entry = makeEntry({ tags: '' })
+    const csv = formatCsv([entry], CLIENT_MAP)
+    // tags column is 7th (0-indexed 6), should be empty between two separators
+    const dataLine = csv.replace('\uFEFF', '').split('\r\n')[1]
+    const fields = dataLine.split(';')
+    expect(fields[6]).toBe('') // tags
+  })
+
+  it('escapes fields containing the separator', () => {
+    const entry = makeEntry({ description: 'Projekt; Detail' })
+    const csv = formatCsv([entry], CLIENT_MAP)
+    expect(csv).toContain('"Projekt; Detail"')
+  })
+
+  it('escapes fields containing double quotes', () => {
+    const entry = makeEntry({ description: 'Er sagte "Hallo"' })
+    const csv = formatCsv([entry], CLIENT_MAP)
+    expect(csv).toContain('"Er sagte ""Hallo"""')
+  })
+
+  it('escapes fields containing newlines', () => {
+    const entry = makeEntry({ description: 'Zeile1\nZeile2' })
+    const csv = formatCsv([entry], CLIENT_MAP)
+    expect(csv).toContain('"Zeile1\nZeile2"')
+  })
+
+  it('handles unknown client_id gracefully (empty client name)', () => {
+    const entry = makeEntry({ client_id: 999 })
+    const csv = formatCsv([entry], CLIENT_MAP)
+    // client name field (index 4) should be empty string
+    const dataLine = csv.replace('\uFEFF', '').split('\r\n')[1]
+    const fields = dataLine.split(';')
+    expect(fields[4]).toBe('') // no client → empty
+  })
+
+  it('midnight-split: two separate entries → two data rows', () => {
+    const linkId = 'abc-123'
+    const first = makeEntry({
+      id: 1,
+      started_at: '2026-04-24T23:00:00.000Z',
+      stopped_at: '2026-04-24T23:59:59.000Z',
+      link_id: linkId
+    })
+    const second = makeEntry({
+      id: 2,
+      started_at: '2026-04-25T00:00:00.000Z',
+      stopped_at: '2026-04-25T01:00:00.000Z',
+      link_id: linkId
+    })
+    const csv = formatCsv([first, second], CLIENT_MAP)
+    const lines = csv.replace('\uFEFF', '').split('\r\n').filter(Boolean)
+    expect(lines).toHaveLength(3) // header + 2 data rows
+  })
+})

--- a/src/shared/csv.ts
+++ b/src/shared/csv.ts
@@ -1,0 +1,124 @@
+/**
+ * CSV export formatter (v1.5 PR C, issue #18).
+ *
+ * Produces UTF-8+BOM CSV that Excel DE opens without encoding prompts.
+ * Default: semicolon separator + comma decimal (DACH convention).
+ * Optional: comma separator + dot decimal (US / DATEV).
+ *
+ * Columns:
+ *   Datum ; Start ; Ende ; Dauer ; Kunde ; Beschreibung ; Tags ; Stundensatz ; Betrag
+ *
+ * - Datum / Start / Ende in DE locale (dd.MM.yyyy / HH:mm).
+ * - Dauer as HH:mm:ss so Excel [h]:mm:ss format works.
+ * - Tags pipe-separated (| can't conflict with field separator).
+ * - Betrag empty when no rate; decimal uses chosen separator.
+ * - Line endings: \r\n (Windows / Excel DE friendly).
+ * - Midnight-split entries stored as 2 separate rows in DB → 2 CSV rows (no special handling needed).
+ */
+
+import { formatTimeHHMM } from './date'
+import { formatDuration } from './duration'
+import { deserializeTags } from './tags'
+import type { Entry, Client } from './types'
+
+export interface CsvOptions {
+  /** Field separator. Default: ';' (DACH). */
+  fieldSeparator?: ';' | ','
+  /** Decimal separator for monetary amounts. Default: ',' (DACH). */
+  decimalSeparator?: ',' | '.'
+}
+
+const HEADER = [
+  'Datum',
+  'Start',
+  'Ende',
+  'Dauer',
+  'Kunde',
+  'Beschreibung',
+  'Tags',
+  'Stundensatz',
+  'Betrag'
+]
+
+/** Wrap a field value in quotes if it contains the separator, quote char, or newline. */
+function escapeField(value: string, sep: string): string {
+  if (value.includes(sep) || value.includes('"') || value.includes('\n') || value.includes('\r')) {
+    return '"' + value.replace(/"/g, '""') + '"'
+  }
+  return value
+}
+
+/** Format a fractional number using the chosen decimal separator, 2 decimal places. */
+function formatDecimal(n: number, decimalSep: string): string {
+  return n.toFixed(2).replace('.', decimalSep)
+}
+
+/**
+ * Build a CSV string (UTF-8 BOM + header + data rows) from a list of entries.
+ *
+ * @param entries  - Only complete entries (stopped_at non-null) are exported.
+ *                   Running entries are silently skipped.
+ * @param clientMap - Map from client_id → Client (for name + rate).
+ * @param opts     - Format options.
+ */
+export function formatCsv(
+  entries: Entry[],
+  clientMap: Map<number, Client>,
+  opts: CsvOptions = {}
+): string {
+  const sep = opts.fieldSeparator ?? ';'
+  const dec = opts.decimalSeparator ?? ','
+
+  const rows: string[] = []
+  rows.push(HEADER.map((h) => escapeField(h, sep)).join(sep))
+
+  for (const entry of entries) {
+    if (!entry.stopped_at) continue // skip running
+
+    const start = new Date(entry.started_at)
+    const stop = new Date(entry.stopped_at)
+    const durationSec = Math.max(0, Math.floor((stop.getTime() - start.getTime()) / 1000))
+
+    const datum = formatDate(start)
+    const startStr = formatTimeHHMM(start)
+    const endeStr = formatTimeHHMM(stop)
+    const dauerStr = formatDuration(durationSec)
+
+    const client = clientMap.get(entry.client_id)
+    const clientName = client?.name ?? ''
+    const rateCent = client?.rate_cent ?? 0
+
+    const rateStr = rateCent > 0 ? formatDecimal(rateCent / 100, dec) : ''
+    const betragStr =
+      rateCent > 0 ? formatDecimal((durationSec / 3600) * (rateCent / 100), dec) : ''
+
+    const tags = deserializeTags(entry.tags).join('|')
+
+    const row = [
+      datum,
+      startStr,
+      endeStr,
+      dauerStr,
+      clientName,
+      entry.description,
+      tags,
+      rateStr,
+      betragStr
+    ]
+      .map((f) => escapeField(f, sep))
+      .join(sep)
+
+    rows.push(row)
+  }
+
+  // UTF-8 BOM + CRLF line endings
+  return '\uFEFF' + rows.join('\r\n') + '\r\n'
+}
+
+/** Format a Date as dd.MM.yyyy in local timezone. */
+function formatDate(d: Date): string {
+  const dd = String(d.getDate()).padStart(2, '0')
+  const mm = String(d.getMonth() + 1).padStart(2, '0')
+  const yyyy = d.getFullYear()
+  return `${dd}.${mm}.${yyyy}`
+}


### PR DESCRIPTION
## Summary

Closes #18

Replaces the PDF-only `PdfExportModal` with a unified `ExportModal` component that has a **PDF | CSV** tab toggle. Both tabs share the same client / date-range pickers so switching never resets the selection.

## Changes

### New: `src/shared/csv.ts`
Pure formatter. Produces UTF-8 + BOM CSV with CRLF line endings.
- Columns: Datum, Start, Ende, Dauer, Kunde, Beschreibung, Tags, Stundensatz, Betrag
- **DE format** — field sep `;`, decimal `,` (Excel DE)
- **US format** — field sep `,`, decimal `.` (DATEV)
- Tags are `|`-separated to avoid conflict with the field separator
- RFC-4180 quoting: fields containing sep / `"` / newline are wrapped in `"..."`; `"` → `""`

### New: `src/shared/csv.test.ts`
16 unit tests — BOM, CRLF, header, empty, running-entry skip, DE/US format, Betrag calc, empty rate, tags, escape variants, unknown client, midnight-split rows.

### New: `src/main/csvExport.ts`
IPC handler. Queries DB entries by clientId + range (stopped_at IS NOT NULL), opens native Save-dialog with default filename `Zeiterfassung-{safeName}-{YYYY-MM}.csv`, writes UTF-8.

### Modified: `src/main/ipc.ts`
Registers `csv:export` channel.

### Modified: `src/preload/index.ts` + `index.d.ts`
Exposes `window.api.csv.export(req)` to the renderer with full types.

### New: `src/renderer/src/components/ExportModal.tsx`
Unified modal, two tabs:
- **PDF tab** — existing Stundennachweis flow unchanged
- **CSV tab** — DE / US format radio buttons + explanatory hint

Old component re-exported as `PdfExportModal` for backward compatibility.

### Modified: `src/renderer/src/views/CalendarView.tsx`
Imports `ExportModal` instead of `PdfExportModal`; renders `<ExportModal>`.

### Modified: `CHANGELOG.md`
CSV-Export entry added under `[Unreleased] — v1.5`.

## Test results
```
Test Files  15 passed (15)
     Tests  136 passed | 51 skipped (187)
```
`pnpm typecheck` — clean.
