### PR TITLE
docs(v1.6): contributing docs bundle — CONTRIBUTING, CoC, SECURITY, PRIVACY + issue templates (PR A)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,47 @@
+name: Bug Report
+description: Fehler oder unerwartetes Verhalten melden
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: input
+    id: version
+    attributes:
+      label: TimeTrack Version
+      placeholder: "z. B. 1.5.2 (Hilfe → Über TimeTrack)"
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: Betriebssystem
+      placeholder: "z. B. Windows 11 24H2, macOS 15.3"
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Schritte zum Reproduzieren
+      placeholder: |
+        1. App starten
+        2. Auf ... klicken
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Erwartetes Verhalten
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Tatsächliches Verhalten
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Log-Ausgabe (optional)
+      description: "Logs findest du unter %AppData%\\TimeTrack\\logs\\"
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Frage / Diskussion
+    url: https://github.com/skoedr/time-tracking/discussions
+    about: Fragen zur Nutzung und allgemeine Diskussionen bitte hier stellen.
+  - name: Sicherheitslücke melden
+    url: https://github.com/skoedr/time-tracking/security/advisories/new
+    about: Sicherheitsprobleme bitte vertraulich über GitHub Security Advisories melden.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature Request
+description: Neue Funktion oder Verbesserung vorschlagen
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Motivation
+      description: Welches Problem soll diese Funktion lösen?
+      placeholder: "Als Freelancer möchte ich ..., damit ..."
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Vorgeschlagene Lösung
+      description: Wie stellst du dir die Umsetzung vor?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternativen
+      description: Welche anderen Lösungen hast du in Betracht gezogen?
+  - type: textarea
+    id: usecase
+    attributes:
+      label: Konkreter Anwendungsfall
+      description: Beschreibe einen typischen Workflow, der diese Funktion nutzen würde.
+    validations:
+      required: true

