### PR TITLE
fix: QuickStart label above pills, constant pill height (#99)

### DIFF
--- a/src/renderer/src/views/TodayView.tsx
+++ b/src/renderer/src/views/TodayView.tsx
@@ -312,8 +312,9 @@ function QuickStartRow({
   const t = useT()
   if (topClients.length === 0) return null
   return (
-    <div className="flex flex-wrap items-center gap-2">
+    <div className="flex flex-col gap-2">
       <span className="text-xs uppercase tracking-wide" style={{ color: 'var(--text3)' }}>{t('today.quickstart.label')}</span>
+      <div className="flex flex-wrap gap-2">
       {topClients.map((c) => (
         <QuickStartPill
           key={c.client_id}
@@ -327,6 +328,7 @@ function QuickStartRow({
           onStart={onStart}
         />
       ))}
+      </div>
     </div>
   )
 }
@@ -644,11 +646,9 @@ function QuickStartPill({
           )}
           <Icons.Play width={11} height={11} style={{ color: 'var(--text3)' }} />
         </div>
-        {lastProject && (
-          <div className="pl-4 text-xs leading-tight" style={{ color: 'var(--text3)', marginTop: 2 }}>
-            {lastProject.name}
-          </div>
-        )}
+        <div className="pl-4 text-xs leading-tight" style={{ color: 'var(--text3)', marginTop: 2, visibility: lastProject ? 'visible' : 'hidden' }}>
+          {lastProject?.name ?? '\u00A0'}
+        </div>
       </button>
     </div>
   )


### PR DESCRIPTION
## Problem
After Quick Start 2.0 (#97), the label `SCHNELLSTART` was rendered inline (left of the pills) via `flex-wrap`. With multiple pills this caused an awkward layout. Also, pills with no last-used project were shorter than pills with a project subtitle, causing height jumps.

## Changes
- `QuickStartRow`: switched container from `flex-wrap` to `flex-col` — label sits above the pill row
- `QuickStartPill`: subtitle div always rendered, `visibility: hidden` + `&nbsp;` placeholder when no project — pills stay the same height regardless of project presence