### PR TITLE
feat(clients): archived clients collapsed by default (#73)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -27,7 +27,7 @@ jobs:
         with:
           version: 10
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: pnpm
@@ -97,7 +97,7 @@ jobs:
           Write-Host "Smoke test passed (schema v$($payload.schemaVersion), Electron $($payload.electronVersion), PDF $($payload.pdfBytes) bytes)"
 
       - name: Upload installer artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v7
         with:
           name: timetrack-windows-installer
           path: |
@@ -111,7 +111,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -119,7 +119,7 @@ jobs:
         with:
           version: 10
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: pnpm
@@ -197,7 +197,7 @@ jobs:
           "
 
       - name: Upload macOS artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v7
         with:
           name: timetrack-macos
           path: |
@@ -213,18 +213,18 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Download installer artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v8
         with:
           name: timetrack-windows-installer
           path: dist
 
       - name: Download macOS artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v8
         with:
           name: timetrack-macos
           path: dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           version: 10
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: pnpm

--- a/src/renderer/src/views/ClientsView.tsx
+++ b/src/renderer/src/views/ClientsView.tsx
@@ -37,7 +37,9 @@ export default function ClientsView() {
   const [isLoading, setIsLoading] = useState(true)
   const [showForm, setShowForm] = useState(false)
   const [editingClient, setEditingClient] = useState<Client | null>(null)
+  const [archivedExpanded, setArchivedExpanded] = useState(false)
   const bumpClientsVersion = useClientsStore((s) => s.bumpVersion)
+  const t = useT()
 
   useEffect(() => {
     loadClients()
@@ -127,16 +129,35 @@ export default function ClientsView() {
 
           {inactiveClients.length > 0 && (
             <div className="mt-6">
-              <p className="text-slate-500 text-xs font-medium uppercase tracking-wide mb-2">
-                {t('clients.archived.label')}
-              </p>
-              <ClientList
-                clients={inactiveClients}
-                onEdit={openEdit}
-                onDelete={handleDelete}
-                onToggleActive={handleToggleActive}
-                dimmed
-              />
+              <button
+                onClick={() => setArchivedExpanded((v) => !v)}
+                className="flex items-center gap-1.5 text-slate-500 hover:text-slate-300
+                  text-xs font-medium uppercase tracking-wide mb-2 transition-colors"
+                aria-expanded={archivedExpanded}
+              >
+                <svg
+                  className={`w-3 h-3 transition-transform duration-200 ${archivedExpanded ? 'rotate-90' : ''}`}
+                  viewBox="0 0 12 12"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M4 2l4 4-4 4" />
+                </svg>
+                {t('clients.archivedSection', { count: inactiveClients.length })}
+              </button>
+              {archivedExpanded && (
+                <ClientList
+                  clients={inactiveClients}
+                  onEdit={openEdit}
+                  onDelete={handleDelete}
+                  onToggleActive={handleToggleActive}
+                  dimmed
+                />
+              )}
             </div>
           )}
         </>

--- a/src/renderer/src/views/ClientsView.tsx
+++ b/src/renderer/src/views/ClientsView.tsx
@@ -39,7 +39,6 @@ export default function ClientsView() {
   const [editingClient, setEditingClient] = useState<Client | null>(null)
   const [archivedExpanded, setArchivedExpanded] = useState(false)
   const bumpClientsVersion = useClientsStore((s) => s.bumpVersion)
-  const t = useT()
 
   useEffect(() => {
     loadClients()
@@ -134,7 +133,6 @@ export default function ClientsView() {
                 aria-expanded={archivedExpanded}
                 className="flex items-center gap-1.5 text-slate-500 hover:text-slate-300
                   text-xs font-medium uppercase tracking-wide mb-2 transition-colors"
-                aria-expanded={archivedExpanded}
               >
                 <svg
                   aria-hidden="true"
@@ -145,7 +143,6 @@ export default function ClientsView() {
                   strokeWidth="2"
                   strokeLinecap="round"
                   strokeLinejoin="round"
-                  aria-hidden="true"
                 >
                   <path d="M4 2l4 4-4 4" />
                 </svg>

--- a/src/renderer/src/views/ClientsView.tsx
+++ b/src/renderer/src/views/ClientsView.tsx
@@ -131,11 +131,13 @@ export default function ClientsView() {
             <div className="mt-6">
               <button
                 onClick={() => setArchivedExpanded((v) => !v)}
+                aria-expanded={archivedExpanded}
                 className="flex items-center gap-1.5 text-slate-500 hover:text-slate-300
                   text-xs font-medium uppercase tracking-wide mb-2 transition-colors"
                 aria-expanded={archivedExpanded}
               >
                 <svg
+                  aria-hidden="true"
                   className={`w-3 h-3 transition-transform duration-200 ${archivedExpanded ? 'rotate-90' : ''}`}
                   viewBox="0 0 12 12"
                   fill="none"

--- a/src/shared/locales/de.ts
+++ b/src/shared/locales/de.ts
@@ -92,6 +92,9 @@ export const de = {
   'entry.reference.hint': 'z. B. JIRA-123 oder #42 (optional)',
   'entry.reference.placeholder': 'Ticket oder Issue-Nummer',
 
+  // ── ClientsView ──────────────────────────────────────────────────────────
+  'clients.archivedSection': 'Archiviert ({count})',
+
   // ── About-Dialog ─────────────────────────────────────────────
   'about.title': 'Über TimeTrack',
   'about.version': 'Version',

--- a/src/shared/locales/en.ts
+++ b/src/shared/locales/en.ts
@@ -91,11 +91,10 @@ export const en: Record<TranslationKey, string> = {
   'entry.reference.hint': 'e.g. JIRA-123 or #42 (optional)',
   'entry.reference.placeholder': 'Ticket or issue number',
 
-  // ── About-Dialog ─────────────────────────────────────────────
-  // ── ClientsView
+  // ── ClientsView ──────────────────────────────────────────────
   'clients.archivedSection': 'Archived ({count})',
 
-  // ── About-Dialog
+  // ── About-Dialog ─────────────────────────────────────────────
   'about.title': 'About TimeTrack',
   'about.version': 'Version',
   'about.ownLicense': 'License',

--- a/src/shared/locales/en.ts
+++ b/src/shared/locales/en.ts
@@ -92,6 +92,10 @@ export const en: Record<TranslationKey, string> = {
   'entry.reference.placeholder': 'Ticket or issue number',
 
   // ── About-Dialog ─────────────────────────────────────────────
+  // ── ClientsView
+  'clients.archivedSection': 'Archived ({count})',
+
+  // ── About-Dialog
   'about.title': 'About TimeTrack',
   'about.version': 'Version',
   'about.ownLicense': 'License',


### PR DESCRIPTION
## Summary

Archivierte Kunden sind jetzt standardmäßig eingeklappt. Ein Klick auf den Header blendet sie ein oder aus.

## Changes

**ClientsView.tsx**
- \rchivedExpanded\ state (default \alse\) added
- Static \<p>Archiviert</p>\ label replaced with a clickable toggle button
- Chevron SVG rotates 90° when expanded (200ms Tailwind transition)
- Count shown in label: \Archiviert (3)\ / \Archived (3)\

**locales/de.ts + locales/en.ts**
- New key: \clients.archivedSection\ with \{count}\ interpolation

## Before / After

**Before:** All archived clients always visible as a static dimmed list below active ones.

**After:** Section header \▶ Archiviert (3)\ — click to expand/collapse. Collapsed on load so the active clients list isn't cluttered.

## Checks

- \pnpm typecheck\ — ✅ 0 errors
- \pnpm test\ — ✅ 201/201 passing