### PR TITLE
security: CSO audit fixes — v1.5.2 (supply chain, path traversal, protocol, permissions)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,21 +10,20 @@ on:
         description: 'Tag to release (e.g. v1.1.0)'
         required: true
 
-permissions:
-  contents: write
-
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build-windows:
     runs-on: windows-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.tag || github.ref }}
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           version: 10
 
@@ -110,6 +109,8 @@ jobs:
   publish-release:
     needs: build-windows
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           version: 10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to TimeTrack are documented here.
 
+## [1.5.2] — 2026-04-25
+
+### Security
+
+- **Supply-Chain-Härtung** — `pnpm/action-setup` in beiden CI-Workflows auf einen
+  festen Commit-SHA gepinnt (`fc06bc1...`), statt auf den mutablen `@v5`-Tag zu
+  zeigen. Verhindert, dass ein kompromittierter Tag transparente Code-Ausführung im
+  Release-Build-Runner ermöglicht.
+- **Backup-Restore Path-Traversal behoben** — `backup:restore`-IPC-Handler prüft
+  jetzt per `path.resolve`, dass der übergebene Dateipfad tatsächlich im Backups-
+  Verzeichnis liegt. Pfade außerhalb werden mit einem Fehler abgelehnt.
+- **URL-Öffner: `shell.openExternal` statt `shell.openPath`** — Links im About-Dialog
+  (GitHub-Repository sowie Drittanbieter-Paket-Repositories) nutzen jetzt den dafür
+  vorgesehenen `shell.openExternal`-IPC-Handler mit HTTP/HTTPS-Whitelist. Der neue
+  Handler lehnt Nicht-HTTP-URLs ab.
+- **CI-Permissions auf Least-Privilege** — `permissions: contents: write` aus dem
+  Workflow-Scope von `release.yml` entfernt und auf den `publish-release`-Job
+  beschränkt. Der `build-windows`-Job läuft nun mit `contents: read`.
+
 ## [1.5.1] — 2026-04-25
 
 ### Changed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -79,7 +79,7 @@ geschlossenen Schleife. Keine Tabs, keine Browser, kein zweites Programm nötig.
 
 ---
 
