### PR TITLE
feat(csv): group by tag with subtotals + grand total (#68)

### DIFF
--- a/src/main/csvExport.ts
+++ b/src/main/csvExport.ts
@@ -22,6 +22,8 @@ export interface CsvRequest {
   toIso: string
   /** DE = ';' / ',' (default), US = ',' / '.' */
   format?: 'de' | 'us'
+  /** When true, entries are grouped by their first tag with subtotal rows. Default: false. */
+  groupByTag?: boolean
 }
 
 function ok<T>(data: T): IpcResult<T> {
@@ -71,8 +73,8 @@ export async function handleCsvExport(
 
     const opts: CsvOptions =
       req.format === 'us'
-        ? { fieldSeparator: ',', decimalSeparator: '.' }
-        : { fieldSeparator: ';', decimalSeparator: ',' }
+        ? { fieldSeparator: ',', decimalSeparator: '.', groupByTag: req.groupByTag }
+        : { fieldSeparator: ';', decimalSeparator: ',', groupByTag: req.groupByTag }
 
     const clientMap = new Map([[client.id, client]])
     const csv = formatCsv(entries, clientMap, opts)

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -136,6 +136,7 @@ declare global {
           fromIso: string
           toIso: string
           format?: 'de' | 'us'
+          groupByTag?: boolean
         }): Promise<IpcResult<{ path: string }>>
       }
       update: {

--- a/src/renderer/src/components/ExportModal.tsx
+++ b/src/renderer/src/components/ExportModal.tsx
@@ -40,6 +40,7 @@ export function ExportModal(props: Props): React.JSX.Element {
 
   // CSV-specific
   const [csvFormat, setCsvFormat] = useState<CsvFormat>('de')
+  const [csvGroupByTag, setCsvGroupByTag] = useState(false)
 
   const [busy, setBusy] = useState(false)
   const [statusMsg, setStatusMsg] = useState<string | null>(null)
@@ -122,7 +123,8 @@ export function ExportModal(props: Props): React.JSX.Element {
       clientId: clientId!,
       fromIso,
       toIso,
-      format: csvFormat
+      format: csvFormat,
+      groupByTag: csvGroupByTag
     })
     setBusy(false)
     if (res.ok) {
@@ -246,6 +248,21 @@ export function ExportModal(props: Props): React.JSX.Element {
         {/* CSV-specific options */}
         {tab === 'csv' && (
           <div className="flex flex-col gap-2">
+            <label className="flex items-start gap-2 text-sm text-zinc-300">
+              <input
+                type="checkbox"
+                checked={csvGroupByTag}
+                onChange={(e) => setCsvGroupByTag(e.target.checked)}
+                disabled={busy}
+                className={checkboxClass}
+              />
+              <span>
+                {t('export.csv.groupByTag')}
+                <span className="block text-xs text-zinc-500">
+                  {t('export.csv.groupByTagHint')}
+                </span>
+              </span>
+            </label>
             <span className="text-sm font-medium text-zinc-300">{t('export.csv.format')}</span>
             <div className="flex gap-4">
               <label className="flex items-center gap-2 text-sm text-zinc-300 cursor-pointer">

--- a/src/shared/csv.test.ts
+++ b/src/shared/csv.test.ts
@@ -194,4 +194,93 @@ describe('formatCsv', () => {
     const csv = formatCsv([b, nb], CLIENT_MAP)
     const lines = csv.replace('\uFEFF', '').split('\r\n').filter(Boolean)
     expect(lines).toHaveLength(2) // header + 1
-  })})
+  })
+
+  describe('groupByTag', () => {
+    it('flat output when no entries have tags (groupByTag ignored)', () => {
+      const e1 = makeEntry({ id: 1, tags: '' })
+      const e2 = makeEntry({ id: 2, tags: '' })
+      const csv = formatCsv([e1, e2], CLIENT_MAP, { groupByTag: true })
+      const lines = csv.replace('\uFEFF', '').split('\r\n').filter(Boolean)
+      // No tagged entries → falls back to flat: header + 2 data rows
+      expect(lines).toHaveLength(3)
+    })
+
+    it('groups entries by first tag alphabetically', () => {
+      const eDesign = makeEntry({ id: 1, tags: ',Design,', description: 'UI' })
+      const eDev = makeEntry({ id: 2, tags: ',Dev,', description: 'Backend' })
+      const csv = formatCsv([eDev, eDesign], CLIENT_MAP, { groupByTag: true })
+      const lines = csv.replace('\uFEFF', '').split('\r\n').filter(Boolean)
+      // header + [Design] header + 1 data + Design Σ + [Dev] header + 1 data + Dev Σ + Σ Gesamt
+      expect(lines).toHaveLength(8)
+      // Design group should appear before Dev alphabetically
+      const beschreibungCol = 5
+      const designHeaderLine = lines.find((l) => l.split(';')[beschreibungCol] === '[Design]')
+      const devHeaderLine = lines.find((l) => l.split(';')[beschreibungCol] === '[Dev]')
+      expect(designHeaderLine).toBeDefined()
+      expect(devHeaderLine).toBeDefined()
+      expect(lines.indexOf(designHeaderLine!)).toBeLessThan(lines.indexOf(devHeaderLine!))
+    })
+
+    it('subtotal row has correct duration for a group', () => {
+      // entry: 09:00 → 10:30 = 5400s = 01:30:00
+      const entry = makeEntry({ tags: ',Development,' })
+      const csv = formatCsv([entry], CLIENT_MAP, { groupByTag: true })
+      const lines = csv.replace('\uFEFF', '').split('\r\n').filter(Boolean)
+      const subtotalLine = lines.find((l) => l.includes('Development Σ'))
+      expect(subtotalLine).toBeDefined()
+      const fields = subtotalLine!.split(';')
+      expect(fields[3]).toBe('01:30:00') // Dauer column
+    })
+
+    it('subtotal row has correct Betrag (1.5h × 75€/h = 112,50)', () => {
+      const entry = makeEntry({ tags: ',Dev,' })
+      const csv = formatCsv([entry], CLIENT_MAP, { groupByTag: true })
+      const subtotalLine = csv
+        .replace('\uFEFF', '')
+        .split('\r\n')
+        .find((l) => l.includes('Dev Σ'))
+      expect(subtotalLine).toBeDefined()
+      const fields = subtotalLine!.split(';')
+      expect(fields[9]).toBe('112,50') // Betrag column
+    })
+
+    it('entries with no tag go into Ohne Tag group (shown last)', () => {
+      const withTag = makeEntry({ id: 1, tags: ',alpha,', description: 'Tagged' })
+      const noTag = makeEntry({ id: 2, tags: '', description: 'Untagged' })
+      const csv = formatCsv([withTag, noTag], CLIENT_MAP, { groupByTag: true })
+      const lines = csv.replace('\uFEFF', '').split('\r\n').filter(Boolean)
+      const alphaIdx = lines.findIndex((l) => l.split(';')[5] === '[alpha]')
+      const ohneTagIdx = lines.findIndex((l) => l.split(';')[5] === '[Ohne Tag]')
+      expect(alphaIdx).toBeGreaterThan(-1)
+      expect(ohneTagIdx).toBeGreaterThan(-1)
+      expect(alphaIdx).toBeLessThan(ohneTagIdx) // named tags before Ohne Tag
+    })
+
+    it('grand total row at end has combined Dauer + Betrag', () => {
+      // Two entries of 1.5h each → 3h total, 2 × 112,50 = 225,00
+      const e1 = makeEntry({ id: 1, tags: ',A,' })
+      const e2 = makeEntry({ id: 2, tags: ',B,' })
+      const csv = formatCsv([e1, e2], CLIENT_MAP, { groupByTag: true })
+      const lines = csv.replace('\uFEFF', '').split('\r\n').filter(Boolean)
+      const totalLine = lines[lines.length - 1]
+      const fields = totalLine.split(';')
+      expect(fields[5]).toBe('Σ Gesamt')
+      expect(fields[3]).toBe('03:00:00')
+      expect(fields[9]).toBe('225,00')
+    })
+
+    it('multi-tag entry is grouped by first tag only (no duplication)', () => {
+      const entry = makeEntry({ tags: ',Design,Dev,' })
+      const csv = formatCsv([entry], CLIENT_MAP, { groupByTag: true })
+      const lines = csv.replace('\uFEFF', '').split('\r\n').filter(Boolean)
+      // Only one data row expected, under Design (alphabetically first)
+      const dataRows = lines.filter((l) => {
+        const fields = l.split(';')
+        // Data rows have a date in col 0 (dd.MM.yyyy)
+        return /^\d{2}\.\d{2}\.\d{4}$/.test(fields[0])
+      })
+      expect(dataRows).toHaveLength(1)
+    })
+  })
+})

