### PR TITLE
fix(ui): custom scrollbar styling to match dark theme (#63)

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -32,3 +32,27 @@ textarea {
   -webkit-app-region: no-drag;
 }
 
+/* Scrollbar styling — Chromium/Electron only */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: #1e293b; /* slate-800 */
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #475569; /* slate-600 */
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #64748b; /* slate-500 */
+}
+
+::-webkit-scrollbar-corner {
+  background: #1e293b;
+}
+


### PR DESCRIPTION
## Summary

Closes #63

Native Windows scrollbar (bright grey) visually clashes with the app's dark theme (slate-900 background). This fix applies Chromium-native \\::-webkit-scrollbar\\ CSS to align the scrollbar with the existing slate color palette.

## Changes

- \\src/renderer/src/assets/main.css\\ — added \\::-webkit-scrollbar\\, \\::-webkit-scrollbar-track\\, \\::-webkit-scrollbar-thumb\\, \\::-webkit-scrollbar-thumb:hover\\, \\::-webkit-scrollbar-corner\\

## Design tokens used

| Part | Token | Hex |
|---|---|---|
| Track | slate-800 | \\#1e293b\\ |
| Thumb | slate-600 | \\#475569\\ |
| Thumb hover | slate-500 | \\#64748b\\ |

8 px width, 4 px border-radius. Applies globally to all scrollable areas in the app.