--- a/.github/pr-body-v16-a.md
+++ b/.github/pr-body-v16-a.md
@@ -1,0 +1,28 @@
+## PR A — Contributing Docs Bundle (v1.6 OSS-Readiness)
+
+Adds the full contributing-docs layer required before going public as an OSS project.
+
+### Changes
+
+| File | Content |
+| ---- | ------- |
+| `CONTRIBUTING.md` | Dev setup (`pnpm install/dev/test/typecheck`), branch naming, conventional commits, PR rules, i18n reminder |
+| `CODE_OF_CONDUCT.md` | Contributor Covenant 2.1 |
+| `SECURITY.md` | Private Security Advisory (preferred) + email fallback, supported versions, scope |
+| `PRIVACY.md` | All data stays local; only outbound call = auto-update check against `api.github.com`; no telemetry |
+| `.github/ISSUE_TEMPLATE/bug_report.yml` | Structured form: version, OS, repro steps, expected/actual, logs |
+| `.github/ISSUE_TEMPLATE/feature_request.yml` | Structured form: problem, solution, alternatives, use case |
+| `.github/ISSUE_TEMPLATE/config.yml` | Blank issues disabled; links to Discussions + Security Advisory |
+
+### Why now?
+
+Part of the v1.6 OSS-Readiness milestone (Approach B from office-hours 2026-04-26).
+A public repo without CONTRIBUTING/SECURITY/PRIVACY creates unnecessary friction
+for external contributors and is incomplete from a license-hygiene perspective.
+
+### Test plan
+
+- [ ] Open a new issue on GitHub → templates appear, blank issue is blocked
+- [ ] Check "Frage / Diskussion" link → redirects to Discussions
+- [ ] Check "Sicherheitslücke melden" link → opens Private Security Advisory form
+- [ ] Read PRIVACY.md — verify no outbound calls are missing or wrong

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,54 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainer at **robin.wald@hotmail.de**.
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,105 @@
+# Contributing to TimeTrack
+
+Danke, dass du zu TimeTrack beitragen möchtest! Dieses Dokument beschreibt den
+Workflow für Issues, Pull Requests und lokale Entwicklung.
+
+> Sprachen: Issues, PRs und Commit-Messages dürfen auf **Deutsch oder Englisch**
+> sein. Code-Kommentare und Variablennamen bitte **Englisch** halten.
+
+## Code of Conduct
+
+Mit deiner Mitwirkung akzeptierst du den [Code of Conduct](./CODE_OF_CONDUCT.md).
+Verstöße bitte an `robin.wald@hotmail.de` melden.
+
+## Bug melden / Feature vorschlagen
+
+- **Bug:** Nutze das [Bug-Report-Template](./.github/ISSUE_TEMPLATE/bug_report.yml).
+  Bitte Version, OS und reproduzierbare Schritte angeben.
+- **Feature:** Nutze das [Feature-Request-Template](./.github/ISSUE_TEMPLATE/feature_request.yml).
+  Beschreibe das Problem zuerst, dann den Lösungsvorschlag.
+- **Frage / Diskussion:** Bitte über
+  [GitHub Discussions](https://github.com/skoedr/time-tracking/discussions)
+  statt Issue.
+- **Sicherheitslücke:** **Kein** öffentliches Issue. Siehe [SECURITY.md](./SECURITY.md).
+
+## Lokale Entwicklung
+
+Voraussetzungen: **Node.js 20+**, **pnpm 10+**, Windows oder macOS.
+
+```powershell
+pnpm install        # Dependencies + native Module bauen
+pnpm dev            # Electron + Vite Dev-Server starten
+pnpm test           # Vitest unit tests
+pnpm typecheck      # tsc --noEmit für alle tsconfig*-Projekte
+pnpm lint           # ESLint
+pnpm build          # Production-Build (electron-builder, ohne Publish)
+```
+
+App-Daten landen lokal in `%AppData%\TimeTrack\` (Windows) bzw.
+`~/Library/Application Support/TimeTrack/` (macOS). Diese kannst du beim
+Entwickeln gefahrlos sichern oder löschen.
+
+## Pull-Request-Workflow
+
+1. **Issue zuerst** – außer für sehr kleine Fixes (Typo, ein-Zeilen-Bug).
+   Bei größeren Features bitte im Issue Konsens herstellen, bevor du Code
+   schreibst, damit der PR nicht abgelehnt werden muss.
+2. **Branch-Konvention:** `feat/v{X.Y}-{kurzname}`, `fix/v{X.Y}-{kurzname}`
+   oder `docs/v{X.Y}-{kurzname}`. Beispiel: `feat/v1.7-pdf-merge`.
+3. **Kleine PRs.** Ein PR = ein Thema. Refactor und Feature trennen.
+4. **Tests.** Neue Logik in `src/main/` oder `src/shared/` braucht einen
+   Vitest-Test. Renderer-only-Änderungen (Layout, Styling) sind ohne Test okay.
+5. **Lokale Checks vor Push:** `pnpm typecheck && pnpm lint && pnpm test`.
+6. **Conventional Commits** (siehe unten).
+7. **PR-Beschreibung:** Was, Warum, Wie getestet, Screenshots/GIFs bei UI.
+
+### Conventional Commits
+
+```
+<type>(<scope>): <kurze Zusammenfassung>
+
+[optionaler Body]
+```
+
+Erlaubte Types:
+
+| Type       | Wofür                                                    |
+| ---------- | -------------------------------------------------------- |
+| `feat`     | Neues nutzersichtbares Feature                           |
+| `fix`      | Bugfix                                                   |
+| `docs`     | Doku, README, Plan-Files                                 |
+| `chore`    | Build, Dependencies, Tooling                             |
+| `refactor` | Code-Umbau ohne Verhaltensänderung                       |
+| `test`     | Tests hinzufügen oder verbessern                         |
+| `security` | Security-relevante Änderung                              |
+
+Scope ist optional, aber willkommen (`csv`, `pdf`, `i18n`, `db`, `ipc`, …).
+
+Beispiele:
+
+- `feat(pdf): merge external timesheet pages into export (#42)`
+- `fix(timer): stop drift after suspend/resume`
+- `chore(deps): bump electron 39.0.1 -> 39.0.4`
+
+## Stil & Architektur
+
+- **TypeScript strict.** Keine `any` ohne Begründung.
+- **Pure-Funktionen** in `src/shared/` – keine Electron- oder DOM-Imports dort.
+- **DB-Migrationen** sind unveränderlich. Neue Schemaänderung = neue
+  Migrationsdatei in `src/main/migrations/` + DB-Version hochzählen.
+- **i18n:** Nutzersichtbare Strings über `useT()` / `t(...)` und in
+  `src/shared/locales/{de,en}.ts` pflegen. `pnpm exec node scripts/find-untranslated.mjs`
+  findet vergessene Stellen.
+- **Keine Telemetrie.** Siehe [PRIVACY.md](./PRIVACY.md).
+
+## Release-Prozess (nur Maintainer)
+
+1. Stage-PRs gegen `main` mergen (squash).
+2. Version in `package.json` bumpen, `CHANGELOG.md` ergänzen.
+3. Tag `v{X.Y.Z}` setzen, pushen → GitHub-Actions baut Release-Artefakte.
+4. Release-Notes auf GitHub freigeben → Auto-Updater zieht es.
+
+## Lizenz
+
+Mit dem Einreichen eines PRs stimmst du zu, dass dein Beitrag unter der
+[MIT-Lizenz](./LICENSE) des Projekts veröffentlicht wird.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,46 @@
+# Datenschutz / Privacy
+
+TimeTrack speichert alle Daten **ausschließlich lokal** auf deinem Gerät.
+Es gibt keine Cloud-Synchronisation, keine Konten und keinen eigenen Server.
+
+## Wo liegen die Daten?
+
+| Typ | Pfad (Windows) | Pfad (macOS) |
+| --- | -------------- | ------------ |
+| Datenbank | `%AppData%\TimeTrack\timetrack.db` | `~/Library/Application Support/TimeTrack/timetrack.db` |
+| Einstellungen | `%AppData%\TimeTrack\timetrack.db` | (selbe DB) |
+| Log-Dateien | `%AppData%\TimeTrack\logs\` | `~/Library/Logs/TimeTrack/` |
+| PDF-Exporte | Frei wählbarer Speicherort | Frei wählbarer Speicherort |
+
+Du kannst die Datenbank jederzeit sichern oder löschen. Ein Backup-Export
+ist über *Einstellungen → Backup* möglich.
+
+## Netzwerk-Kommunikation
+
+TimeTrack stellt genau **einen** ausgehenden HTTPS-Request her:
+
+```
+GET https://api.github.com/repos/skoedr/time-tracking/releases/latest
+```
+
+Dieser Aufruf prüft beim App-Start, ob eine neue Version verfügbar ist
+(Auto-Updater via `electron-updater`). Er enthält keine Nutzer-Kennungen,
+keine Gerätedaten und keine Zeiteinträge. Er kann durch Deaktivierung des
+Auto-Updaters in den Einstellungen unterbunden werden.
+
+## Kein Tracking
+
+- Kein Telemetrie-Dienst (z. B. Sentry, Mixpanel, Amplitude)
+- Kein Analytics (z. B. Google Analytics, Plausible)
+- Kein Crash-Reporter zu Drittanbietern
+- Keine Werbung, keine Monetarisierung über Nutzerdaten
+
+## Drittanbieter-Abhängigkeiten
+
+Alle eingesetzten Open-Source-Bibliotheken und ihre Lizenzen sind in
+`resources/licenses.json` aufgeführt (erreichbar über *Hilfe → Lizenzen*).
+Keine dieser Bibliotheken stellt selbst Netzwerkverbindungen her.
+
+## Kontakt
+
+Fragen zum Datenschutz: robin.wald@hotmail.de

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ A personal Windows desktop time-tracking app for freelancers. Lightweight Toggl 
 - **PDF-Merge an Rechnung** (v1.7) — Stundennachweis wird mit einem Klick an
   eine bestehende Lexware-/sevDesk-/Billomat-Rechnungs-PDF angehängt. Spart
   den manuellen Smallpdf/Acrobat-Schritt.
-- **OSS-Readiness** (v1.6) — `CONTRIBUTING.md`, englischer README, macOS-Build.
 - **Outlook-Integration** (v2.0) — Read-only-Import via Microsoft Graph
   (Device-Code-Flow, kein Server, Office E1 + persönliche Konten).
 - Pomodoro-Modus (#23) — bedingt auf User-Demand verschoben nach v1.8.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest minor release receives security fixes.
+
+| Version | Supported |
+| ------- | --------- |
+| 1.x (latest) | :white_check_mark: |
+| < 1.x | :x: |
+
+## Reporting a Vulnerability
+
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+### Option 1 — GitHub Private Security Advisory (bevorzugt)
+
+1. Gehe zu https://github.com/skoedr/time-tracking/security/advisories/new
+2. Beschreibe die Schwachstelle mit reproduzierbaren Schritten.
+3. Du erhältst innerhalb von **5 Werktagen** eine erste Rückmeldung.
+
+### Option 2 — E-Mail
+
+Schreibe an **robin.wald@hotmail.de** mit dem Betreff `[SECURITY] TimeTrack`.
+Bitte verschlüssle sensible Details wenn möglich.
+
+## Was passiert danach?
+
+1. Bestätigung des Eingangs (≤ 5 Werktage)
+2. Bewertung und Einschätzung der Schwere
+3. Fix entwickeln und testen
+4. Coordinated Disclosure: Patch-Release + CVE/Advisory veröffentlichen
+5. Credit im CHANGELOG (sofern gewünscht)
+
+## Scope
+
+TimeTrack ist eine Desktop-App ohne eigenen Server-Backend. Relevante
+Angriffsflächen sind:
+
+- **SQLite-Datenbank** in `%AppData%\TimeTrack\timetrack.db` (lokaler Zugriff)
+- **Auto-Update** via `api.github.com` (GitHub Releases, signierte Artefakte)
+- **PDF-Generierung** und -Verarbeitung
+- **Electron IPC** zwischen Renderer und Main-Prozess


### PR DESCRIPTION
## PR A — Contributing Docs Bundle (v1.6 OSS-Readiness)

Adds the full contributing-docs layer required before going public as an OSS project.

### Changes

| File | Content |
| ---- | ------- |
| `CONTRIBUTING.md` | Dev setup (`pnpm install/dev/test/typecheck`), branch naming, conventional commits, PR rules, i18n reminder |
| `CODE_OF_CONDUCT.md` | Contributor Covenant 2.1 |
| `SECURITY.md` | Private Security Advisory (preferred) + email fallback, supported versions, scope |
| `PRIVACY.md` | All data stays local; only outbound call = auto-update check against `api.github.com`; no telemetry |
| `.github/ISSUE_TEMPLATE/bug_report.yml` | Structured form: version, OS, repro steps, expected/actual, logs |
| `.github/ISSUE_TEMPLATE/feature_request.yml` | Structured form: problem, solution, alternatives, use case |
| `.github/ISSUE_TEMPLATE/config.yml` | Blank issues disabled; links to Discussions + Security Advisory |

### Why now?

Part of the v1.6 OSS-Readiness milestone (Approach B from office-hours 2026-04-26).
A public repo without CONTRIBUTING/SECURITY/PRIVACY creates unnecessary friction
for external contributors and is incomplete from a license-hygiene perspective.

### Test plan

- [ ] Open a new issue on GitHub → templates appear, blank issue is blocked
- [ ] Check "Frage / Diskussion" link → redirects to Discussions
- [ ] Check "Sicherheitslücke melden" link → opens Private Security Advisory form
- [ ] Read PRIVACY.md — verify no outbound calls are missing or wrong
