### PR TITLE
v1.9.0 feat: Projekte pro Kunde — DB, Types, IPC (PR 1/4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,23 @@
 
 All notable changes to TimeTrack are documented here.
 
+## [1.9.0] — unreleased
+
+### Added
+
+- **Projekte pro Kunde — DB, Types, IPC (PR 1/4)** — Foundation für Issue #75. Neue `projects`-Tabelle (client-scoped via FK, Soft-Delete via `active = 0`), `project_id`-Spalte auf `entries` (nullable, ON DELETE SET NULL), vollständige IPC-Handler (`projects:getAll`, `projects:create`, `projects:update`, `projects:archive`, `projects:delete`), TypeScript-Typen (`Project`, `CreateProjectInput`, `UpdateProjectInput`, `ProjectWithCount`) und Preload-Exposition (`window.api.projects.*`). ([#75](https://github.com/skoedr/time-tracking/issues/75))
+
+### Fixed
+
+- **`insertEntrySegments` unterschlug `project_id`** — Der 11-Spalten-INSERT in der Hilfsfunktion übergab `project_id` nicht. Jetzt 12-Spalten-INSERT; beide Aufrufer (`entries:create`, `entries:update`) reichen `input.project_id ?? null` weiter.
+- **`entries:start` speicherte `project_id` nicht** — Der 4-Spalten-INSERT beim Starten eines Timers setzte `project_id` implizit auf NULL. Jetzt explizit übergeben.
+
+### Migration Note
+
+Migration 012 (`v1.9-projects`) fügt einen Index `idx_entries_project_started` auf der `entries`-Tabelle hinzu. Bei sehr großen Datenbanken (50.000+ Einträge) kann der erste App-Start nach dem Update 2–5 Sekunden länger dauern, während der Index aufgebaut wird.
+
 ## [1.8.1] — 2026-04-28
+
 
 ### Fixed
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -5,6 +5,13 @@ Deferred items from plan reviews. Items here have explicit decisions — they ar
 ## Open Issues
 
 - **#87 — UI centering across views** (Low effort) — Settings ist der einzige Knackpunkt: Outer-Wrapper in `src/renderer/src/views/SettingsView.tsx:189` braucht `max-w-4xl mx-auto`. Today/Timer/Calendar/Clients sind in Toleranz oder pragmatisch korrekt (Verifikation gegen `design/issue-76-glass-reference.html` durchgeführt 2026-04-28). Optional: pixelgenaue Werte via `max-w-[740px]` / `max-w-[600px]` statt Tailwind-Tokens. → v1.9 candidate.
+- **#75 — Projekte pro Kunde** (Medium-Large effort) — Plan akzeptiert (2026-04-29), `/autoplan` Phase 1 (CEO) abgeschlossen 2026-04-29. Hierarchie Kunde→Projekt→Eintrag mit eigener Tabelle, Migration 012, optional eigener Stundensatz pro Projekt, projektgefilterte Exporte. **Aktueller Stand:** Approach B + Cherry-Picks E2/E4/E6 locked (E2: "Allgemein"-virtual-project; E4: projects.client_id nullable für v2.0-escape-hatch; E6: starts_on/ends_on aus v1.9 entfernt — YAGNI). Premissen P1-P4 bestätigt. **Nächste Schritte:** `/autoplan` Phase 2 (Design Review), Phase 3 (Eng Review), Final Gate. Danach 4 sequenzielle PRs (DB+IPC → Project-CRUD-UI → Timer/Today/Calendar → Exports). → v1.9.
+
+### Deferred from #75 /autoplan Phase 1 (CEO Cherry-Picks)
+
+- **E1 — Auto-color-shift für Projekte** (Low effort, Low risk) — Projektfarbe automatisch aus Kundenfarbe ableiten (Helligkeitsverschiebung), statt manuelle Farbwahl im Project-Modal. Visual coherence pro Kunde. → v1.9.x oder v2.0.
+- **E3 — Projekt-Budget-Warnung** (Medium effort, Low risk) — Read-only "X von Y Stunden verbraucht"-Anzeige im Project-Modal und in TodayView. Setzt Stundenkontingent pro Projekt voraus. → v2.0.
+- **E5 — Project-Quick-Stats in ClientsView** (Low effort, Low risk) — Pro Projekt: Eintragsanzahl + letzte Aktivität neben dem Projektnamen in der Sub-Liste. → v1.9.x.
 
 ## Blocking v1.7 — RESOLVED
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "time-tracking",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "Schlanker Desktop-Zeiterfasser für Windows — Toggl-Track-Style, lokal, ohne Cloud.",
   "main": "./out/main/index.js",
   "author": "skoedr",

--- a/src/main/ipc.test.ts
+++ b/src/main/ipc.test.ts
@@ -582,8 +582,272 @@ describe('billable + private_note — DB round-trip', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Regression test: dashboard:summary duration calculation must return exact
-// integer seconds for entries with round durations (e.g. exactly 1 hour).
+// projects — validateProject + projects:* IPC SQL contract tests
+// ---------------------------------------------------------------------------
+
+/**
+ * Local replica of validateProject from ipc.ts so we can test it without
+ * booting the Electron runtime.
+ */
+function validateProject(
+  input: { client_id: number | null; name: string; color: string; rate_cent?: number | null },
+  db?: Database.Database
+): string | null {
+  const name = input.name?.trim() ?? ''
+  if (name.length === 0) return 'Name darf nicht leer sein'
+  if (name.length > 100) return 'Name darf höchstens 100 Zeichen lang sein'
+  if (['allgemein', 'general'].includes(name.toLowerCase())) {
+    return `"${input.name}" ist ein reservierter Name`
+  }
+  if (input.rate_cent !== undefined && input.rate_cent !== null) {
+    const rate = Number(input.rate_cent)
+    if (!Number.isFinite(rate) || rate < 0) return 'Stundensatz darf nicht negativ sein'
+  }
+  if (db && input.client_id !== null && input.client_id !== undefined) {
+    const clientRow = db.prepare('SELECT id FROM clients WHERE id = ?').get(input.client_id) as
+      | { id: number }
+      | undefined
+    if (!clientRow) return 'Kunde existiert nicht'
+  }
+  return null
+}
+
+describe('projects — validateProject', () => {
+  let tmpDir: string
+  let db: Database.Database
+
+  beforeEach((ctx) => {
+    if (!DatabaseImpl) {
+      ctx.skip()
+      return
+    }
+    tmpDir = mkdtempSync(join(tmpdir(), 'tt-projects-'))
+    db = new DatabaseImpl(join(tmpDir, 'test.sqlite'))
+    db.pragma('foreign_keys = ON')
+    db.exec(
+      `CREATE TABLE schema_version (
+         version INTEGER PRIMARY KEY,
+         name TEXT NOT NULL,
+         applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+       )`
+    )
+    for (const m of migrations) {
+      const tx = db.transaction(() => {
+        db.exec(m.up)
+        db.prepare('INSERT INTO schema_version (version, name) VALUES (?, ?)').run(
+          m.version,
+          m.name
+        )
+      })
+      tx()
+    }
+    db.prepare(`INSERT INTO clients (id, name) VALUES (1, 'Acme')`).run()
+    db.prepare(`INSERT INTO clients (id, name) VALUES (2, 'Other')`).run()
+  })
+
+  afterEach(() => {
+    if (!db) return
+    db.close()
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('accepts valid project input', () => {
+    const err = validateProject({ client_id: 1, name: 'App', color: '#abc', rate_cent: null }, db)
+    expect(err).toBeNull()
+  })
+
+  it('rejects empty name', () => {
+    const err = validateProject({ client_id: 1, name: '  ', color: '' }, db)
+    expect(err).toMatch(/Name darf nicht leer/)
+  })
+
+  it('rejects name over 100 chars', () => {
+    const err = validateProject({ client_id: 1, name: 'x'.repeat(101), color: '' }, db)
+    expect(err).toMatch(/100 Zeichen/)
+  })
+
+  it('rejects reserved name "Allgemein"', () => {
+    const err = validateProject({ client_id: 1, name: 'Allgemein', color: '' }, db)
+    expect(err).toMatch(/reservierter Name/)
+  })
+
+  it('rejects reserved name "allgemein" (case-insensitive)', () => {
+    const err = validateProject({ client_id: 1, name: 'allgemein', color: '' }, db)
+    expect(err).toMatch(/reservierter Name/)
+  })
+
+  it('rejects negative rate_cent', () => {
+    const err = validateProject({ client_id: 1, name: 'App', color: '', rate_cent: -100 }, db)
+    expect(err).toMatch(/negativ/)
+  })
+
+  it('rejects unknown client_id', () => {
+    const err = validateProject({ client_id: 999, name: 'App', color: '' }, db)
+    expect(err).toMatch(/Kunde existiert nicht/)
+  })
+
+  it('allows null client_id (E4 orphan escape hatch)', () => {
+    const err = validateProject({ client_id: null, name: 'App', color: '' }, db)
+    expect(err).toBeNull()
+  })
+})
+
+describe('projects — SQL contract tests', () => {
+  let tmpDir: string
+  let db: Database.Database
+
+  beforeEach((ctx) => {
+    if (!DatabaseImpl) {
+      ctx.skip()
+      return
+    }
+    tmpDir = mkdtempSync(join(tmpdir(), 'tt-projects-sql-'))
+    db = new DatabaseImpl(join(tmpDir, 'test.sqlite'))
+    db.pragma('foreign_keys = ON')
+    db.exec(
+      `CREATE TABLE schema_version (
+         version INTEGER PRIMARY KEY,
+         name TEXT NOT NULL,
+         applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+       )`
+    )
+    for (const m of migrations) {
+      const tx = db.transaction(() => {
+        db.exec(m.up)
+        db.prepare('INSERT INTO schema_version (version, name) VALUES (?, ?)').run(
+          m.version,
+          m.name
+        )
+      })
+      tx()
+    }
+    db.prepare(`INSERT INTO clients (id, name) VALUES (1, 'Acme')`).run()
+    db.prepare(`INSERT INTO clients (id, name) VALUES (2, 'Other')`).run()
+  })
+
+  afterEach(() => {
+    if (!db) return
+    db.close()
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  // Helper: insert a project and return its id
+  function createProject(clientId: number | null, name: string, active = 1): number {
+    const row = db
+      .prepare(
+        `INSERT INTO projects (client_id, name, color, rate_cent, active) VALUES (?, ?, '', NULL, ?) RETURNING id`
+      )
+      .get(clientId, name, active) as { id: number }
+    return row.id
+  }
+
+  // Helper: insert an entry for a project
+  function createEntry(
+    clientId: number,
+    projectId: number | null,
+    deletedAt: string | null = null
+  ): number {
+    const start = new Date(Date.now() - 2 * 3600 * 1000).toISOString()
+    const stop = new Date(Date.now() - 1 * 3600 * 1000).toISOString()
+    const info = db
+      .prepare(
+        `INSERT INTO entries (client_id, started_at, stopped_at, project_id, deleted_at)
+         VALUES (?, ?, ?, ?, ?)`
+      )
+      .run(clientId, start, stop, projectId, deletedAt)
+    return info.lastInsertRowid as number
+  }
+
+  it('projects:update — blocks client_id change when entries exist', () => {
+    const pid = createProject(1, 'App')
+    createEntry(1, pid)
+    // Simulate the IPC guard: count entries
+    const { n } = db
+      .prepare(`SELECT COUNT(*) AS n FROM entries WHERE project_id = ? AND deleted_at IS NULL`)
+      .get(pid) as { n: number }
+    expect(n).toBeGreaterThan(0)
+    // The handler would return fail() here — validate the guard
+    const current = db
+      .prepare('SELECT client_id FROM projects WHERE id = ?')
+      .get(pid) as { client_id: number | null }
+    expect(current.client_id).toBe(1)
+    // Moving to client 2 should be blocked
+    const wouldBlock = current.client_id !== 2 && n > 0
+    expect(wouldBlock).toBe(true)
+  })
+
+  it('projects:update — allows client_id change when no entries exist', () => {
+    const pid = createProject(1, 'App')
+    const { n } = db
+      .prepare(`SELECT COUNT(*) AS n FROM entries WHERE project_id = ? AND deleted_at IS NULL`)
+      .get(pid) as { n: number }
+    expect(n).toBe(0)
+    db.prepare(`UPDATE projects SET client_id = 2 WHERE id = ?`).run(pid)
+    const updated = db.prepare('SELECT client_id FROM projects WHERE id = ?').get(pid) as {
+      client_id: number
+    }
+    expect(updated.client_id).toBe(2)
+  })
+
+  it('projects:delete — blocked when active entries exist', () => {
+    const pid = createProject(1, 'App')
+    createEntry(1, pid)
+    const { n } = db
+      .prepare(`SELECT COUNT(*) AS n FROM entries WHERE project_id = ? AND deleted_at IS NULL`)
+      .get(pid) as { n: number }
+    expect(n).toBe(1)
+    // Should throw inside the transaction
+    expect(() => {
+      const tx = db.transaction(() => {
+        const countRow = db
+          .prepare(`SELECT COUNT(*) AS n FROM entries WHERE project_id = ? AND deleted_at IS NULL`)
+          .get(pid) as { n: number }
+        if (countRow.n > 0) throw new Error('Projekt hat noch aktive Einträge')
+        db.prepare('DELETE FROM projects WHERE id = ?').run(pid)
+      })
+      tx()
+    }).toThrow(/aktive Einträge/)
+    // Project must still exist
+    const still = db.prepare('SELECT id FROM projects WHERE id = ?').get(pid)
+    expect(still).toBeDefined()
+  })
+
+  it('projects:delete — succeeds when only soft-deleted entries exist', () => {
+    const pid = createProject(1, 'App')
+    createEntry(1, pid, new Date().toISOString()) // soft-deleted
+    const { n } = db
+      .prepare(`SELECT COUNT(*) AS n FROM entries WHERE project_id = ? AND deleted_at IS NULL`)
+      .get(pid) as { n: number }
+    expect(n).toBe(0)
+    db.prepare('DELETE FROM projects WHERE id = ?').run(pid)
+    const gone = db.prepare('SELECT id FROM projects WHERE id = ?').get(pid)
+    expect(gone).toBeUndefined()
+  })
+
+  it('projects:getAll — entry_count excludes soft-deleted entries', () => {
+    const pid = createProject(1, 'App')
+    createEntry(1, pid) // active
+    createEntry(1, pid, new Date().toISOString()) // soft-deleted
+    const row = db
+      .prepare(
+        `SELECT p.*, COALESCE(ec.cnt, 0) AS entry_count FROM projects p
+         LEFT JOIN (SELECT project_id, COUNT(*) AS cnt FROM entries WHERE deleted_at IS NULL GROUP BY project_id) ec
+           ON ec.project_id = p.id
+         WHERE p.id = ?`
+      )
+      .get(pid) as { entry_count: number }
+    expect(row.entry_count).toBe(1)
+  })
+
+  it('entries — project_id is stored and retrieved correctly', () => {
+    const pid = createProject(1, 'App')
+    const eid = createEntry(1, pid)
+    const row = db.prepare('SELECT project_id FROM entries WHERE id = ?').get(eid) as {
+      project_id: number | null
+    }
+    expect(row.project_id).toBe(pid)
+  })
+})
 //
 // Root cause of the bug: julianday() arithmetic in SQLite uses IEEE-754
 // floating point and can return 3599.9999... for a 3600-second interval.

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -20,11 +20,14 @@ import { mergeOnlyHandler, pdfInfoHandler } from './pdfMergeHandlers'
 import type {
   Client,
   Entry,
+  Project,
   CreateClientInput,
   UpdateClientInput,
   CreateEntryInput,
   CreateManualEntryInput,
   UpdateEntryInput,
+  CreateProjectInput,
+  UpdateProjectInput,
   MonthQuery,
   Settings,
   IpcResult,
@@ -130,10 +133,10 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
       )
       const info = db
         .prepare(
-          `INSERT INTO entries (client_id, description, started_at, heartbeat_at)
-           VALUES (?, ?, ?, ?)`
+          `INSERT INTO entries (client_id, description, started_at, heartbeat_at, project_id)
+           VALUES (?, ?, ?, ?, ?)`
         )
-        .run(input.client_id, input.description, input.started_at, input.started_at)
+        .run(input.client_id, input.description, input.started_at, input.started_at, input.project_id ?? null)
       const row = db
         .prepare(`SELECT * FROM entries WHERE id = ?`)
         .get(info.lastInsertRowid) as Entry
@@ -220,7 +223,7 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
       const err = validateManualEntry(db, input)
       if (err) return fail(err)
       const segments = splitAtMidnight(new Date(input.started_at), new Date(input.stopped_at))
-      const insertedRow = insertEntrySegments(db, input, segments, input.tags ?? '', input.reference ?? '', input.billable ?? 1, input.private_note ?? '')
+      const insertedRow = insertEntrySegments(db, input, segments, input.tags ?? '', input.reference ?? '', input.billable ?? 1, input.private_note ?? '', input.project_id ?? null)
       return ok(insertedRow)
     } catch (e) {
       return fail(e)
@@ -248,7 +251,7 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
         } else {
           db.prepare(`DELETE FROM entries WHERE id = ?`).run(input.id)
         }
-        return insertEntrySegments(db, input, segments, input.tags ?? '', input.reference ?? '', input.billable ?? 1, input.private_note ?? '')
+        return insertEntrySegments(db, input, segments, input.tags ?? '', input.reference ?? '', input.billable ?? 1, input.private_note ?? '', input.project_id ?? null)
       })
       const row = tx()
       return ok(row)
@@ -321,6 +324,121 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
         .sort((a, b) => b[1] - a[1])
         .map(([tag]) => tag)
       return ok(sorted)
+    } catch (e) {
+      return fail(e)
+    }
+  })
+
+  // ── Projects (v1.9 #75) ──────────────────────────────────────
+  ipcMain.handle(
+    'projects:getAll',
+    (_e, req?: { clientId?: number | null }): IpcResult<Project[]> => {
+      try {
+        const base = `SELECT p.*, COALESCE(ec.cnt, 0) AS entry_count FROM projects p
+          LEFT JOIN (SELECT project_id, COUNT(*) AS cnt FROM entries WHERE deleted_at IS NULL GROUP BY project_id) ec
+            ON ec.project_id = p.id`
+        let query: string
+        let params: unknown[]
+        if (req !== undefined && req !== null && 'clientId' in req) {
+          if (req.clientId === null) {
+            query = `${base} WHERE p.client_id IS NULL ORDER BY p.active DESC, p.name`
+            params = []
+          } else {
+            query = `${base} WHERE p.client_id = ? ORDER BY p.active DESC, p.name`
+            params = [req.clientId]
+          }
+        } else {
+          query = `${base} ORDER BY p.active DESC, p.name`
+          params = []
+        }
+        const rows = db.prepare(query).all(...params) as Project[]
+        return ok(rows)
+      } catch (e) {
+        return fail(e)
+      }
+    }
+  )
+
+  ipcMain.handle('projects:create', (_e, input: CreateProjectInput): IpcResult<Project> => {
+    try {
+      const err = validateProject(input, db)
+      if (err) return fail(err)
+      const result = db
+        .prepare(
+          `INSERT INTO projects (client_id, name, color, rate_cent) VALUES (?, ?, ?, ?) RETURNING *`
+        )
+        .get(
+          input.client_id ?? null,
+          input.name.trim(),
+          input.color ?? '',
+          input.rate_cent ?? null
+        ) as Project
+      return ok(result)
+    } catch (e) {
+      return fail(e)
+    }
+  })
+
+  ipcMain.handle('projects:update', (_e, input: UpdateProjectInput): IpcResult<Project> => {
+    try {
+      const err = validateProject(input, db)
+      if (err) return fail(err)
+      const current = db
+        .prepare('SELECT client_id FROM projects WHERE id = ?')
+        .get(input.id) as { client_id: number | null } | undefined
+      if (!current) return fail('Projekt nicht gefunden')
+      if (current.client_id !== input.client_id) {
+        const countRow = db
+          .prepare(
+            `SELECT COUNT(*) AS n FROM entries WHERE project_id = ? AND deleted_at IS NULL`
+          )
+          .get(input.id) as { n: number }
+        if (countRow.n > 0) {
+          return fail(
+            'Projekt hat Einträge und kann nicht zu einem anderen Kunden verschoben werden'
+          )
+        }
+      }
+      const result = db
+        .prepare(
+          `UPDATE projects SET client_id=?, name=?, color=?, rate_cent=?, active=? WHERE id=? RETURNING *`
+        )
+        .get(
+          input.client_id ?? null,
+          input.name.trim(),
+          input.color ?? '',
+          input.rate_cent ?? null,
+          input.active,
+          input.id
+        ) as Project
+      return ok(result)
+    } catch (e) {
+      return fail(e)
+    }
+  })
+
+  ipcMain.handle('projects:archive', (_e, id: number): IpcResult<void> => {
+    try {
+      db.prepare('UPDATE projects SET active = 0 WHERE id = ?').run(id)
+      return ok(undefined)
+    } catch (e) {
+      return fail(e)
+    }
+  })
+
+  ipcMain.handle('projects:delete', (_e, id: number): IpcResult<void> => {
+    try {
+      const tx = db.transaction(() => {
+        const countRow = db
+          .prepare(
+            `SELECT COUNT(*) AS n FROM entries WHERE project_id = ? AND deleted_at IS NULL`
+          )
+          .get(id) as { n: number }
+        if (countRow.n > 0) throw new Error('Projekt hat noch aktive Einträge')
+        db.prepare('DELETE FROM projects WHERE id = ?').run(id)
+      })
+      tx()
+      return ok(undefined)
     } catch (e) {
       return fail(e)
     }
@@ -846,6 +964,33 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
 }
 
 /**
+ * Server-side validation for project create/update.
+ * Returns an error string if invalid, `null` if valid.
+ */
+function validateProject(
+  input: CreateProjectInput | UpdateProjectInput,
+  db?: ReturnType<typeof getDb>
+): string | null {
+  const name = input.name?.trim() ?? ''
+  if (name.length === 0) return 'Name darf nicht leer sein'
+  if (name.length > 100) return 'Name darf höchstens 100 Zeichen lang sein'
+  if (['allgemein', 'general'].includes(name.toLowerCase())) {
+    return `"${input.name}" ist ein reservierter Name`
+  }
+  if (input.rate_cent !== undefined && input.rate_cent !== null) {
+    const rate = Number(input.rate_cent)
+    if (!Number.isFinite(rate) || rate < 0) return 'Stundensatz darf nicht negativ sein'
+  }
+  if (db && input.client_id !== null && input.client_id !== undefined) {
+    const clientRow = db
+      .prepare('SELECT id FROM clients WHERE id = ?')
+      .get(input.client_id) as { id: number } | undefined
+    if (!clientRow) return 'Kunde existiert nicht'
+  }
+  return null
+}
+
+/**
  * Server-side validation contract for manual entry create/update (E3).
  * Returns an error string if invalid, `null` if valid. Single point of
  * truth: UI may pre-validate but must not be the only line of defence
@@ -941,13 +1086,14 @@ function insertEntrySegments(
   tags = '',
   reference = '',
   billable = 1,
-  private_note = ''
+  private_note = '',
+  project_id: number | null = null
 ): Entry {
   const linkId = segments.length > 1 ? randomUUID() : null
   const description = input.description.trim()
   const insertStmt = db.prepare(
-    `INSERT INTO entries (client_id, description, started_at, stopped_at, heartbeat_at, rounded_min, link_id, tags, reference, billable, private_note)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    `INSERT INTO entries (client_id, description, started_at, stopped_at, heartbeat_at, rounded_min, link_id, project_id, tags, reference, billable, private_note)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
   )
   const tx = db.transaction((): Entry => {
     let firstId = 0
@@ -962,6 +1108,7 @@ function insertEntrySegments(
         stoppedAt,
         Math.round((seg.stop.getTime() - seg.start.getTime()) / 60000),
         linkId,
+        project_id,
         tags,
         reference,
         billable,

--- a/src/main/migrations/012-v19-projects.ts
+++ b/src/main/migrations/012-v19-projects.ts
@@ -1,0 +1,40 @@
+import type { Migration } from './index'
+
+/**
+ * v1.9 #75 — Projekte pro Kunde.
+ *
+ * Adds a `projects` table (scoped to clients via FK) and a nullable
+ * `project_id` column on `entries`. Existing entries keep project_id = NULL
+ * which is treated as "no project / general" by the renderer.
+ *
+ * Performance note (FG-3): building idx_entries_project_started scans all
+ * existing entries. On large databases (50K+ entries) this may take 2-5
+ * seconds during first launch after upgrade. Documented in CHANGELOG.md.
+ */
+export const migration012: Migration = {
+  version: 12,
+  name: 'v1.9-projects',
+  up: `
+    CREATE TABLE IF NOT EXISTS projects (
+      id          INTEGER PRIMARY KEY AUTOINCREMENT,
+      client_id   INTEGER REFERENCES clients(id) ON DELETE CASCADE,
+      name        TEXT    NOT NULL,
+      color       TEXT    NOT NULL DEFAULT '',
+      rate_cent   INTEGER,
+      active      INTEGER NOT NULL DEFAULT 1,
+      created_at  TEXT    NOT NULL DEFAULT (datetime('now'))
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_projects_client_active
+      ON projects(client_id, active);
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_projects_unique_active_name
+      ON projects(client_id, name) WHERE active = 1;
+
+    ALTER TABLE entries ADD COLUMN project_id INTEGER
+      REFERENCES projects(id) ON DELETE SET NULL;
+
+    CREATE INDEX IF NOT EXISTS idx_entries_project_started
+      ON entries(project_id, started_at);
+  `
+}

--- a/src/main/migrations/index.ts
+++ b/src/main/migrations/index.ts
@@ -9,6 +9,7 @@ import { migration008 } from './008-v15-onboarding'
 import { migration009 } from './009-v18-reference'
 import { migration010 } from './010-v18-billable-private-note'
 import { migration011 } from './011-v18-theme'
+import { migration012 } from './012-v19-projects'
 
 export interface Migration {
   /** Monotonically increasing integer. Never reused, never reordered. */
@@ -34,5 +35,6 @@ export const migrations: Migration[] = [
   migration008,
   migration009,
   migration010,
-  migration011
+  migration011,
+  migration012
 ].sort((a, b) => a.version - b.version)

--- a/src/main/migrations/migrations.test.ts
+++ b/src/main/migrations/migrations.test.ts
@@ -548,4 +548,113 @@ describe('migration SQL execution', () => {
     const row = db.prepare('SELECT reference FROM entries').get() as { reference: string }
     expect(row.reference).toBe('JIRA-123')
   })
+
+  // ── Migration 012 — v1.9-projects ──────────────────────────────────────
+
+  it('migration 012 — projects table exists after full migration run', () => {
+    applyAll()
+    const tables = (
+      db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as Array<{
+        name: string
+      }>
+    ).map((r) => r.name)
+    expect(tables).toContain('projects')
+  })
+
+  it('migration 012 — entries.project_id column exists and is nullable', () => {
+    applyAll()
+    const cols = db.prepare('PRAGMA table_info(entries)').all() as Array<{
+      name: string
+      notnull: number
+    }>
+    const col = cols.find((c) => c.name === 'project_id')
+    expect(col).toBeDefined()
+    expect(col?.notnull).toBe(0)
+  })
+
+  it('migration 012 — idx_projects_client_active index exists', () => {
+    applyAll()
+    const idx = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_projects_client_active'"
+      )
+      .get()
+    expect(idx).toBeDefined()
+  })
+
+  it('migration 012 — existing entries survive with project_id = NULL', () => {
+    // Apply 001-011, insert entry, then apply 012.
+    const pre = migrations.filter((m) => m.version < 12)
+    for (const m of pre) {
+      const tx = db.transaction(() => {
+        db.exec(m.up)
+        db.prepare('INSERT INTO schema_version (version, name) VALUES (?, ?)').run(
+          m.version,
+          m.name
+        )
+      })
+      tx()
+    }
+    db.prepare(`INSERT INTO clients (id, name) VALUES (1, 'Acme')`).run()
+    db.prepare(
+      `INSERT INTO entries (client_id, started_at, stopped_at)
+       VALUES (1, '2026-05-01T08:00:00Z', '2026-05-01T09:00:00Z')`
+    ).run()
+    // Apply migration 012
+    const m012 = migrations.find((m) => m.version === 12)!
+    const tx = db.transaction(() => {
+      db.exec(m012.up)
+      db.prepare('INSERT INTO schema_version (version, name) VALUES (?, ?)').run(
+        m012.version,
+        m012.name
+      )
+    })
+    tx()
+    const row = db.prepare('SELECT project_id FROM entries').get() as {
+      project_id: number | null
+    }
+    expect(row.project_id).toBeNull()
+  })
+
+  it('migration 012 — deleting project sets entries.project_id to NULL (SET NULL)', () => {
+    applyAll()
+    db.prepare(`INSERT INTO clients (id, name) VALUES (1, 'Acme')`).run()
+    db.prepare(`INSERT INTO projects (id, client_id, name) VALUES (1, 1, 'App')`).run()
+    db.prepare(
+      `INSERT INTO entries (client_id, started_at, stopped_at, project_id)
+       VALUES (1, '2026-05-01T08:00:00Z', '2026-05-01T09:00:00Z', 1)`
+    ).run()
+    db.prepare('DELETE FROM projects WHERE id = 1').run()
+    const row = db.prepare('SELECT project_id FROM entries').get() as {
+      project_id: number | null
+    }
+    expect(row.project_id).toBeNull()
+  })
+
+  it('migration 012 — deleting client cascades to projects', () => {
+    applyAll()
+    db.prepare(`INSERT INTO clients (id, name) VALUES (1, 'Acme')`).run()
+    db.prepare(`INSERT INTO projects (client_id, name) VALUES (1, 'App')`).run()
+    db.prepare('DELETE FROM clients WHERE id = 1').run()
+    const count = db.prepare('SELECT COUNT(*) AS n FROM projects').get() as { n: number }
+    expect(count.n).toBe(0)
+  })
+
+  it('migration 012 — UNIQUE partial index: two active projects same name same client → rejected', () => {
+    applyAll()
+    db.prepare(`INSERT INTO clients (id, name) VALUES (1, 'Acme')`).run()
+    db.prepare(`INSERT INTO projects (client_id, name, active) VALUES (1, 'App', 1)`).run()
+    expect(() => {
+      db.prepare(`INSERT INTO projects (client_id, name, active) VALUES (1, 'App', 1)`).run()
+    }).toThrow()
+  })
+
+  it('migration 012 — UNIQUE partial index: two archived projects same name same client → allowed', () => {
+    applyAll()
+    db.prepare(`INSERT INTO clients (id, name) VALUES (1, 'Acme')`).run()
+    db.prepare(`INSERT INTO projects (client_id, name, active) VALUES (1, 'App', 0)`).run()
+    expect(() => {
+      db.prepare(`INSERT INTO projects (client_id, name, active) VALUES (1, 'App', 0)`).run()
+    }).not.toThrow()
+  })
 })

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -2,11 +2,14 @@ import { ElectronAPI } from '@electron-toolkit/preload'
 import type {
   Client,
   Entry,
+  Project,
   CreateClientInput,
   UpdateClientInput,
   CreateEntryInput,
   CreateManualEntryInput,
   UpdateEntryInput,
+  CreateProjectInput,
+  UpdateProjectInput,
   MonthQuery,
   Settings,
   IpcResult,
@@ -138,6 +141,13 @@ declare global {
           format?: 'de' | 'us'
           groupByTag?: boolean
         }): Promise<IpcResult<{ path: string }>>
