### PR TITLE
feat(v1.6): add macOS build job - arm64 DMG+ZIP, smoke test (PR C)

### DIFF
--- a/.github/pr-body-v16-c.md
+++ b/.github/pr-body-v16-c.md
@@ -1,0 +1,44 @@
+## PR C — macOS Build Job (v1.6 OSS-Readiness)
+
+Adds a `build-macos` job to the release pipeline and configures electron-builder
+for macOS targets.
+
+> ⚠️ **Unverified on real hardware.** This PR was written on Windows. The CI run
+> on the first `v*` tag push will be the first real test. If the smoke test fails,
+> see the "Known risks" section below before reverting.
+
+### Changes
+
+| File | What changed |
+| ---- | ------------ |
+| `electron-builder.yml` | New `mac:` section: `hardenedRuntime: true`, entitlements wired to existing `build/entitlements.mac.plist`, targets: `dmg` + `zip` for `arm64` |
+| `.github/workflows/release.yml` | New `build-macos` job (mirrors `build-windows`: typecheck → test → electron-rebuild → build → smoke test → upload). `publish-release` now `needs: [build-windows, build-macos]` and downloads both artifact sets. |
+
+### What the macOS job does
+
+1. `pnpm install` → `typecheck` → `test` (same checks as Windows)
+2. `electron-rebuild` to recompile `better-sqlite3` against the Electron ABI
+3. `electron-builder --mac --publish never` → `dist/mac-arm64/TimeTrack.app` + `.dmg` + `.zip`
+4. Smoke test: runs `TimeTrack.app/Contents/MacOS/TimeTrack --smoke-test=/tmp/smoke.json`, validates `ok=true`, `schemaVersion >= 3`, `pdfBytes >= 1000`
+5. Uploads `*.dmg`, `*.dmg.blockmap`, `*.zip`, `latest-mac.yml` as `timetrack-macos` artifact
+
+### Distribution note
+
+The build is **unsigned** (`CSC_IDENTITY_AUTO_DISCOVERY=false`). macOS Gatekeeper
+will block direct double-click. Users must right-click → Open (or `xattr -d com.apple.quarantine TimeTrack.dmg`).
+Code signing + notarization can be added in a later PR once Apple Developer credentials are available.
+
+### Known risks / things to verify on first CI run
+
+- **Binary path:** electron-builder should output `dist/mac-arm64/TimeTrack.app` for `arch: [arm64]`. If it uses a different path (e.g. `dist/mac/`), update the `APP_BINARY` variable in the smoke test step.
+- **Electron display:** The smoke test creates a hidden `BrowserWindow` for PDF rendering. macOS GitHub Actions runners have a virtual display; this should work without `xvfb`.
+- **`electron-rebuild` availability:** Confirmed same as Windows job.
+- **x64 / universal builds:** Deferred. Add `arch: [x64]` or `arch: [universal]` to `electron-builder.yml` targets in a follow-up once arm64 is confirmed green.
+
+### Test plan (after merging, on first tag push)
+
+- [ ] `build-macos` job completes green in GitHub Actions
+- [ ] Smoke test step reports `ok=true` with valid `schemaVersion` and `pdfBytes`
+- [ ] `timetrack-macos` artifact contains `.dmg`, `.zip`, `latest-mac.yml`
+- [ ] GitHub Release includes macOS artifacts alongside Windows installer
+- [ ] `.dmg` mounts and app launches on a real Mac (right-click → Open)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,8 +106,109 @@ jobs:
             dist/latest.yml
           if-no-files-found: error
 