-## v1.4 — Flow & Less Friction
+## v1.4 — Flow & Less Friction ✅ ausgeliefert v1.4.0–v1.4.1 (2026-04-25)
 
 📂 [Issues mit Label `v1.4`](https://github.com/skoedr/time-tracking/labels/v1.4)
 📋 [Plan & Multi-Angle Review](.github/plan-v1.4.md)
@@ -87,45 +87,48 @@ geschlossenen Schleife. Keine Tabs, keine Browser, kein zweites Programm nötig.
 **Thema:** App soll im Workflow verschwinden, nicht stören. Plus die CI-Hausaufgabe
 (Node 20 → 24), bevor sie blocking wird.
 
-- **CI Node 24 Bump** (#41) — `pnpm/action-setup@v4` → `@v5` in beiden Workflows.
+- ✅ **CI Node 24 Bump** (#41) — `pnpm/action-setup@v4` → `@v5` in beiden Workflows.
   Vor Juni-Deadline für Node-20-Action-Deprecation.
-- **Mini-Widget** (#22) — Always-on-top, **200×40px horizontal** (Toggl-Style),
+- ✅ **Mini-Widget** (#22) — Always-on-top, **200×40px horizontal** (Toggl-Style),
   zeigt Zeit + Kunde + Stop-Button nebeneinander. Toggle per Hotkey `Alt+Shift+M`.
   Hero-Feature von v1.4.
-- **Tags pro Eintrag** (#24) — `#feature`, `#bugfix`, `#meeting` o.ä. Hash-basierte
+- ✅ **Tags pro Eintrag** (#24) — `#feature`, `#bugfix`, `#meeting` o.ä. Hash-basierte
   Chip-Farben aus 8er-Palette. Im PDF gruppierbar.
-- **Schnell-Notiz nach Stop** (#25) — wenn Beschreibung leer war, Toast "Was war das?"
+- ✅ **Schnell-Notiz nach Stop** (#25) — wenn Beschreibung leer war, Toast "Was war das?"
   mit 30s-Eingabefenster + Progress-Bar.
 - **Fenster-Größe & Layout-Density** — Mindestgröße, letzte Position/Größe persistieren,
   Container-Width-Audit (TodayView/CalendarView atmen lassen).
 
 **Ship-Kriterium:** Wochenlang täglich nutzen ohne dass es nervt. Niemand öffnet das
-Hauptfenster, um zu sehen "läuft mein Timer?".
+Hauptfenster, um zu sehen "läuft mein Timer?". ✅
 
 ---
 
-## v1.5 — Trust at Scale & Data Portability
+## v1.5 — Trust at Scale & Data Portability ✅ ausgeliefert v1.5.0–v1.5.2 (2026-04-25)
 
 📂 [Issues mit Label `v1.5`](https://github.com/skoedr/time-tracking/labels/v1.5)
 📋 [Plan & Multi-Angle Review](.github/plan-v1.5.md)
 
 **Thema:** Wenn jemand außer dir das Tool nutzt, soll es nicht peinlich sein.
 
-- **Crash-Logging** (#34) — `electron-log` schreibt Errors in `%AppData%\TimeTrack\logs\`.
+- ✅ **Crash-Logging** (#34) — `electron-log` schreibt Errors in `%AppData%\TimeTrack\logs\`.
   Settings-Button "Log-Datei öffnen" für Debugging. Foundation für alle anderen v1.5-PRs.
-- **Auto-Update** (#33) — `electron-updater` gegen GitHub Releases. Update-Banner statt
+- ✅ **Auto-Update** (#33) — `electron-updater` gegen GitHub Releases. Update-Banner statt
   silent failure. Update wird beim nächsten Restart angewendet.
-- **CSV-Export** (#18) — für Steuerberater oder externe Tools (DATEV-kompatibel).
+- ✅ **CSV-Export** (#18) — für Steuerberater oder externe Tools (DATEV-kompatibel).
   Verschoben aus v1.4, da JSON-Vollexport die Daten-Portabilität bereits abdeckt
   und v1.4 auf Friction-Removal fokussiert.
-- **i18n-Foundation** — kleine eigene Implementation (kein i18next-Heavyweight).
+- ✅ **i18n-Foundation** — kleine eigene Implementation (kein i18next-Heavyweight).
   DE als Source-of-Truth, EN-Stub für migrierte Bereiche. Nicht-migrierte Strings
   bleiben hardcoded; volle App-Übersetzung kommt in v1.6.
-- **Onboarding-Wizard** (#32) — beim ersten Start: 3 Schritte (Willkommen+Sprache →
+- ✅ **Onboarding-Wizard** (#32) — beim ersten Start: 3 Schritte (Willkommen+Sprache →
   ersten Kunden anlegen → Hotkey-Hinweis). Ein-mal gezeigt. Bestandsuser bekommen
   Flag automatisch gesetzt.
-- **Lizenz-Hinweise** (#35) — About-Dialog mit MIT-Lizenz und automatisch generierten
+- ✅ **Lizenz-Hinweise** (#35) — About-Dialog mit MIT-Lizenz und automatisch generierten
   Drittanbieter-Lizenzen.
+- ✅ **Security Patches (v1.5.2)** — Supply-Chain-Härtung (Action-SHA-Pinning),
+  Backup-Restore Path-Traversal-Fix, URL-Links via `shell.openExternal` statt
+  `openPath`, CI-Permissions auf Least-Privilege eingeschränkt.
 
 > **Gestrichen aus v1.5:** Pomodoro-Modus (#23). Maintainer nutzt es nicht selbst;
 > Daily-Trust wird durch Mini-Widget + Quicknote bereits abgedeckt.
@@ -133,7 +136,7 @@ Hauptfenster, um zu sehen "läuft mein Timer?".
 > **Bewusst nicht in v1.5:** Code-Signing. SmartScreen-Warnung bei Installation
 > wird in Kauf genommen. Bricht keine Funktion, nur einmaliger "Trotzdem ausführen"-Klick.
 
-**Ship-Kriterium:** Du kannst die App einem zweiten Freelancer ohne Anleitung geben.
+**Ship-Kriterium:** Du kannst die App einem zweiten Freelancer ohne Anleitung geben. ✅
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "time-tracking",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Schlanker Desktop-Zeiterfasser für Windows — Toggl-Track-Style, lokal, ohne Cloud.",
   "main": "./out/main/index.js",
   "author": "skoedr",

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -2,7 +2,7 @@ import { ipcMain, shell } from 'electron'
 import { app } from 'electron'
 import { dialog } from 'electron'
 import { writeFileSync, readFileSync } from 'fs'
-import { dirname, join } from 'path'
+import { dirname, join, resolve, sep } from 'path'
 import log from 'electron-log/main'
 import { randomUUID } from 'crypto'
 import { getDb, getDbPath } from './db'
@@ -507,6 +507,12 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
     'backup:restore',
     (_e, filePath: string): IpcResult<{ safetyBackupPath: string }> => {
       try {
+        // Guard: reject paths that escape the backups directory
+        const backupsDir = getBackupsDir()
+        const resolved = resolve(filePath)
+        if (!resolved.startsWith(backupsDir + sep)) {
+          return fail('Ungültiger Backup-Pfad')
+        }
         // Close the live DB so the file can be replaced. App must restart
         // afterwards; the renderer is expected to call app.relaunch via a
         // separate IPC or a manual user action.
@@ -530,6 +536,12 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
   ipcMain.handle('shell:openPath', async (_e, path: string): Promise<IpcResult<void>> => {
     const err = await shell.openPath(path)
     if (err) return fail(err)
+    return ok(undefined)
+  })
+
+  ipcMain.handle('shell:openExternal', async (_e, url: string): Promise<IpcResult<void>> => {
+    if (!/^https?:\/\//i.test(url)) return fail('Nur https:// URLs erlaubt')
+    await shell.openExternal(url)
     return ok(undefined)
   })
 

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -89,6 +89,7 @@ declare global {
       }
       shell: {
         openPath(path: string): Promise<IpcResult<void>>
+        openExternal(url: string): Promise<IpcResult<void>>
         showItemInFolder(path: string): Promise<IpcResult<void>>
       }
       paths: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -127,6 +127,8 @@ const api = {
   shell: {
     openPath: (path: string): Promise<IpcResult<void>> =>
       ipcRenderer.invoke('shell:openPath', path),
+    openExternal: (url: string): Promise<IpcResult<void>> =>
+      ipcRenderer.invoke('shell:openExternal', url),
     showItemInFolder: (path: string): Promise<IpcResult<void>> =>
       ipcRenderer.invoke('shell:showItemInFolder', path)
   },

--- a/src/renderer/src/components/AboutDialog.tsx
+++ b/src/renderer/src/components/AboutDialog.tsx
@@ -67,7 +67,7 @@ export function AboutDialog({ open, onClose, version }: Props): React.JSX.Elemen
             rel="noreferrer"
             onClick={(e) => {
               e.preventDefault()
-              void window.api.shell.openPath('https://github.com/skoedr/time-tracking')
+              void window.api.shell.openExternal('https://github.com/skoedr/time-tracking')
             }}
             className="text-xs text-indigo-400 hover:text-indigo-300 underline"
           >
@@ -120,7 +120,7 @@ export function AboutDialog({ open, onClose, version }: Props): React.JSX.Elemen
                     {pkg.repository && (
                       <button
                         type="button"
-                        onClick={() => void window.api.shell.openPath(pkg.repository!)}
+                        onClick={() => void window.api.shell.openExternal(pkg.repository!)}
                         className="text-left text-xs text-indigo-400 hover:text-indigo-300 underline truncate"
                       >
                         {pkg.repository}


### PR DESCRIPTION
## Security: v1.5.2 — CSO Audit Fixes

This PR implements all 4 findings from the 2026-04-25 CSO security audit (\.gstack/security-reports/2026-04-25-cso.json\).

---

### Finding #1 — HIGH: Unpinned \pnpm/action-setup@v5\ (supply chain)

**Files:** \.github/workflows/release.yml\, \.github/workflows/test.yml\

Pinned \pnpm/action-setup\ to commit SHA \c06bc1257f339d1d5d8b3a19a8cae5388b55320\ (verified tag \5\, signed by Zoltan Kochan). A mutable tag pointing at a malicious action would execute in the release build runner and could trojan the distributed \.exe\ installer.

---

### Finding #2 — MEDIUM: \ackup:restore\ path traversal

**File:** \src/main/ipc.ts\

Added \path.resolve()\ boundary check before restoring a backup: the resolved path must start with \getBackupsDir() + sep\. Paths outside the backups directory are rejected with an error before the DB is closed or any file is copied.

---

### Finding #3 — MEDIUM: \shell.openPath\ used for URLs

**Files:** \src/main/ipc.ts\, \src/preload/index.ts\, \src/preload/index.d.ts\, \src/renderer/src/components/AboutDialog.tsx\

Added a \shell:openExternal\ IPC handler with an \https?://\ whitelist. AboutDialog now calls \openExternal\ for the GitHub repository link and third-party package repository links. \shell.openPath\ is for filesystem paths (Electron docs are explicit about this); \openExternal\ is the correct API for URLs.

---

### Finding #4 — MEDIUM: \contents: write\ over-scoped in \elease.yml\

**File:** \.github/workflows/release.yml\

Removed workflow-level \permissions: contents: write\. Added \contents: read\ to \uild-windows\ (only needs to check out code) and \contents: write\ to \publish-release\ (needs to create/update the GitHub Release). Least-privilege.

---

### Document release

- CHANGELOG: \[1.5.2]\ entry with all 4 security fixes
- ROADMAP: marked v1.4 and v1.5 as shipped with individual ✅ checkmarks (both were missing from previous doc update)

---

### Merge → tag \1.5.2\ → release