### PR TITLE
fix: refresh client list in timer UI after create/archive (v1.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to TimeTrack are documented here.
 
+## [1.7.1] — 2026-04-27
+
+### Fixed
+
+- **Kunden-Refresh ohne App-Neustart** — Nach dem Anlegen, Archivieren oder Reaktivieren eines Kunden wurde `timerStore.clients` nicht aktualisiert. TodayView und CalendarView zeigten daher veraltete Daten, bis die App neu gestartet wurde. Fix: neuer `clientsStore` (Version-Counter-Pattern, analog `entriesStore`). `useTimer` re-fetcht die Kundenliste bei jeder Version-Erhöhung; `ClientsView` bumpt die Version nach jedem Mutations-IPC-Call. ([#66](https://github.com/skoedr/time-tracking/issues/66))
+
 ## [1.7.0] — 2026-04-26
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "time-tracking",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Schlanker Desktop-Zeiterfasser für Windows — Toggl-Track-Style, lokal, ohne Cloud.",
   "main": "./out/main/index.js",
   "author": "skoedr",

--- a/src/renderer/src/hooks/useTimer.ts
+++ b/src/renderer/src/hooks/useTimer.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useCallback } from 'react'
 import { useTimerStore } from '../store/timerStore'
+import { useClientsStore } from '../store/clientsStore'
 import { formatDuration as _formatDuration } from '../../../shared/duration'
 
 /**
@@ -63,8 +64,20 @@ export function useTimer() {
     setQuickNoteEntry
   } = useTimerStore()
 
+  const clientsVersion = useClientsStore((s) => s.version)
+
   const tickRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const heartbeatRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  // Re-fetch client list whenever clientsVersion is bumped (create/update/delete
+  // in ClientsView). Skip version 0 — the init effect below handles the initial
+  // load so we don't double-fetch on mount.
+  useEffect(() => {
+    if (clientsVersion === 0) return
+    void window.api.clients.getAll().then((res) => {
+      if (res.ok) setClients(res.data)
+    })
+  }, [clientsVersion])
 
   // Load clients + check for running entry on first mount only (idempotent).
   useEffect(() => {

--- a/src/renderer/src/store/clientsStore.ts
+++ b/src/renderer/src/store/clientsStore.ts
@@ -1,0 +1,20 @@
+import { create } from 'zustand'
+
+/**
+ * Mutation-version store for clients (C1).
+ *
+ * Pattern mirrors entriesStore (E1): any IPC call that mutates client data
+ * (`clients:create`, `:update`, `:delete`) must call `bumpVersion()` after
+ * success. `useTimer` re-fetches the client list via `useEffect([version])`.
+ * This keeps timerStore.clients — and any view that reads it (TodayView,
+ * CalendarView) — in sync without a full app restart.
+ */
+interface ClientsState {
+  version: number
+  bumpVersion: () => void
+}
+
+export const useClientsStore = create<ClientsState>((set) => ({
+  version: 0,
+  bumpVersion: (): void => set((s) => ({ version: s.version + 1 }))
+}))

--- a/src/renderer/src/views/ClientsView.tsx
+++ b/src/renderer/src/views/ClientsView.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import type { Client, CreateClientInput, UpdateClientInput } from '../../../shared/types'
 import { formatRateInput, parseRateInput } from '../../../shared/rate'
+import { useClientsStore } from '../store/clientsStore'
 
 const COLORS = [
   '#6366f1', // indigo
@@ -33,6 +34,7 @@ export default function ClientsView() {
   const [isLoading, setIsLoading] = useState(true)
   const [showForm, setShowForm] = useState(false)
   const [editingClient, setEditingClient] = useState<Client | null>(null)
+  const bumpClientsVersion = useClientsStore((s) => s.bumpVersion)
 
   useEffect(() => {
     loadClients()
@@ -60,11 +62,13 @@ export default function ClientsView() {
       return
     await window.api.clients.delete(client.id)
     await loadClients()
+    bumpClientsVersion()
   }
 
   async function handleToggleActive(client: Client) {
     await window.api.clients.update({ ...client, active: client.active ? 0 : 1 })
     await loadClients()
+    bumpClientsVersion()
   }
 
   async function handleSave(data: { name: string; color: string; rate_cent: number }) {
@@ -76,6 +80,7 @@ export default function ClientsView() {
       await window.api.clients.create(input)
     }
     await loadClients()
+    bumpClientsVersion()
     setShowForm(false)
     setEditingClient(null)
   }


### PR DESCRIPTION
## Problem

Nach dem Anlegen, Archivieren oder Reaktivieren eines Kunden erscheint dieser erst nach einem App-Neustart im Timer-Dropdown (TodayView und CalendarView).

## Root Cause

`useTimer.ts` laedt die Kundenliste genau einmal beim Start (module-level `initRan` guard) und speichert sie in `timerStore.clients`. `ClientsView` refresht nach Mutationen nur seinen eigenen lokalen `useState<Client[]>` -- `timerStore.clients` bleibt dabei unveraendert. TodayView und CalendarView lesen `clients` aus `useTimer()` (d.h. aus `timerStore`), weshalb das Dropdown/Name-Lookup veraltet bleibt.

## Fix

Gleiches Version-Counter-Pattern wie `entriesStore` (E1):

- Neuer `src/renderer/src/store/clientsStore.ts` mit `version` + `bumpVersion`
- `useTimer.ts`: neuer `useEffect([clientsVersion])` -- re-fetcht die Kundenliste, wenn `clientsVersion > 0`
- `ClientsView.tsx`: ruft `bumpVersion()` nach `create`, `update` (archive/reactivate) und `delete` auf

Alle 201 Tests gruen, kein TypeScript-Fehler.

Closes #66
