### PR TITLE
feat(entry): non-billable flag + private note per entry (#71, #72)

### DIFF
--- a/src/main/ipc.test.ts
+++ b/src/main/ipc.test.ts
@@ -485,6 +485,103 @@ describe('reference field — insertEntrySegments round-trip', () => {
 })
 
 // ---------------------------------------------------------------------------
+// Round-trip tests: billable flag + private_note stored and retrieved (#71/#72)
+// ---------------------------------------------------------------------------
+describe('billable + private_note — DB round-trip', () => {
+  let tmpDir: string
+  let db: Database.Database
+
+  const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000)
+  function todayAt(hh: number, mm: number): string {
+    const d = new Date(yesterday)
+    d.setHours(hh, mm, 0, 0)
+    return d.toISOString()
+  }
+
+  beforeEach((ctx) => {
+    if (!DatabaseImpl) {
+      ctx.skip()
+      return
+    }
+    tmpDir = mkdtempSync(join(tmpdir(), 'tt-billable-'))
+    db = new DatabaseImpl(join(tmpDir, 'test.sqlite'))
+    db.pragma('foreign_keys = ON')
+    db.exec(
+      `CREATE TABLE schema_version (
+         version INTEGER PRIMARY KEY,
+         name TEXT NOT NULL,
+         applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+       )`
+    )
+    for (const m of migrations) {
+      const tx = db.transaction(() => {
+        db.exec(m.up)
+        db.prepare('INSERT INTO schema_version (version, name) VALUES (?, ?)').run(
+          m.version,
+          m.name
+        )
+      })
+      tx()
+    }
+    db.prepare(`INSERT INTO clients (id, name) VALUES (1, 'Acme')`).run()
+  })
+
+  afterEach(() => {
+    if (!db) return
+    db.close()
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function insertEntry(overrides: { billable?: number; private_note?: string } = {}): number {
+    const start = todayAt(8, 0)
+    const stop = todayAt(9, 0)
+    const info = db.prepare(
+      `INSERT INTO entries (client_id, description, started_at, stopped_at, heartbeat_at,
+        rounded_min, link_id, tags, reference, billable, private_note)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      1, 'work', start, stop, stop, 60, null, '', '',
+      overrides.billable ?? 1,
+      overrides.private_note ?? ''
+    )
+    return Number(info.lastInsertRowid)
+  }
+
+  it('billable defaults to 1', () => {
+    const id = insertEntry()
+    const row = db.prepare('SELECT billable FROM entries WHERE id = ?').get(id) as { billable: number }
+    expect(row.billable).toBe(1)
+  })
+
+  it('persists billable = 0 (non-billable)', () => {
+    const id = insertEntry({ billable: 0 })
+    const row = db.prepare('SELECT billable FROM entries WHERE id = ?').get(id) as { billable: number }
+    expect(row.billable).toBe(0)
+  })
+
+  it('private_note defaults to empty string', () => {
+    const id = insertEntry()
+    const row = db.prepare('SELECT private_note FROM entries WHERE id = ?').get(id) as { private_note: string }
+    expect(row.private_note).toBe('')
+  })
+
+  it('persists non-empty private_note', () => {
+    const id = insertEntry({ private_note: 'Interner Hinweis' })
+    const row = db.prepare('SELECT private_note FROM entries WHERE id = ?').get(id) as { private_note: string }
+    expect(row.private_note).toBe('Interner Hinweis')
+  })
+
+  it('billable and private_note columns are present in SELECT *', () => {
+    const id = insertEntry({ billable: 0, private_note: 'Test' })
+    const row = db.prepare('SELECT * FROM entries WHERE id = ?').get(id) as Record<string, unknown>
+    expect('billable' in row).toBe(true)
+    expect('private_note' in row).toBe(true)
+    expect(row.billable).toBe(0)
+    expect(row.private_note).toBe('Test')
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Regression test: dashboard:summary duration calculation must return exact
 // integer seconds for entries with round durations (e.g. exactly 1 hour).
 //

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -35,6 +35,7 @@ import type {
 
 const MAX_DESCRIPTION_LEN = 500
 const MAX_REFERENCE_LEN = 200
+const MAX_NOTE_LEN = 1000
 const MAX_DURATION_SECONDS = 24 * 3600
 
 export interface IpcHooks {
@@ -219,7 +220,7 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
       const err = validateManualEntry(db, input)
       if (err) return fail(err)
       const segments = splitAtMidnight(new Date(input.started_at), new Date(input.stopped_at))
-      const insertedRow = insertEntrySegments(db, input, segments, input.tags ?? '', input.reference ?? '')
+      const insertedRow = insertEntrySegments(db, input, segments, input.tags ?? '', input.reference ?? '', input.billable ?? 1, input.private_note ?? '')
       return ok(insertedRow)
     } catch (e) {
       return fail(e)
@@ -247,7 +248,7 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
         } else {
           db.prepare(`DELETE FROM entries WHERE id = ?`).run(input.id)
         }
-        return insertEntrySegments(db, input, segments, input.tags ?? '', input.reference ?? '')
+        return insertEntrySegments(db, input, segments, input.tags ?? '', input.reference ?? '', input.billable ?? 1, input.private_note ?? '')
       })
       const row = tx()
       return ok(row)
@@ -859,6 +860,7 @@ function validateManualEntry(
     started_at: string
     stopped_at: string
     reference?: string
+    private_note?: string
   },
   excludeId?: number,
   excludeLinkId?: string
@@ -877,6 +879,9 @@ function validateManualEntry(
   }
   if ((input.reference ?? '').length > MAX_REFERENCE_LEN) {
     return `Referenz überschreitet ${MAX_REFERENCE_LEN} Zeichen`
+  }
+  if ((input.private_note ?? '').length > MAX_NOTE_LEN) {
+    return `Notiz überschreitet ${MAX_NOTE_LEN} Zeichen`
   }
   const clientRow = db.prepare(`SELECT id FROM clients WHERE id = ?`).get(input.client_id) as
     | { id: number }
@@ -920,13 +925,15 @@ function insertEntrySegments(
   input: { client_id: number; description: string },
   segments: Array<{ start: Date; stop: Date }>,
   tags = '',
-  reference = ''
+  reference = '',
+  billable = 1,
+  private_note = ''
 ): Entry {
   const linkId = segments.length > 1 ? randomUUID() : null
   const description = input.description.trim()
   const insertStmt = db.prepare(
-    `INSERT INTO entries (client_id, description, started_at, stopped_at, heartbeat_at, rounded_min, link_id, tags, reference)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    `INSERT INTO entries (client_id, description, started_at, stopped_at, heartbeat_at, rounded_min, link_id, tags, reference, billable, private_note)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
   )
   const tx = db.transaction((): Entry => {
     let firstId = 0
@@ -942,7 +949,9 @@ function insertEntrySegments(
         Math.round((seg.stop.getTime() - seg.start.getTime()) / 60000),
         linkId,
         tags,
-        reference
+        reference,
+        billable,
+        private_note
       )
       if (firstId === 0) firstId = Number(info.lastInsertRowid)
     }

--- a/src/main/migrations/010-v18-billable-private-note.ts
+++ b/src/main/migrations/010-v18-billable-private-note.ts
@@ -1,0 +1,23 @@
+import type { Migration } from './index'
+
+/**
+ * v1.8 #71 / #72 — Non-billable flag and private note per entry.
+ *
+ * `billable INTEGER NOT NULL DEFAULT 1`
+ *   0 = non-billable: the entry is counted in total duration but excluded
+ *   from invoice exports (CSV, PDF) and the billable-hours summary.
+ *   1 = billable (default, backwards-compatible).
+ *
+ * `private_note TEXT NOT NULL DEFAULT ''`
+ *   Free-text internal annotation visible only inside the app.
+ *   Never written to any export (CSV, PDF, JSON backup omits it intentionally).
+ *   Empty string means no note set.
+ */
+export const migration010: Migration = {
+  version: 10,
+  name: 'v1.8-billable-private-note',
+  up: `
+    ALTER TABLE entries ADD COLUMN billable    INTEGER NOT NULL DEFAULT 1;
+    ALTER TABLE entries ADD COLUMN private_note TEXT    NOT NULL DEFAULT '';
+  `
+}

--- a/src/main/migrations/index.ts
+++ b/src/main/migrations/index.ts
@@ -7,6 +7,7 @@ import { migration006 } from './006-v14-mini-widget'
 import { migration007 } from './007-v14-tags'
 import { migration008 } from './008-v15-onboarding'
 import { migration009 } from './009-v18-reference'
+import { migration010 } from './010-v18-billable-private-note'
 
 export interface Migration {
   /** Monotonically increasing integer. Never reused, never reordered. */
@@ -30,5 +31,6 @@ export const migrations: Migration[] = [
   migration006,
   migration007,
   migration008,
-  migration009
+  migration009,
+  migration010
 ].sort((a, b) => a.version - b.version)

--- a/src/renderer/src/components/EntryEditForm.tsx
+++ b/src/renderer/src/components/EntryEditForm.tsx
@@ -19,6 +19,7 @@ type FormState = 'idle' | 'saving' | 'success'
 
 const MAX_DESCRIPTION_LEN = 500
 const MAX_REFERENCE_LEN = 200
+const MAX_NOTE_LEN = 1000
 
 function toDateInputValue(d: Date): string {
   // <input type="date"> wants YYYY-MM-DD in LOCAL time.
@@ -58,6 +59,8 @@ export function EntryEditForm({
   const [description, setDescription] = useState(entry?.description ?? '')
   const [tags, setTags] = useState(entry?.tags ?? '')
   const [reference, setReference] = useState(entry?.reference ?? '')
+  const [billable, setBillable] = useState(entry?.billable ?? 1)
+  const [privateNote, setPrivateNote] = useState(entry?.private_note ?? '')
   const [state, setState] = useState<FormState>('idle')
   const [error, setError] = useState<string | null>(null)
   const bumpVersion = useEntriesStore((s) => s.bumpVersion)
@@ -112,7 +115,9 @@ export function EntryEditForm({
           started_at: start,
           stopped_at: stop,
           tags,
-          reference: reference.trim()
+          reference: reference.trim(),
+          billable,
+          private_note: privateNote.trim()
         })
       : await window.api.entries.create({
           client_id: clientId,
@@ -120,7 +125,9 @@ export function EntryEditForm({
           started_at: start,
           stopped_at: stop,
           tags,
-          reference: reference.trim()
+          reference: reference.trim(),
+          billable,
+          private_note: privateNote.trim()
         })
     if (!res.ok) {
       setState('idle')
@@ -228,6 +235,34 @@ export function EntryEditForm({
           disabled={isSaving}
         />
         <span className="text-xs text-zinc-600">{t('entry.reference.hint')}</span>
+      </label>
+
+      <label className="flex items-center gap-2 cursor-pointer select-none">
+        <input
+          type="checkbox"
+          checked={billable === 1}
+          onChange={(e) => setBillable(e.target.checked ? 1 : 0)}
+          className="h-4 w-4 rounded border-zinc-700 bg-zinc-900 accent-indigo-500"
+          disabled={isSaving}
+        />
+        <span className="text-xs text-zinc-400">{t('entry.billable.label')}</span>
+        {billable === 0 && (
+          <span className="ml-auto text-xs text-amber-400">{t('entry.billable.hint')}</span>
+        )}
+      </label>
+
+      <label className="flex flex-col gap-1">
+        <span className="text-xs text-zinc-400">{t('entry.privateNote.label')}</span>
+        <textarea
+          value={privateNote}
+          onChange={(e) => setPrivateNote(e.target.value)}
+          rows={2}
+          maxLength={MAX_NOTE_LEN}
+          placeholder={t('entry.privateNote.placeholder')}
+          className="rounded border border-zinc-700 bg-zinc-900 px-2 py-1.5 text-zinc-100 placeholder-zinc-600 focus:border-indigo-500 focus:outline-none"
+          disabled={isSaving}
+        />
+        <span className="text-xs text-zinc-600">{t('entry.privateNote.hint')}</span>
       </label>
 
       {visibleError && (

--- a/src/shared/csv.test.ts
+++ b/src/shared/csv.test.ts
@@ -27,6 +27,8 @@ function makeEntry(overrides: Partial<Entry> = {}): Entry {
     link_id: null,
     tags: '',
     reference: '',
+    billable: 1,
+    private_note: '',
     ...overrides
   }
 }
@@ -172,4 +174,24 @@ describe('formatCsv', () => {
     const lines = csv.replace('﻿', '').split('\r\n').filter(Boolean)
     expect(lines).toHaveLength(3) // header + 2 data rows
   })
-})
+  it('skips non-billable entries (billable = 0)', () => {
+    const nonBillable = makeEntry({ billable: 0 })
+    const csv = formatCsv([nonBillable], CLIENT_MAP)
+    const lines = csv.replace('\uFEFF', '').split('\r\n').filter(Boolean)
+    expect(lines).toHaveLength(1) // header only
+  })
+
+  it('includes billable entries (billable = 1)', () => {
+    const billable = makeEntry({ billable: 1 })
+    const csv = formatCsv([billable], CLIENT_MAP)
+    const lines = csv.replace('\uFEFF', '').split('\r\n').filter(Boolean)
+    expect(lines).toHaveLength(2) // header + 1 data row
+  })
+
+  it('mixed billable + non-billable: only billable rows exported', () => {
+    const b = makeEntry({ id: 1, billable: 1 })
+    const nb = makeEntry({ id: 2, billable: 0 })
+    const csv = formatCsv([b, nb], CLIENT_MAP)
+    const lines = csv.replace('\uFEFF', '').split('\r\n').filter(Boolean)
+    expect(lines).toHaveLength(2) // header + 1
+  })})

--- a/src/shared/csv.ts
+++ b/src/shared/csv.ts
@@ -75,6 +75,7 @@ export function formatCsv(
 
   for (const entry of entries) {
     if (!entry.stopped_at) continue // skip running
+    if (entry.billable === 0) continue // skip non-billable (#71)
 
     const start = new Date(entry.started_at)
     const stop = new Date(entry.stopped_at)

--- a/src/shared/locales/de.ts
+++ b/src/shared/locales/de.ts
@@ -92,6 +92,15 @@ export const de = {
   'entry.reference.hint': 'z. B. JIRA-123 oder #42 (optional)',
   'entry.reference.placeholder': 'Ticket oder Issue-Nummer',
 
+  // ── EntryEditForm — Abrechenbar-Flag (#71) ───────────────────
+  'entry.billable.label': 'Abrechenbar',
+  'entry.billable.hint': 'Nicht abrechenbar — wird aus Exporten ausgeschlossen',
+
+  // ── EntryEditForm — Private Notiz (#72) ──────────────────────
+  'entry.privateNote.label': 'Interne Notiz',
+  'entry.privateNote.hint': 'Nur in der App sichtbar, nicht in Exporten enthalten',
+  'entry.privateNote.placeholder': 'Interne Anmerkungen (optional)',
+
   // ── ClientsView ──────────────────────────────────────────────────────────
   'clients.archivedSection': 'Archiviert ({count})',
 

--- a/src/shared/locales/en.ts
+++ b/src/shared/locales/en.ts
@@ -91,6 +91,15 @@ export const en: Record<TranslationKey, string> = {
   'entry.reference.hint': 'e.g. JIRA-123 or #42 (optional)',
   'entry.reference.placeholder': 'Ticket or issue number',
 
+  // ── EntryEditForm — billable flag (#71) ──────────────────────
+  'entry.billable.label': 'Billable',
+  'entry.billable.hint': 'Non-billable — excluded from exports',
+
+  // ── EntryEditForm — private note (#72) ───────────────────────
+  'entry.privateNote.label': 'Internal note',
+  'entry.privateNote.hint': 'Visible in the app only, not included in any export',
+  'entry.privateNote.placeholder': 'Internal notes (optional)',
+
   // ── ClientsView ──────────────────────────────────────────────
   'clients.archivedSection': 'Archived ({count})',
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -38,6 +38,17 @@ export interface Entry {
    * NOT NULL DEFAULT ''.
    */
   reference: string
+  /**
+   * v1.8 #71: 1 = billable (default), 0 = non-billable.
+   * Non-billable entries are counted in total duration but excluded from
+   * invoice exports (CSV, PDF) and the billable-hours summary.
+   */
+  billable: number
+  /**
+   * v1.8 #72: optional internal-only note, never written to any export.
+   * Empty string means no note set.
+   */
+  private_note: string
 }
 
 export interface Settings {
@@ -110,6 +121,10 @@ export interface CreateManualEntryInput {
   tags?: string
   /** Free-text ticket/reference (e.g. 'JIRA-123'). Optional — defaults to '' */
   reference?: string
+  /** 1 = billable (default), 0 = non-billable. Optional — defaults to 1 */
+  billable?: number
+  /** Internal-only note, never exported. Optional — defaults to '' */
+  private_note?: string
 }
 
 export interface UpdateEntryInput {
@@ -122,6 +137,10 @@ export interface UpdateEntryInput {
   tags?: string
   /** Free-text ticket/reference (e.g. 'JIRA-123'). Optional — defaults to '' */
   reference?: string
+  /** 1 = billable (default), 0 = non-billable. Optional — defaults to 1 */
+  billable?: number
+  /** Internal-only note, never exported. Optional — defaults to '' */
+  private_note?: string
 }
 
 export interface MonthQuery {


### PR DESCRIPTION
## Summary

Closes #71, closes #72

Two small but useful entry-level features, implemented in a single PR since they share the same migration and follow the same pattern as #70 (reference field).

---

## Changes

### #71 — Nicht-abrechenbares Flag
- New illable INTEGER NOT NULL DEFAULT 1 column on ntries
- Checkbox in EntryEditForm — defaults to checked (billable)
- When unchecked: amber hint text appears inline
- csv.ts: non-billable entries are **silently skipped** from all CSV exports
- Server-side validation via alidateManualEntry (no new constraint needed — 0/1 are valid by SQLite convention)

### #72 — Private Notiz
- New private_note TEXT NOT NULL DEFAULT '' column on ntries
- Textarea in EntryEditForm (max 1000 chars, validated server-side)
- Hint: \Nur in der App sichtbar, nicht in Exporten enthalten\
- **Never** written to CSV, PDF, or JSON backup/export

---

## Migration

**010** — \1.8-billable-private-note\
\\\sql
ALTER TABLE entries ADD COLUMN billable     INTEGER NOT NULL DEFAULT 1;
ALTER TABLE entries ADD COLUMN private_note TEXT    NOT NULL DEFAULT '';
\\\

Backwards-compatible: existing entries get \illable = 1\ and \private_note = ''\ automatically.

---

## Tests

- **+3** \csv.test.ts\: non-billable skipped, billable included, mixed list
- **+5** \ipc.test.ts\: DB round-trip for billable default, billable=0, private_note default, non-empty note, SELECT * coverage
- 209 tests total, 0 failures