+      }
+      projects: {
+        getAll(req?: { clientId?: number | null }): Promise<IpcResult<Project[]>>
+        create(input: CreateProjectInput): Promise<IpcResult<Project>>
+        update(input: UpdateProjectInput): Promise<IpcResult<Project>>
+        archive(id: number): Promise<IpcResult<void>>
+        delete(id: number): Promise<IpcResult<void>>
       }
       update: {
         getStatus(): Promise<IpcResult<UpdateStatus>>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3,11 +3,14 @@ import { electronAPI } from '@electron-toolkit/preload'
 import type {
   Client,
   Entry,
+  Project,
   CreateClientInput,
   UpdateClientInput,
   CreateEntryInput,
   CreateManualEntryInput,
   UpdateEntryInput,
+  CreateProjectInput,
+  UpdateProjectInput,
   MonthQuery,
   Settings,
   IpcResult,
@@ -190,6 +193,17 @@ const api = {
   csv: {
     export: (req: CsvRequest): Promise<IpcResult<{ path: string }>> =>
       ipcRenderer.invoke('csv:export', req)
+  },
+  // v1.9 #75 — Projects
+  projects: {
+    getAll: (req?: { clientId?: number | null }): Promise<IpcResult<Project[]>> =>
+      ipcRenderer.invoke('projects:getAll', req),
+    create: (input: CreateProjectInput): Promise<IpcResult<Project>> =>
+      ipcRenderer.invoke('projects:create', input),
+    update: (input: UpdateProjectInput): Promise<IpcResult<Project>> =>
+      ipcRenderer.invoke('projects:update', input),
+    archive: (id: number): Promise<IpcResult<void>> => ipcRenderer.invoke('projects:archive', id),
+    delete: (id: number): Promise<IpcResult<void>> => ipcRenderer.invoke('projects:delete', id)
   },
   // v1.5 PR B — auto-updater
   update: {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -49,6 +49,49 @@ export interface Entry {
    * Empty string means no note set.
    */
   private_note: string
+  /**
+   * v1.9 #75: optional project association. NULL means "no project / general".
+   */
+  project_id?: number | null
+}
+
+// ── Projects (v1.9 #75) ───────────────────────────────────────────────────
+
+export interface Project {
+  id: number
+  /** NULL = orphaned / no client (E4 escape hatch). */
+  client_id: number | null
+  name: string
+  /** '' = inherit client color. */
+  color: string
+  /** null = inherit client rate. */
+  rate_cent: number | null
+  /** 1 = active, 0 = archived. */
+  active: number
+  created_at: string
+  /**
+   * Only present in `projects:getAll` responses. Counts non-deleted entries.
+   */
+  entry_count?: number
+}
+
+/** Project guaranteed to include entry_count (returned by projects:getAll). */
+export type ProjectWithCount = Required<Pick<Project, 'entry_count'>> & Omit<Project, 'entry_count'>
+
+export interface CreateProjectInput {
+  client_id: number | null
+  name: string
+  color: string
+  rate_cent?: number | null
+}
+
+export interface UpdateProjectInput {
+  id: number
+  client_id: number | null
+  name: string
+  color: string
+  rate_cent?: number | null
+  active: number
 }
 
 export interface Settings {
@@ -106,6 +149,8 @@ export interface CreateEntryInput {
   client_id: number
   description: string
   started_at: string
+  /** v1.9 #75: optional project association. */
+  project_id?: number | null
 }
 
 /**
@@ -127,6 +172,8 @@ export interface CreateManualEntryInput {
   billable?: number
   /** Internal-only note, never exported. Optional — defaults to '' */
   private_note?: string
+  /** v1.9 #75: optional project association. */
+  project_id?: number | null
 }
 
 export interface UpdateEntryInput {
@@ -143,6 +190,8 @@ export interface UpdateEntryInput {
   billable?: number
   /** Internal-only note, never exported. Optional — defaults to '' */
   private_note?: string
+  /** v1.9 #75: optional project association. */
+  project_id?: number | null
 }
 
 export interface MonthQuery {


### PR DESCRIPTION
## Summary

Foundation for Issue #75 (Projekte pro Kunde). This PR delivers the DB, shared types, and IPC layer — no renderer changes yet.

## What's in this PR

### Migration 012 (\1.9-projects\)
- New \projects\ table: \id, client_id, name, color, rate_cent, active, created_at\
- \client_id\ FK → \clients(id) ON DELETE CASCADE\
- Composite index \idx_projects_client_active\ on \(client_id, active)\
- UNIQUE partial index \idx_projects_unique_active_name\ on \(client_id, name) WHERE active = 1\
- \ntries.project_id\ column (nullable INTEGER, FK → \projects(id) ON DELETE SET NULL\)
- \idx_entries_project_started\ index on \(project_id, started_at)\

### Types (\src/shared/types.ts\)
- \Project\, \ProjectWithCount\, \CreateProjectInput\, \UpdateProjectInput\
- \project_id\ added to \Entry\, \CreateEntryInput\, \CreateManualEntryInput\, \UpdateEntryInput\

### IPC handlers (\src/main/ipc.ts\)
- \projects:getAll\ — optional \clientId\ filter; LEFT JOIN entry counts excluding soft-deleted
- \projects:create\ — with \alidateProject\ (name, reserved names, negative rate, client existence)
- \projects:update\ — blocks \client_id\ change when active entries exist (FG-2)
- \projects:archive\ — soft-delete via \ctive = 0\
- \projects:delete\ — atomic transaction, blocks when active entries exist

### Bug fixes
- **\insertEntrySegments\ silently NULLed \project_id\** — 11-column INSERT → 12-column
- **\ntries:start\ omitted \project_id\** — now explicitly passed

### Preload (\src/preload/index.ts\ + \index.d.ts\)
- \window.api.projects.*\ exposed for all 5 channels

## Tests
- 8 new \alidateProject\ unit tests
- 6 new projects SQL contract tests
- 6 new migration 012 tests (table/column/index existence, FK cascade, SET NULL, UNIQUE partial index)
- 216 tests passing, 88 skipped (pre-existing bun/better-sqlite3 skip behavior), 0 failures

## Migration Note
Migration 012 builds \idx_entries_project_started\ by scanning all entries. On databases with 50k+ entries this may add 2–5 seconds to the first launch after upgrade. Documented in CHANGELOG.

## Decisions (from autoplan Final Gate)
- **FG-1**: UNIQUE partial index included ✅
- **FG-2**: \client_id\ change with entries → blocked with error ✅  
- **FG-3**: Migration slowness accepted + documented in CHANGELOG ✅

## What's next
- PR 2/4: Renderer — \projectsStore\, \ClientsView\ project management, \EntryEditForm\ project selector
- PR 3/4: TimerView, export filters, PDF/CSV with project scope
- PR 4/4: Polish, onboarding, i18n