+  build-macos:
+    runs-on: macos-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Rebuild native modules for Node (test runtime)
+        run: pnpm rebuild better-sqlite3
+
+      - name: Test
+        run: pnpm test
+
+      - name: Rebuild better-sqlite3 for Electron ABI
+        run: pnpm exec electron-rebuild -f -w better-sqlite3
+
+      - name: Build app (DMG + ZIP, arm64)
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: false
+        run: |
+          pnpm run build
+          pnpm exec electron-builder --mac --publish never
+
+      - name: Smoke test packaged binary (DB + migrations against Electron ABI)
+        run: |
+          APP_BINARY="dist/mac-arm64/TimeTrack.app/Contents/MacOS/TimeTrack"
+          if [ ! -f "$APP_BINARY" ]; then
+            echo "ERROR: Binary not found at $APP_BINARY"
+            ls -la dist/ || true
+            exit 1
+          fi
+          OUT="$RUNNER_TEMP/smoke.json"
+          echo "Running smoke test: $APP_BINARY --smoke-test=$OUT"
+          "$APP_BINARY" "--smoke-test=$OUT" &
+          SMOKE_PID=$!
+          WAITED=0
+          while kill -0 $SMOKE_PID 2>/dev/null && [ $WAITED -lt 60 ]; do
+            sleep 1
+            WAITED=$((WAITED + 1))
+          done
+          if kill -0 $SMOKE_PID 2>/dev/null; then
+            kill -9 $SMOKE_PID 2>/dev/null
+            echo "ERROR: Smoke test timed out after 60s"
+            exit 1
+          fi
+          wait $SMOKE_PID
+          SMOKE_EXIT=$?
+          if [ $SMOKE_EXIT -ne 0 ]; then
+            echo "ERROR: Smoke test exited with code $SMOKE_EXIT"
+            cat "$OUT" 2>/dev/null || true
+            exit 1
+          fi
+          if [ ! -f "$OUT" ]; then
+            echo "ERROR: Smoke test did not produce $OUT"
+            exit 1
+          fi
+          python3 -c "
+          import json, sys
+          d = json.load(open('$OUT'))
+          print('Smoke result:', json.dumps(d))
+          if not d.get('ok'):
+              print('ERROR: ok=false:', d.get('error'))
+              sys.exit(1)
+          if d.get('schemaVersion', 0) < 3:
+              print('ERROR: schemaVersion', d.get('schemaVersion'))
+              sys.exit(1)
+          if d.get('pdfBytes', 0) < 1000:
+              print('ERROR: pdfBytes', d.get('pdfBytes'))
+              sys.exit(1)
+          print('Smoke test passed (schema v{}, Electron {}, PDF {} bytes)'.format(
+              d['schemaVersion'], d.get('electronVersion', '?'), d['pdfBytes']))
+          "
+
+      - name: Upload macOS artifacts
+        uses: actions/upload-artifact@v5
+        with:
+          name: timetrack-macos
+          path: |
+            dist/*.dmg
+            dist/*.dmg.blockmap
+            dist/*.zip
+            dist/latest-mac.yml
+          if-no-files-found: error
+
   publish-release:
-    needs: build-windows
+    needs: [build-windows, build-macos]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -120,6 +221,12 @@ jobs:
         uses: actions/download-artifact@v5
         with:
           name: timetrack-windows-installer
+          path: dist
+
+      - name: Download macOS artifacts
+        uses: actions/download-artifact@v5
+        with:
+          name: timetrack-macos
           path: dist
 
       - name: Resolve tag

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -15,6 +15,16 @@ files:
 asarUnpack:
   - resources/**
   - '**/*.node'
+mac:
+  category: public.app-category.productivity
+  hardenedRuntime: true
+  entitlementsInherit: build/entitlements.mac.plist
+  target:
+    - target: dmg
+      arch: [arm64]
+    - target: zip
+      arch: [arm64]
+
 win:
   executableName: TimeTrack
   target:


### PR DESCRIPTION
## PR C — macOS Build Job (v1.6 OSS-Readiness)

Adds a `build-macos` job to the release pipeline and configures electron-builder
for macOS targets.

> ⚠️ **Unverified on real hardware.** This PR was written on Windows. The CI run
> on the first `v*` tag push will be the first real test. If the smoke test fails,
> see the "Known risks" section below before reverting.

### Changes

| File | What changed |
| ---- | ------------ |
| `electron-builder.yml` | New `mac:` section: `hardenedRuntime: true`, entitlements wired to existing `build/entitlements.mac.plist`, targets: `dmg` + `zip` for `arm64` |
| `.github/workflows/release.yml` | New `build-macos` job (mirrors `build-windows`: typecheck → test → electron-rebuild → build → smoke test → upload). `publish-release` now `needs: [build-windows, build-macos]` and downloads both artifact sets. |

### What the macOS job does

1. `pnpm install` → `typecheck` → `test` (same checks as Windows)
2. `electron-rebuild` to recompile `better-sqlite3` against the Electron ABI
3. `electron-builder --mac --publish never` → `dist/mac-arm64/TimeTrack.app` + `.dmg` + `.zip`
4. Smoke test: runs `TimeTrack.app/Contents/MacOS/TimeTrack --smoke-test=/tmp/smoke.json`, validates `ok=true`, `schemaVersion >= 3`, `pdfBytes >= 1000`
5. Uploads `*.dmg`, `*.dmg.blockmap`, `*.zip`, `latest-mac.yml` as `timetrack-macos` artifact

### Distribution note

The build is **unsigned** (`CSC_IDENTITY_AUTO_DISCOVERY=false`). macOS Gatekeeper
will block direct double-click. Users must right-click → Open (or `xattr -d com.apple.quarantine TimeTrack.dmg`).
Code signing + notarization can be added in a later PR once Apple Developer credentials are available.

### Known risks / things to verify on first CI run

- **Binary path:** electron-builder should output `dist/mac-arm64/TimeTrack.app` for `arch: [arm64]`. If it uses a different path (e.g. `dist/mac/`), update the `APP_BINARY` variable in the smoke test step.
- **Electron display:** The smoke test creates a hidden `BrowserWindow` for PDF rendering. macOS GitHub Actions runners have a virtual display; this should work without `xvfb`.
- **`electron-rebuild` availability:** Confirmed same as Windows job.
- **x64 / universal builds:** Deferred. Add `arch: [x64]` or `arch: [universal]` to `electron-builder.yml` targets in a follow-up once arm64 is confirmed green.

### Test plan (after merging, on first tag push)

- [ ] `build-macos` job completes green in GitHub Actions
- [ ] Smoke test step reports `ok=true` with valid `schemaVersion` and `pdfBytes`
- [ ] `timetrack-macos` artifact contains `.dmg`, `.zip`, `latest-mac.yml`
- [ ] GitHub Release includes macOS artifacts alongside Windows installer
- [ ] `.dmg` mounts and app launches on a real Mac (right-click → Open)