--- a/src/shared/csv.ts
+++ b/src/shared/csv.ts
@@ -26,6 +26,8 @@ export interface CsvOptions {
   fieldSeparator?: ';' | ','
   /** Decimal separator for monetary amounts. Default: ',' (DACH). */
   decimalSeparator?: ',' | '.'
+  /** When true, entries are grouped by their first tag with subtotal rows. Default: false. */
+  groupByTag?: boolean
 }
 
 const HEADER = [
@@ -70,53 +72,152 @@ export function formatCsv(
   const sep = opts.fieldSeparator ?? ';'
   const dec = opts.decimalSeparator ?? ','
 
-  const rows: string[] = []
-  rows.push(HEADER.map((h) => escapeField(h, sep)).join(sep))
+  // Pre-filter: skip running entries and non-billable entries.
+  const validEntries = entries.filter((e) => {
+    if (!e.stopped_at) return false
+    if (e.billable === 0) return false
+    return true
+  })
 
-  for (const entry of entries) {
-    if (!entry.stopped_at) continue // skip running
-    if (entry.billable === 0) continue // skip non-billable (#71)
+  const headerRow = HEADER.map((h) => escapeField(h, sep)).join(sep)
+  const rows: string[] = [headerRow]
 
-    const start = new Date(entry.started_at)
-    const stop = new Date(entry.stopped_at)
-    const durationSec = Math.max(0, Math.floor((stop.getTime() - start.getTime()) / 1000))
-
-    const datum = formatDate(start)
-    const startStr = formatTimeHHMM(start)
-    const endeStr = formatTimeHHMM(stop)
-    const dauerStr = formatDuration(durationSec)
-
-    const client = clientMap.get(entry.client_id)
-    const clientName = client?.name ?? ''
-    const rateCent = client?.rate_cent ?? 0
-
-    const rateStr = rateCent > 0 ? formatDecimal(rateCent / 100, dec) : ''
-    const betragStr =
-      rateCent > 0 ? formatDecimal((durationSec / 3600) * (rateCent / 100), dec) : ''
-
-    const tags = deserializeTags(entry.tags).join('|')
-    const reference = entry.reference ?? ''
-
-    const row = [
-      datum,
-      startStr,
-      endeStr,
-      dauerStr,
-      clientName,
-      entry.description,
-      tags,
-      reference,
-      rateStr,
-      betragStr
-    ]
-      .map((f) => escapeField(f, sep))
-      .join(sep)
-
-    rows.push(row)
+  if (opts.groupByTag && validEntries.some((e) => deserializeTags(e.tags).length > 0)) {
+    appendGroupedRows(rows, validEntries, clientMap, sep, dec)
+  } else {
+    for (const entry of validEntries) {
+      rows.push(buildEntryRow(entry, clientMap, sep, dec))
+    }
   }
 
   // UTF-8 BOM + CRLF line endings
   return '\uFEFF' + rows.join('\r\n') + '\r\n'
+}
+
+/**
+ * Build an array of CSV rows for a single entry (no newline handling — caller
+ * is responsible for joining with \r\n).
+ */
+function buildEntryRow(
+  entry: Entry,
+  clientMap: Map<number, Client>,
+  sep: string,
+  dec: string
+): string {
+  const start = new Date(entry.started_at)
+  const stop = new Date(entry.stopped_at!)
+  const durationSec = Math.max(0, Math.floor((stop.getTime() - start.getTime()) / 1000))
+
+  const client = clientMap.get(entry.client_id)
+  const clientName = client?.name ?? ''
+  const rateCent = client?.rate_cent ?? 0
+
+  const rateStr = rateCent > 0 ? formatDecimal(rateCent / 100, dec) : ''
+  const betragStr =
+    rateCent > 0 ? formatDecimal((durationSec / 3600) * (rateCent / 100), dec) : ''
+
+  const tags = deserializeTags(entry.tags).join('|')
+  const reference = entry.reference ?? ''
+
+  return [
+    formatDate(start),
+    formatTimeHHMM(start),
+    formatTimeHHMM(stop),
+    formatDuration(durationSec),
+    clientName,
+    entry.description,
+    tags,
+    reference,
+    rateStr,
+    betragStr
+  ]
+    .map((f) => escapeField(f, sep))
+    .join(sep)
+}
+
+/**
+ * Append tag-grouped rows (header + data + subtotal per group, then grand
+ * total) to the rows array in-place.
+ *
+ * Grouping key: first tag of each entry. Entries with no tags fall into the
+ * "Ohne Tag" group (shown last). Named groups sorted alphabetically.
+ */
+function appendGroupedRows(
+  rows: string[],
+  entries: Entry[],
+  clientMap: Map<number, Client>,
+  sep: string,
+  dec: string
+): void {
+  // Build groups keyed by first tag ('' = no tag).
+  const groupMap = new Map<string, Entry[]>()
+  for (const entry of entries) {
+    const entryTags = deserializeTags(entry.tags)
+    const key = entryTags[0] ?? ''
+    const bucket = groupMap.get(key) ?? []
+    bucket.push(entry)
+    groupMap.set(key, bucket)
+  }
+
+  // Named tags alphabetically first, then '' (Ohne Tag) last.
+  const sortedKeys = [...groupMap.keys()].sort((a, b) => {
+    if (a === '') return 1
+    if (b === '') return -1
+    return a.localeCompare(b, 'de')
+  })
+
+  let grandDurSec = 0
+  let grandAmountCent = 0
+  let grandHasRate = false
+
+  for (const key of sortedKeys) {
+    const groupEntries = groupMap.get(key)!
+    const tagLabel = key === '' ? 'Ohne Tag' : key
+
+    // Group header row: tag name in Beschreibung column, all others empty.
+    const headerFields = Array<string>(HEADER.length).fill('')
+    headerFields[5] = `[${tagLabel}]` // Beschreibung column
+    rows.push(headerFields.map((f) => escapeField(f, sep)).join(sep))
+
+    let groupDurSec = 0
+    let groupAmountCent = 0
+    let groupHasRate = false
+
+    for (const entry of groupEntries) {
+      rows.push(buildEntryRow(entry, clientMap, sep, dec))
+
+      const start = new Date(entry.started_at)
+      const stop = new Date(entry.stopped_at!)
+      const durSec = Math.max(0, Math.floor((stop.getTime() - start.getTime()) / 1000))
+      groupDurSec += durSec
+
+      const rateCent = clientMap.get(entry.client_id)?.rate_cent ?? 0
+      if (rateCent > 0) {
+        groupHasRate = true
+        groupAmountCent += (durSec / 3600) * rateCent
+      }
+    }
+
+    grandDurSec += groupDurSec
+    if (groupHasRate) {
+      grandHasRate = true
+      grandAmountCent += groupAmountCent
+    }
+
+    // Subtotal row: Beschreibung = label, Dauer = duration, Betrag = amount.
+    const subtotalFields = Array<string>(HEADER.length).fill('')
+    subtotalFields[3] = formatDuration(groupDurSec) // Dauer
+    subtotalFields[5] = `${tagLabel} Σ` // Beschreibung
+    if (groupHasRate) subtotalFields[9] = formatDecimal(groupAmountCent / 100, dec) // Betrag
+    rows.push(subtotalFields.map((f) => escapeField(f, sep)).join(sep))
+  }
+
+  // Grand total row.
+  const totalFields = Array<string>(HEADER.length).fill('')
+  totalFields[3] = formatDuration(grandDurSec)
+  totalFields[5] = 'Σ Gesamt'
+  if (grandHasRate) totalFields[9] = formatDecimal(grandAmountCent / 100, dec)
+  rows.push(totalFields.map((f) => escapeField(f, sep)).join(sep))
 }
 
 /** Format a Date as dd.MM.yyyy in local timezone. */

--- a/src/shared/locales/de.ts
+++ b/src/shared/locales/de.ts
@@ -301,6 +301,8 @@ export const de = {
   'export.csv.formatDeHint': '(Semikolon, Komma-Dezimal — Excel DE)',
   'export.csv.formatUsHint': '(Komma, Punkt-Dezimal — DATEV)',
   'export.csv.encodingNote': 'UTF-8 mit BOM. Excel öffnet die Datei ohne Encoding-Abfrage.',
+  'export.csv.groupByTag': 'Nach Tags gruppieren',
+  'export.csv.groupByTagHint': 'Fügt pro Tag eine Kopfzeile und Zwischensumme ein.',
   'export.footer.pdfHint': 'Vorlage anpassen unter',
   'export.footer.pdfHintPath': 'Einstellungen → PDF-Vorlage',
   'export.footer.csvHint': 'Enthält alle abgeschlossenen Einträge im gewählten Zeitraum.',

--- a/src/shared/locales/en.ts
+++ b/src/shared/locales/en.ts
@@ -298,6 +298,8 @@ export const en: Record<TranslationKey, string> = {
   'export.csv.formatDeHint': '(Semicolon, comma decimal — Excel DE)',
   'export.csv.formatUsHint': '(Comma, period decimal — DATEV)',
   'export.csv.encodingNote': 'UTF-8 with BOM. Excel opens the file without encoding prompts.',
+  'export.csv.groupByTag': 'Group by tag',
+  'export.csv.groupByTagHint': 'Inserts a header row and subtotal for each tag.',
   'export.footer.pdfHint': 'Customize template under',
   'export.footer.pdfHintPath': 'Settings → PDF template',
   'export.footer.csvHint': 'Includes all completed entries in the selected period.',


### PR DESCRIPTION
## Was wurde gemacht

Schließt Issue #68 — CSV-Export nach Tags gruppieren.

### Änderungen

**src/shared/csv.ts**
- Neue Option \groupByTag?: boolean\ in \CsvOptions\
- Refactoring: \uildEntryRow\-Hilfsfunktion extrahiert (kein Code-Duplikat)
- Neue Funktion \ppendGroupedRows\: gruppiert Einträge nach erstem Tag, alphabetisch sortiert; »Ohne Tag« immer zuletzt
- Pro Gruppe: Kopfzeile \[TagName]\ in der Beschreibungs-Spalte, anschließend normale Zeilen, dann Zwischensummen-Zeile \TagName Σ\ (Dauer + Betrag)
- Gesamtsummen-Zeile \Σ Gesamt\ am Ende
- Fallback auf flache Ausgabe wenn kein Eintrag Tags hat

**src/main/csvExport.ts**
- \groupByTag?: boolean\ in \CsvRequest\ ergänzt, wird an \ormatCsv\ weitergegeben

**src/preload/index.d.ts**
- \groupByTag?: boolean\ im \csv.export\-Typ ergänzt

**src/renderer/src/components/ExportModal.tsx**
- Neuer State \csvGroupByTag\, wird an API-Aufruf übergeben
- Checkbox »Nach Tags gruppieren« (mit Hinweistext) im CSV-Tab — über der Format-Auswahl

**src/shared/locales/de.ts + \n.ts\**
- Keys \xport.csv.groupByTag\ und \xport.csv.groupByTagHint\

**src/shared/csv.test.ts**
- 7 neue Tests: flat fallback, alphabetische Reihenfolge, Dauer-Subtotal, Betrag-Subtotal, »Ohne Tag« zuletzt, Gesamtsumme, Multi-Tag-Dedup

### CSV-Format (Beispiel)

\\\
Datum;Start;Ende;Dauer;Kunde;Beschreibung;Tags;Referenz;Stundensatz;Betrag
;;;;; [Design];;;;
01.04.2026;09:00;10:30;01:30:00;Acme GmbH;UI Review;Design;;75,00;112,50
;;;;;Design Σ;;;; 112,50
;;;;; [Dev];;;;
02.04.2026;14:00;16:00;02:00:00;Acme GmbH;Backend;Dev;;75,00;150,00
;;;;;Dev Σ;;;;150,00
;;;;;Σ Gesamt;;;; 262,50
\\\

### Tests
216 Tests ✅ (vorher 209, +7 neue)