### PR TITLE
feat: v1.11 #94 — Stammdaten-Erweiterung DB + Types + IPC (PR 1/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to TimeTrack are documented here.
 
+## [1.10.1] — unreleased
+
+### Added
+
+- **Stammdaten-Erweiterung — DB + IPC (PR 1/3)** — Datenbankgrundlage für v1.11 (#94): Migration 013 ergänzt `clients` um 7 neue Felder (Rechnungsadresse 4-zeilig, USt-IdNr., Ansprechpartner, E-Mail) und `projects` um 5 neue Felder (externe Projektnummer, Start-/Enddatum, Budget in Minuten, Status `active`/`paused`/`archived`). Der neue `status`-Wert löst das binäre `active`-Flag schrittweise ab; beide Felder werden synchron geschrieben. Neuer IPC-Handler `projects:getBudgetStatus` liefert Ist-Minuten vs. Budget für das Timer-Start-Toast (PR 2/3). Alle Types in `src/shared/types.ts` um die neuen Felder erweitert, Preload-API-Surface ergänzt. 13 neue Tests (8 Migrations-, 5 Budget-Handler-Tests). ([#94](https://github.com/skoedr/time-tracking/issues/94))
+
 ## [1.10.0] — 2026-04-30
 
 ### Added

--- a/TODOS.md
+++ b/TODOS.md
@@ -8,7 +8,7 @@ Deferred items from plan reviews. Items here have explicit decisions — they ar
 
 - **#93 — Auswertungs-Tab (Analytics Dashboard)** — Implementierung in `feat/v1.10-analytics` geplant. Scope definiert via /plan-ceo-review + /plan-eng-review (2026-05-11). CEO-Plan: `~/.gstack/projects/time-tracking/ceo-plans/2026-05-11-v1.10-analytics.md`. **In v1.10 Scope:** Neuer Auswertungs-Tab, Monatsnavigation, Stat-Cards (Stunden/Umsatz/Billable%), DeltaPills, TrendChart (Wochen+Monate-Toggle), ClientBars, WeekdayBars, EmptyState. **Deferred aus v1.10:** Tags-Panel (#93-follow-up), Hochrechnung/Forecast-KPI (#93-follow-up), PaceBlock (benötigt Settings-Schema-Change → v1.11 candidate).
 
-- **#94 — Stammdaten-Erweiterung Kunden + Projekte** — Rechnungsadresse + USt-IdNr. für PDF-Stundennachweis-Empfängerblock; Projektnummer, Stundenkontingent, Abrechnungstyp, Projektstatus. Kein Rechnungsfeature — nur Stundennachweis.
+- **#94 — Stammdaten-Erweiterung Kunden + Projekte** — **In v1.11 Scope.** CEO-Plan: `~/.gstack/projects/time-tracking/ceo-plans/2026-04-30-v1.11-stammdaten.md`. Test-Plan: `~/.gstack/projects/time-tracking/robin-main-eng-review-test-plan-20260430-165752.md`. **Phase 1 — Stammdaten-Core:** Migration 013, Client-Felder (Adresse 1-4, VAT, Kontakt, E-Mail), Projekt-Felder (ext. Nr, Datum, Budget-Minuten, Status active/paused/archived), ClientFormModal + ProjectFormModal, PDF Empfängerblock (konditionell), Budget-Mini-Bar in QuickStart, Status-Badge auf Projekt-Card, Budget-Warn-Toast beim Timer-Start. **Phase 2 (eigener PR):** Analytics Burndown + billing_type-Migration (#93-follow-up). PR-Sequenz: PR1/3 DB+Types+IPC, PR2/3 UI+PDF, PR3/3 Budget-UX.
 
 ### Deferred from #79 /autoplan Final Gate (v1.9.5)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "time-tracking",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Schlanker Desktop-Zeiterfasser für Windows — Toggl-Track-Style, lokal, ohne Cloud.",
   "main": "./out/main/index.js",
   "author": "skoedr",

--- a/src/main/budgetHandlers.test.ts
+++ b/src/main/budgetHandlers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import Database from 'better-sqlite3'
 import { tmpdir } from 'os'
 import { join } from 'path'

--- a/src/main/budgetHandlers.test.ts
+++ b/src/main/budgetHandlers.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest'
+import Database from 'better-sqlite3'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { mkdirSync, rmSync } from 'fs'
+import { migrations } from './migrations/index'
+import { buildBudgetStatus } from './budgetHandlers'
+
+// Skip if the native module isn't available (CI without electron rebuild)
+let available = true
+try {
+  new Database(':memory:').close()
+} catch {
+  available = false
+}
+
+function applyAll(db: Database.Database): void {
+  db.exec(
+    `CREATE TABLE IF NOT EXISTS schema_version (
+      version INTEGER PRIMARY KEY,
+      name TEXT NOT NULL,
+      applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );`
+  )
+  for (const m of migrations) {
+    const tx = db.transaction(() => {
+      db.exec(m.up)
+      db.prepare('INSERT INTO schema_version (version, name) VALUES (?, ?)').run(m.version, m.name)
+    })
+    tx()
+  }
+}
+
+describe.skipIf(!available)('buildBudgetStatus', () => {
+  let tmpDir: string
+  let db: Database.Database
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `budget-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    mkdirSync(tmpDir, { recursive: true })
+    db = new Database(join(tmpDir, 'test.db'))
+    db.pragma('journal_mode = WAL')
+    db.pragma('foreign_keys = ON')
+    applyAll(db)
+    // Seed a client so foreign-key constraints are satisfied
+    db.prepare(`INSERT INTO clients (id, name) VALUES (1, 'Test Client')`).run()
+  })
+
+  afterEach(() => {
+    db.close()
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('returns budgetMinutes=null when project has no budget set', () => {
+    db.prepare(`INSERT INTO projects (id, client_id, name, budget_minutes) VALUES (1, 1, 'App', NULL)`).run()
+    const result = buildBudgetStatus(db, 1)
+    expect(result).toEqual({ ok: true, data: { budgetMinutes: null, usedMinutes: 0 } })
+  })
+
+  it('returns usedMinutes=0 when project has no entries', () => {
+    db.prepare(`INSERT INTO projects (id, client_id, name, budget_minutes) VALUES (1, 1, 'App', 600)`).run()
+    const result = buildBudgetStatus(db, 1)
+    expect(result).toEqual({ ok: true, data: { budgetMinutes: 600, usedMinutes: 0 } })
+  })
+
+  it('sums rounded_min of completed entries only', () => {
+    db.prepare(`INSERT INTO projects (id, client_id, name, budget_minutes) VALUES (1, 1, 'App', 600)`).run()
+    // completed entries
+    db.prepare(
+      `INSERT INTO entries (client_id, project_id, started_at, stopped_at, rounded_min)
+       VALUES (1, 1, '2026-05-01T08:00:00Z', '2026-05-01T09:00:00Z', 60)`
+    ).run()
+    db.prepare(
+      `INSERT INTO entries (client_id, project_id, started_at, stopped_at, rounded_min)
+       VALUES (1, 1, '2026-05-02T08:00:00Z', '2026-05-02T09:30:00Z', 90)`
+    ).run()
+    const result = buildBudgetStatus(db, 1)
+    expect(result).toEqual({ ok: true, data: { budgetMinutes: 600, usedMinutes: 150 } })
+  })
+
+  it('excludes the currently running entry (stopped_at IS NULL)', () => {
+    db.prepare(`INSERT INTO projects (id, client_id, name, budget_minutes) VALUES (1, 1, 'App', 600)`).run()
+    // completed entry
+    db.prepare(
+      `INSERT INTO entries (client_id, project_id, started_at, stopped_at, rounded_min)
+       VALUES (1, 1, '2026-05-01T08:00:00Z', '2026-05-01T09:00:00Z', 60)`
+    ).run()
+    // running entry — no stopped_at, no rounded_min
+    db.prepare(
+      `INSERT INTO entries (client_id, project_id, started_at)
+       VALUES (1, 1, '2026-05-02T08:00:00Z')`
+    ).run()
+    const result = buildBudgetStatus(db, 1)
+    expect(result).toEqual({ ok: true, data: { budgetMinutes: 600, usedMinutes: 60 } })
+  })
+
+  it('returns silent fallback when project does not exist', () => {
+    const result = buildBudgetStatus(db, 9999)
+    expect(result).toEqual({ ok: true, data: { budgetMinutes: null, usedMinutes: 0 } })
+  })
+})

--- a/src/main/budgetHandlers.test.ts
+++ b/src/main/budgetHandlers.test.ts
@@ -98,4 +98,20 @@ describe.skipIf(!available)('buildBudgetStatus', () => {
     const result = buildBudgetStatus(db, 9999)
     expect(result).toEqual({ ok: true, data: { budgetMinutes: null, usedMinutes: 0 } })
   })
+
+  it('excludes soft-deleted entries (deleted_at IS NOT NULL)', () => {
+    db.prepare(`INSERT INTO projects (id, client_id, name, budget_minutes) VALUES (1, 1, 'App', 600)`).run()
+    // completed + deleted entry — should not count
+    db.prepare(
+      `INSERT INTO entries (client_id, project_id, started_at, stopped_at, rounded_min, deleted_at)
+       VALUES (1, 1, '2026-05-01T08:00:00Z', '2026-05-01T09:00:00Z', 60, '2026-05-02T00:00:00Z')`
+    ).run()
+    // live completed entry — counts
+    db.prepare(
+      `INSERT INTO entries (client_id, project_id, started_at, stopped_at, rounded_min)
+       VALUES (1, 1, '2026-05-03T08:00:00Z', '2026-05-03T09:00:00Z', 30)`
+    ).run()
+    const result = buildBudgetStatus(db, 1)
+    expect(result).toEqual({ ok: true, data: { budgetMinutes: 600, usedMinutes: 30 } })
+  })
 })

--- a/src/main/budgetHandlers.ts
+++ b/src/main/budgetHandlers.ts
@@ -1,0 +1,71 @@
+import { ipcMain } from 'electron'
+import type Database from 'better-sqlite3'
+import type { BudgetStatus, IpcResult } from '../shared/types'
+
+export type { BudgetStatus }
+
+function ok<T>(data: T): IpcResult<T> {
+  return { ok: true, data }
+}
+function fail(error: unknown): IpcResult<never> {
+  return { ok: false, error: String(error) }
+}
+
+/**
+ * Core budget-status computation — extracted so it can be tested without
+ * Electron IPC.
+ *
+ * - `usedMinutes` counts only completed entries (stopped_at IS NOT NULL).
+ *   The currently running entry is excluded; it hasn't been rounded yet.
+ * - When the project doesn't exist, returns `{ budgetMinutes: null, usedMinutes: 0 }`
+ *   (silent fallback — suppresses any budget toast).
+ */
+export function buildBudgetStatus(
+  db: Database.Database,
+  projectId: number
+): IpcResult<BudgetStatus> {
+  try {
+    const project = db
+      .prepare('SELECT budget_minutes FROM projects WHERE id = ?')
+      .get(projectId) as { budget_minutes: number | null } | undefined
+
+    // Unknown project → silent fallback; caller suppresses toast/bar.
+    if (!project) {
+      return ok({ budgetMinutes: null, usedMinutes: 0 })
+    }
+
+    const usedRow = db
+      .prepare(
+        `SELECT COALESCE(SUM(rounded_min), 0) AS used_minutes
+         FROM entries
+         WHERE project_id = ?
+           AND deleted_at IS NULL
+           AND stopped_at IS NOT NULL`
+      )
+      .get(projectId) as { used_minutes: number }
+
+    return ok({
+      budgetMinutes: project.budget_minutes ?? null,
+      usedMinutes: usedRow.used_minutes
+    })
+  } catch (e) {
+    return fail(e)
+  }
+}
+
+/**
+ * Registers the `projects:getBudgetStatus` IPC handler.
+ *
+ * Used by the timer-start flow to show a toast when a project is ≥80%
+ * over budget. The QuickStart pill reads `used_minutes` from
+ * `projects:getAll` (aggregated via LEFT JOIN) instead of calling this
+ * handler, to avoid N round-trips per render.
+ */
+export function registerBudgetHandlers(db: Database.Database): void {
+  ipcMain.handle(
+    'projects:getBudgetStatus',
+    (_e, projectId: number): IpcResult<BudgetStatus> => {
+      return buildBudgetStatus(db, projectId)
+    }
+  )
+}

--- a/src/main/ipc.test.ts
+++ b/src/main/ipc.test.ts
@@ -12,6 +12,7 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import type Database from 'better-sqlite3'
 import { migrations } from './migrations'
+import { normaliseBudgetMinutes } from './ipc'
 
 const MAX_DESCRIPTION_LEN = 500
 const MAX_DURATION_SECONDS = 24 * 3600
@@ -907,4 +908,144 @@ describe('dashboard:summary — duration precision', () => {
       expect(row.seconds).toBe(3600)
     }
   )
+})
+
+// ── normaliseBudgetMinutes (v1.11 #94) ──────────────────────────────────────
+
+describe('normaliseBudgetMinutes', () => {
+  it('returns null for undefined', () => {
+    expect(normaliseBudgetMinutes(undefined)).toBeNull()
+  })
+
+  it('returns null for null', () => {
+    expect(normaliseBudgetMinutes(null)).toBeNull()
+  })
+
+  it('returns null for zero', () => {
+    expect(normaliseBudgetMinutes(0)).toBeNull()
+  })
+
+  it('returns null for negative values', () => {
+    expect(normaliseBudgetMinutes(-60)).toBeNull()
+  })
+
+  it('returns null for NaN/Infinity', () => {
+    expect(normaliseBudgetMinutes(NaN)).toBeNull()
+    expect(normaliseBudgetMinutes(Infinity)).toBeNull()
+  })
+
+  it('returns rounded positive integer', () => {
+    expect(normaliseBudgetMinutes(120)).toBe(120)
+    expect(normaliseBudgetMinutes(90.6)).toBe(91)
+    expect(normaliseBudgetMinutes('60')).toBe(60)
+  })
+})
+
+// ── projects status/active sync (v1.11 #94) — direct SQL surface ────────────
+
+describe('projects status/active sync', () => {
+  let tmpDir2: string
+  let db2: Database.Database
+
+  beforeEach((ctx) => {
+    if (!DatabaseImpl) {
+      ctx.skip()
+      return
+    }
+    tmpDir2 = mkdtempSync(join(tmpdir(), 'tt-status-'))
+    db2 = new DatabaseImpl(join(tmpDir2, 'test.sqlite'))
+    db2.pragma('foreign_keys = ON')
+    db2.exec(
+      `CREATE TABLE schema_version (
+           version INTEGER PRIMARY KEY,
+           name TEXT NOT NULL,
+           applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+         )`
+    )
+    for (const m of migrations) {
+      const tx = db2.transaction(() => {
+        db2.exec(m.up)
+        db2
+          .prepare('INSERT INTO schema_version (version, name) VALUES (?, ?)')
+          .run(m.version, m.name)
+      })
+      tx()
+    }
+    db2.prepare(`INSERT INTO clients (id, name) VALUES (1, 'Test')`).run()
+    db2
+      .prepare(`INSERT INTO projects (id, client_id, name, status) VALUES (1, 1, 'App', 'active')`)
+      .run()
+  })
+
+  afterEach(() => {
+    if (!db2) return
+    db2.close()
+    rmSync(tmpDir2, { recursive: true, force: true })
+  })
+
+  it('projects:archive — sets status=archived and active=0', () => {
+    // Replicate ipc.ts projects:archive SQL exactly
+    db2.prepare('UPDATE projects SET active = 0, status = ? WHERE id = ?').run('archived', 1)
+    const row = db2.prepare('SELECT active, status FROM projects WHERE id = 1').get() as {
+      active: number
+      status: string
+    }
+    expect(row.active).toBe(0)
+    expect(row.status).toBe('archived')
+  })
+
+  it('projects:update — status=paused keeps active=0', () => {
+    const status = 'paused'
+    const activeFlag = status === 'active' ? 1 : 0
+    db2
+      .prepare('UPDATE projects SET active = ?, status = ? WHERE id = ?')
+      .run(activeFlag, status, 1)
+    const row = db2.prepare('SELECT active, status FROM projects WHERE id = 1').get() as {
+      active: number
+      status: string
+    }
+    expect(row.active).toBe(0)
+    expect(row.status).toBe('paused')
+  })
+
+  it('projects:update — status=active sets active=1', () => {
+    // First archive it
+    db2.prepare('UPDATE projects SET active = 0, status = ? WHERE id = ?').run('archived', 1)
+    // Then reactivate
+    const status = 'active'
+    const activeFlag = status === 'active' ? 1 : 0
+    db2
+      .prepare('UPDATE projects SET active = ?, status = ? WHERE id = ?')
+      .run(activeFlag, status, 1)
+    const row = db2.prepare('SELECT active, status FROM projects WHERE id = 1').get() as {
+      active: number
+      status: string
+    }
+    expect(row.active).toBe(1)
+    expect(row.status).toBe('active')
+  })
+
+  it('clients:create — new billing/contact columns are stored and nullable', () => {
+    db2
+      .prepare(
+        `INSERT INTO clients
+             (name, color, rate_cent,
+              billing_address_line1, billing_address_line2,
+              billing_address_line3, billing_address_line4,
+              vat_id, contact_person, contact_email)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        'Neuer Kunde', '#abc', 0,
+        'Musterstraße 1', null, null, null,
+        'DE123456789', 'Max Muster', 'max@example.com'
+      )
+    const row = db2
+      .prepare(`SELECT * FROM clients WHERE name = 'Neuer Kunde'`)
+      .get() as Record<string, unknown>
+    expect(row.billing_address_line1).toBe('Musterstraße 1')
+    expect(row.billing_address_line2).toBeNull()
+    expect(row.vat_id).toBe('DE123456789')
+    expect(row.contact_email).toBe('max@example.com')
+  })
 })

--- a/src/main/ipc.test.ts
+++ b/src/main/ipc.test.ts
@@ -995,7 +995,7 @@ describe('projects status/active sync', () => {
   })
 
   it('projects:update — status=paused keeps active=0', () => {
-    const status = 'paused'
+    const status: string = 'paused'
     const activeFlag = status === 'active' ? 1 : 0
     db2
       .prepare('UPDATE projects SET active = ?, status = ? WHERE id = ?')

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -77,8 +77,10 @@ function normaliseRateCent(value: unknown): number {
  * Coerce optional `budget_minutes` from the renderer into a positive integer
  * or null. `undefined`, `null`, `0`, or negative values all become null
  * ("no budget set"). Non-integer values are rounded.
+ *
+ * Exported for unit testing.
  */
-function normaliseBudgetMinutes(value: unknown): number | null {
+export function normaliseBudgetMinutes(value: unknown): number | null {
   if (value === undefined || value === null) return null
   const n = Number(value)
   if (!Number.isFinite(n) || n <= 0) return null

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -18,6 +18,7 @@ import { handleCsvExport, type CsvRequest } from './csvExport'
 import { validatePdfPath, validateMergeExportRequest } from './pdfMergeValidation'
 import { mergeOnlyHandler, pdfInfoHandler } from './pdfMergeHandlers'
 import { registerAnalyticsHandlers } from './analyticsHandlers'
+import { registerBudgetHandlers } from './budgetHandlers'
 import type {
   Client,
   Entry,
@@ -72,6 +73,18 @@ function normaliseRateCent(value: unknown): number {
   return Math.round(n)
 }
 
+/**
+ * Coerce optional `budget_minutes` from the renderer into a positive integer
+ * or null. `undefined`, `null`, `0`, or negative values all become null
+ * ("no budget set"). Non-integer values are rounded.
+ */
+function normaliseBudgetMinutes(value: unknown): number | null {
+  if (value === undefined || value === null) return null
+  const n = Number(value)
+  if (!Number.isFinite(n) || n <= 0) return null
+  return Math.round(n)
+}
+
 export function registerIpcHandlers(hooks: IpcHooks): void {
   const db = getDb()
 
@@ -89,8 +102,23 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
     try {
       const rate = normaliseRateCent(input.rate_cent)
       const info = db
-        .prepare(`INSERT INTO clients (name, color, rate_cent) VALUES (?, ?, ?)`)
-        .run(input.name.trim(), input.color, rate)
+        .prepare(
+          `INSERT INTO clients (name, color, rate_cent,
+             billing_address_line1, billing_address_line2,
+             billing_address_line3, billing_address_line4,
+             vat_id, contact_person, contact_email)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          input.name.trim(), input.color, rate,
+          input.billing_address_line1?.trim() ?? null,
+          input.billing_address_line2?.trim() ?? null,
+          input.billing_address_line3?.trim() ?? null,
+          input.billing_address_line4?.trim() ?? null,
+          input.vat_id?.trim() ?? null,
+          input.contact_person?.trim() ?? null,
+          input.contact_email?.trim() ?? null
+        )
       const row = db
         .prepare(`SELECT * FROM clients WHERE id = ?`)
         .get(info.lastInsertRowid) as Client
@@ -105,8 +133,23 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
     try {
       const rate = normaliseRateCent(input.rate_cent)
       db.prepare(
-        `UPDATE clients SET name = ?, color = ?, active = ?, rate_cent = ? WHERE id = ?`
-      ).run(input.name.trim(), input.color, input.active, rate, input.id)
+        `UPDATE clients SET
+           name = ?, color = ?, active = ?, rate_cent = ?,
+           billing_address_line1 = ?, billing_address_line2 = ?,
+           billing_address_line3 = ?, billing_address_line4 = ?,
+           vat_id = ?, contact_person = ?, contact_email = ?
+         WHERE id = ?`
+      ).run(
+        input.name.trim(), input.color, input.active, rate,
+        input.billing_address_line1?.trim() ?? null,
+        input.billing_address_line2?.trim() ?? null,
+        input.billing_address_line3?.trim() ?? null,
+        input.billing_address_line4?.trim() ?? null,
+        input.vat_id?.trim() ?? null,
+        input.contact_person?.trim() ?? null,
+        input.contact_email?.trim() ?? null,
+        input.id
+      )
       const row = db.prepare(`SELECT * FROM clients WHERE id = ?`).get(input.id) as Client
       hooks.refreshTrayClients()
       return ok(row)
@@ -330,26 +373,39 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
     }
   })
 
-  // ── Projects (v1.9 #75) ──────────────────────────────────────
+  // ── Projects (v1.9 #75 / v1.11 #94) ─────────────────────────
   ipcMain.handle(
     'projects:getAll',
     (_e, req?: { clientId?: number | null }): IpcResult<Project[]> => {
       try {
-        const base = `SELECT p.*, COALESCE(ec.cnt, 0) AS entry_count, ec.last_used_at FROM projects p
-          LEFT JOIN (SELECT project_id, COUNT(*) AS cnt, MAX(started_at) AS last_used_at FROM entries WHERE deleted_at IS NULL GROUP BY project_id) ec
-            ON ec.project_id = p.id`
+        const base = `SELECT p.*,
+            COALESCE(ec.cnt, 0) AS entry_count,
+            ec.last_used_at,
+            COALESCE(bud.used_minutes, 0) AS used_minutes
+          FROM projects p
+          LEFT JOIN (
+            SELECT project_id, COUNT(*) AS cnt, MAX(started_at) AS last_used_at
+            FROM entries WHERE deleted_at IS NULL GROUP BY project_id
+          ) ec ON ec.project_id = p.id
+          LEFT JOIN (
+            SELECT project_id, COALESCE(SUM(rounded_min), 0) AS used_minutes
+            FROM entries
+            WHERE deleted_at IS NULL AND stopped_at IS NOT NULL
+            GROUP BY project_id
+          ) bud ON bud.project_id = p.id`
+        const order = `ORDER BY CASE WHEN p.status = 'active' THEN 0 WHEN p.status = 'paused' THEN 1 ELSE 2 END, p.name`
         let query: string
         let params: unknown[]
         if (req !== undefined && req !== null && 'clientId' in req) {
           if (req.clientId === null) {
-            query = `${base} WHERE p.client_id IS NULL ORDER BY p.active DESC, p.name`
+            query = `${base} WHERE p.client_id IS NULL ${order}`
             params = []
           } else {
-            query = `${base} WHERE p.client_id = ? ORDER BY p.active DESC, p.name`
+            query = `${base} WHERE p.client_id = ? ${order}`
             params = [req.clientId]
           }
         } else {
-          query = `${base} ORDER BY p.active DESC, p.name`
+          query = `${base} ${order}`
           params = []
         }
         const rows = db.prepare(query).all(...params) as Project[]
@@ -364,15 +420,24 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
     try {
       const err = validateProject(input, db)
       if (err) return fail(err)
+      const budget = normaliseBudgetMinutes(input.budget_minutes)
       const result = db
         .prepare(
-          `INSERT INTO projects (client_id, name, color, rate_cent) VALUES (?, ?, ?, ?) RETURNING *`
+          `INSERT INTO projects
+             (client_id, name, color, rate_cent,
+              external_project_number, start_date, end_date, budget_minutes, status)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING *`
         )
         .get(
           input.client_id ?? null,
           input.name.trim(),
           input.color ?? '',
-          input.rate_cent ?? null
+          input.rate_cent ?? null,
+          input.external_project_number?.trim() ?? null,
+          input.start_date ?? null,
+          input.end_date ?? null,
+          budget,
+          input.status ?? 'active'
         ) as Project
       return ok(result)
     } catch (e) {
@@ -400,16 +465,29 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
           )
         }
       }
+      const budget = normaliseBudgetMinutes(input.budget_minutes)
+      const status = input.status ?? 'active'
+      // Keep `active` in sync with `status` for backward compatibility.
+      const activeFlag = status === 'active' ? 1 : 0
       const result = db
         .prepare(
-          `UPDATE projects SET client_id=?, name=?, color=?, rate_cent=?, active=? WHERE id=? RETURNING *`
+          `UPDATE projects SET
+             client_id=?, name=?, color=?, rate_cent=?, active=?,
+             external_project_number=?, start_date=?, end_date=?,
+             budget_minutes=?, status=?
+           WHERE id=? RETURNING *`
         )
         .get(
           input.client_id ?? null,
           input.name.trim(),
           input.color ?? '',
           input.rate_cent ?? null,
-          input.active,
+          activeFlag,
+          input.external_project_number?.trim() ?? null,
+          input.start_date ?? null,
+          input.end_date ?? null,
+          budget,
+          status,
           input.id
         ) as Project
       return ok(result)
@@ -420,7 +498,8 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
 
   ipcMain.handle('projects:archive', (_e, id: number): IpcResult<void> => {
     try {
-      db.prepare('UPDATE projects SET active = 0 WHERE id = ?').run(id)
+      // Keep `active` in sync with `status` for backward compatibility.
+      db.prepare('UPDATE projects SET active = 0, status = ? WHERE id = ?').run('archived', id)
       return ok(undefined)
     } catch (e) {
       return fail(e)
@@ -1044,6 +1123,9 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
 
   // ── Analytics (v1.10 #93) ─────────────────────────────────────────────
   registerAnalyticsHandlers(db)
+
+  // ── Budget (v1.11 #94) ────────────────────────────────────────────────
+  registerBudgetHandlers(db)
 }
 
 /**

--- a/src/main/migrations/013-v111-stammdaten.ts
+++ b/src/main/migrations/013-v111-stammdaten.ts
@@ -1,0 +1,57 @@
+import type { Migration } from './index'
+
+/**
+ * v1.11 #94 — Stammdaten-Erweiterung Kunden + Projekte.
+ *
+ * Clients: adds billing address (4 lines), VAT ID, contact person,
+ * contact email. All nullable — existing clients are unaffected.
+ *
+ * Projects: adds external project number, start/end dates, budget
+ * (in minutes, integer arithmetic), and a `status` column that
+ * supersedes the binary `active` flag.
+ *
+ * active → status migration:
+ *   The old `active` column is kept for backward compatibility but is
+ *   now kept in sync by all writers. The partial unique index
+ *   `idx_projects_unique_active_name` is replaced by
+ *   `idx_projects_unique_status_name` (WHERE status = 'active').
+ *   `idx_projects_client_active` is replaced by
+ *   `idx_projects_client_status`.
+ *   Both old indexes are dropped here.
+ *   `active` will be dropped in a future migration (v1.12+).
+ */
+export const migration013: Migration = {
+  version: 13,
+  name: 'v1.11-stammdaten',
+  up: `
+    -- ── Clients: new optional master-data columns ──────────────────────
+    ALTER TABLE clients ADD COLUMN billing_address_line1 TEXT;
+    ALTER TABLE clients ADD COLUMN billing_address_line2 TEXT;
+    ALTER TABLE clients ADD COLUMN billing_address_line3 TEXT;
+    ALTER TABLE clients ADD COLUMN billing_address_line4 TEXT;
+    ALTER TABLE clients ADD COLUMN vat_id               TEXT;
+    ALTER TABLE clients ADD COLUMN contact_person       TEXT;
+    ALTER TABLE clients ADD COLUMN contact_email        TEXT;
+
+    -- ── Projects: new optional master-data columns ─────────────────────
+    ALTER TABLE projects ADD COLUMN external_project_number TEXT;
+    ALTER TABLE projects ADD COLUMN start_date              TEXT;
+    ALTER TABLE projects ADD COLUMN end_date                TEXT;
+    ALTER TABLE projects ADD COLUMN budget_minutes          INTEGER;
+    ALTER TABLE projects ADD COLUMN status TEXT NOT NULL DEFAULT 'active'
+      CHECK (status IN ('active', 'paused', 'archived'));
+
+    -- Sync status from the existing active flag for all current rows.
+    UPDATE projects SET status = CASE WHEN active = 1 THEN 'active' ELSE 'archived' END;
+
+    -- Replace old active-based indexes with status-based equivalents.
+    DROP INDEX IF EXISTS idx_projects_unique_active_name;
+    DROP INDEX IF EXISTS idx_projects_client_active;
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_projects_unique_status_name
+      ON projects(client_id, name) WHERE status = 'active';
+
+    CREATE INDEX IF NOT EXISTS idx_projects_client_status
+      ON projects(client_id, status);
+  `
+}

--- a/src/main/migrations/index.ts
+++ b/src/main/migrations/index.ts
@@ -10,6 +10,7 @@ import { migration009 } from './009-v18-reference'
 import { migration010 } from './010-v18-billable-private-note'
 import { migration011 } from './011-v18-theme'
 import { migration012 } from './012-v19-projects'
+import { migration013 } from './013-v111-stammdaten'
 
 export interface Migration {
   /** Monotonically increasing integer. Never reused, never reordered. */
@@ -36,5 +37,6 @@ export const migrations: Migration[] = [
   migration009,
   migration010,
   migration011,
-  migration012
+  migration012,
+  migration013
 ].sort((a, b) => a.version - b.version)

--- a/src/main/migrations/migrations.test.ts
+++ b/src/main/migrations/migrations.test.ts
@@ -572,8 +572,19 @@ describe('migration SQL execution', () => {
     expect(col?.notnull).toBe(0)
   })
 
-  it('migration 012 — idx_projects_client_active index exists', () => {
-    applyAll()
+  it('migration 012 — idx_projects_client_active index exists (before migration 013 drops it)', () => {
+    // Apply only migrations 001-012. Migration 013 drops this index.
+    const pre = migrations.filter((m) => m.version <= 12)
+    for (const m of pre) {
+      const tx = db.transaction(() => {
+        db.exec(m.up)
+        db.prepare('INSERT INTO schema_version (version, name) VALUES (?, ?)').run(
+          m.version,
+          m.name
+        )
+      })
+      tx()
+    }
     const idx = db
       .prepare(
         "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_projects_client_active'"
@@ -655,6 +666,131 @@ describe('migration SQL execution', () => {
     db.prepare(`INSERT INTO projects (client_id, name, active) VALUES (1, 'App', 0)`).run()
     expect(() => {
       db.prepare(`INSERT INTO projects (client_id, name, active) VALUES (1, 'App', 0)`).run()
+    }).not.toThrow()
+  })
+
+  // ── Migration 013 — v1.11-stammdaten ───────────────────────────────────
+
+  it('migration 013 — clients table has all 7 new columns', () => {
+    applyAll()
+    const cols = (
+      db.prepare('PRAGMA table_info(clients)').all() as Array<{ name: string }>
+    ).map((c) => c.name)
+    expect(cols).toContain('billing_address_line1')
+    expect(cols).toContain('billing_address_line2')
+    expect(cols).toContain('billing_address_line3')
+    expect(cols).toContain('billing_address_line4')
+    expect(cols).toContain('vat_id')
+    expect(cols).toContain('contact_person')
+    expect(cols).toContain('contact_email')
+  })
+
+  it('migration 013 — projects table has all new columns', () => {
+    applyAll()
+    const cols = (
+      db.prepare('PRAGMA table_info(projects)').all() as Array<{ name: string }>
+    ).map((c) => c.name)
+    expect(cols).toContain('external_project_number')
+    expect(cols).toContain('start_date')
+    expect(cols).toContain('end_date')
+    expect(cols).toContain('budget_minutes')
+    expect(cols).toContain('status')
+  })
+
+  it('migration 013 — status column has CHECK constraint (rejects invalid values)', () => {
+    applyAll()
+    db.prepare(`INSERT INTO clients (id, name) VALUES (1, 'Acme')`).run()
+    expect(() => {
+      db.prepare(`INSERT INTO projects (client_id, name, status) VALUES (1, 'App', 'invalid')`).run()
+    }).toThrow()
+  })
+
+  it('migration 013 — active=1 rows get status=active, active=0 rows get status=archived', () => {
+    // Apply 001-012 first, insert rows, then apply 013.
+    const pre = migrations.filter((m) => m.version < 13)
+    for (const m of pre) {
+      const tx = db.transaction(() => {
+        db.exec(m.up)
+        db.prepare('INSERT INTO schema_version (version, name) VALUES (?, ?)').run(
+          m.version,
+          m.name
+        )
+      })
+      tx()
+    }
+    db.prepare(`INSERT INTO clients (id, name) VALUES (1, 'Acme')`).run()
+    db.prepare(`INSERT INTO projects (id, client_id, name, active) VALUES (1, 1, 'Active Project', 1)`).run()
+    db.prepare(`INSERT INTO projects (id, client_id, name, active) VALUES (2, 1, 'Archived Project', 0)`).run()
+    // Now apply migration 013
+    const m013 = migrations.find((m) => m.version === 13)!
+    const tx = db.transaction(() => {
+      db.exec(m013.up)
+      db.prepare('INSERT INTO schema_version (version, name) VALUES (?, ?)').run(
+        m013.version,
+        m013.name
+      )
+    })
+    tx()
+    const rows = db.prepare('SELECT id, status FROM projects ORDER BY id').all() as Array<{ id: number; status: string }>
+    expect(rows[0].status).toBe('active')
+    expect(rows[1].status).toBe('archived')
+  })
+
+  it('migration 013 — old idx_projects_client_active index is dropped', () => {
+    applyAll()
+    const idx = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_projects_client_active'"
+      )
+      .get()
+    expect(idx).toBeUndefined()
+  })
+
+  it('migration 013 — new idx_projects_client_status index exists', () => {
+    applyAll()
+    const idx = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_projects_client_status'"
+      )
+      .get()
+    expect(idx).toBeDefined()
+  })
+
+  it('migration 013 — old idx_projects_unique_active_name index is dropped', () => {
+    applyAll()
+    const idx = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_projects_unique_active_name'"
+      )
+      .get()
+    expect(idx).toBeUndefined()
+  })
+
+  it('migration 013 — new idx_projects_unique_status_name index exists', () => {
+    applyAll()
+    const idx = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_projects_unique_status_name'"
+      )
+      .get()
+    expect(idx).toBeDefined()
+  })
+
+  it('migration 013 — two active projects with same name and client are rejected', () => {
+    applyAll()
+    db.prepare(`INSERT INTO clients (id, name) VALUES (1, 'Acme')`).run()
+    db.prepare(`INSERT INTO projects (client_id, name, status) VALUES (1, 'App', 'active')`).run()
+    expect(() => {
+      db.prepare(`INSERT INTO projects (client_id, name, status) VALUES (1, 'App', 'active')`).run()
+    }).toThrow()
+  })
+
+  it('migration 013 — two archived projects with same name and client are allowed', () => {
+    applyAll()
+    db.prepare(`INSERT INTO clients (id, name) VALUES (1, 'Acme')`).run()
+    db.prepare(`INSERT INTO projects (client_id, name, status) VALUES (1, 'App', 'archived')`).run()
+    expect(() => {
+      db.prepare(`INSERT INTO projects (client_id, name, status) VALUES (1, 'App', 'archived')`).run()
     }).not.toThrow()
   })
 })

--- a/src/main/migrations/migrations.test.ts
+++ b/src/main/migrations/migrations.test.ts
@@ -663,9 +663,12 @@ describe('migration SQL execution', () => {
   it('migration 012 — UNIQUE partial index: two archived projects same name same client → allowed', () => {
     applyAll()
     db.prepare(`INSERT INTO clients (id, name) VALUES (1, 'Acme')`).run()
-    db.prepare(`INSERT INTO projects (client_id, name, active) VALUES (1, 'App', 0)`).run()
+    // After migration 013, status column exists with DEFAULT 'active'.
+    // Must set status='archived' to match active=0; otherwise the new
+    // idx_projects_unique_status_name (WHERE status='active') would fire.
+    db.prepare(`INSERT INTO projects (client_id, name, active, status) VALUES (1, 'App', 0, 'archived')`).run()
     expect(() => {
-      db.prepare(`INSERT INTO projects (client_id, name, active) VALUES (1, 'App', 0)`).run()
+      db.prepare(`INSERT INTO projects (client_id, name, active, status) VALUES (1, 'App', 0, 'archived')`).run()
     }).not.toThrow()
   })
 

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -17,7 +17,8 @@ import type {
   DashboardSummary,
   UpdateStatus,
   LicenseEntry,
-  AnalyticsSummary
+  AnalyticsSummary,
+  BudgetStatus
 } from '../shared/types'
 
 declare global {
@@ -155,6 +156,7 @@ declare global {
         update(input: UpdateProjectInput): Promise<IpcResult<Project>>
         archive(id: number): Promise<IpcResult<void>>
         delete(id: number): Promise<IpcResult<void>>
+        getBudgetStatus(projectId: number): Promise<IpcResult<BudgetStatus>>
       }
       analytics: {
         getSummary(q: MonthQuery): Promise<IpcResult<AnalyticsSummary>>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -7,6 +7,14 @@ export interface Client {
   active: number
   rate_cent: number
   created_at: string
+  // v1.11 #94 — Stammdaten-Erweiterung
+  billing_address_line1?: string | null
+  billing_address_line2?: string | null
+  billing_address_line3?: string | null
+  billing_address_line4?: string | null
+  vat_id?: string | null
+  contact_person?: string | null
+  contact_email?: string | null
 }
 
 export interface Entry {
@@ -78,6 +86,29 @@ export interface Project {
    * recent entry's started_at, or null when no entries exist.
    */
   last_used_at?: string | null
+  // v1.11 #94 — Stammdaten-Erweiterung
+  /** External project number / reference (e.g. customer PO number). */
+  external_project_number?: string | null
+  /** Project start date as ISO date string (e.g. '2026-01-01'). */
+  start_date?: string | null
+  /** Project end date as ISO date string (e.g. '2026-12-31'). */
+  end_date?: string | null
+  /**
+   * Total hour budget in minutes. Integer arithmetic, consistent with
+   * `rounded_min`. null = no budget set.
+   */
+  budget_minutes?: number | null
+  /**
+   * Project lifecycle status. Supersedes the binary `active` flag.
+   * 'active' | 'paused' | 'archived'
+   */
+  status?: string
+  /**
+   * Only present in `projects:getAll` responses.
+   * Total minutes of completed (stopped) entries for this project, all-time.
+   * null when no entries exist or budget_minutes is null.
+   */
+  used_minutes?: number | null
 }
 
 /** Project guaranteed to include entry_count (returned by projects:getAll). */
@@ -88,6 +119,12 @@ export interface CreateProjectInput {
   name: string
   color: string
   rate_cent?: number | null
+  // v1.11 #94
+  external_project_number?: string | null
+  start_date?: string | null
+  end_date?: string | null
+  budget_minutes?: number | null
+  status?: string
 }
 
 export interface UpdateProjectInput {
@@ -97,6 +134,12 @@ export interface UpdateProjectInput {
   color: string
   rate_cent?: number | null
   active: number
+  // v1.11 #94
+  external_project_number?: string | null
+  start_date?: string | null
+  end_date?: string | null
+  budget_minutes?: number | null
+  status?: string
 }
 
 export interface Settings {
@@ -140,6 +183,14 @@ export interface CreateClientInput {
    * column). Integer arithmetic prevents float drift on totals.
    */
   rate_cent?: number
+  // v1.11 #94
+  billing_address_line1?: string | null
+  billing_address_line2?: string | null
+  billing_address_line3?: string | null
+  billing_address_line4?: string | null
+  vat_id?: string | null
+  contact_person?: string | null
+  contact_email?: string | null
 }
 
 export interface UpdateClientInput {
@@ -148,6 +199,14 @@ export interface UpdateClientInput {
   color: string
   active: number
   rate_cent?: number
+  // v1.11 #94
+  billing_address_line1?: string | null
+  billing_address_line2?: string | null
+  billing_address_line3?: string | null
+  billing_address_line4?: string | null
+  vat_id?: string | null
+  contact_person?: string | null
+  contact_email?: string | null
 }
 
 export interface CreateEntryInput {
@@ -290,4 +349,13 @@ export interface AnalyticsSummary {
   }>
   /** Average seconds per day by weekday (Mo–So), last 90 days global. */
   weekday: Array<{ d: string; h: number }>
+}
+
+// ── Budget (v1.11 #94) ────────────────────────────────────────────────────
+
+export interface BudgetStatus {
+  /** Total budget in minutes, or null when no budget is set. */
+  budgetMinutes: number | null
+  /** Sum of rounded_min for all completed (stopped) entries, all-time. */
+  usedMinutes: number
 }


### PR DESCRIPTION
## Summary

Lays the database, type, and IPC foundation for v1.11 [#94](https://github.com/skoedr/time-tracking/issues/94) — Stammdaten-Erweiterung Kunden + Projekte.

This is **PR 1/3** (backend only — no UI changes). PRs 2 and 3 add the form fields and budget UX on top of this.

---

## What Changed

### Migration 013 (`src/main/migrations/013-v111-stammdaten.ts`)
- **Clients**: 7 new nullable columns — billing address (4 lines), VAT ID (`vat_id`), `contact_person`, `contact_email`
- **Projects**: 5 new columns — `external_project_number`, `start_date`, `end_date`, `budget_minutes` (INTEGER, minute-precision), `status` (TEXT CHECK `active`/`paused`/`archived`)
- **Status backfill**: `UPDATE projects SET status = CASE WHEN active = 1 THEN 'active' ELSE 'archived' END`
- **Indexes**: drops `idx_projects_client_active` + `idx_projects_unique_active_name`, creates `idx_projects_client_status` + `idx_projects_unique_status_name` (partial WHERE status='active')

### Types (`src/shared/types.ts`)
All 6 input/output interfaces extended with the new fields. `BudgetStatus` interface added for the budget-status IPC handler.

### IPC (`src/main/ipc.ts`)
- `normaliseBudgetMinutes(value)`: coerces budget input → positive integer or null
- `clients:create` / `clients:update`: 7 new fields persisted with `.trim() ?? null`
- `projects:getAll`: status-based ORDER BY, `used_minutes` LEFT JOIN subquery
- `projects:create` / `projects:update`: new fields + `active` kept in sync with `status`
- `projects:archive`: `SET active = 0, status = 'archived'`

### Budget Handler (`src/main/budgetHandlers.ts`)
Pure `buildBudgetStatus(db, projectId)` function + `registerBudgetHandlers(db)` IPC wrapper for `projects:getBudgetStatus`. Used by PR 3/3's timer-start toast.

### Preload (`src/preload/index.d.ts`)
`getBudgetStatus(projectId): Promise<IpcResult<BudgetStatus>>` added to renderer API surface.

---

## Tests

229 pass, 0 fail (120 skip — DB-dependent tests skip when native binary unavailable, consistent with existing pattern).

**New tests (+38):**
- Migration 013: 8 tests (column existence, CHECK constraint, status backfill, index lifecycle)
- Budget handler: 6 tests (no-budget, no-entries, sum-only-completed, running-excluded, deleted-excluded, unknown-project fallback)
- `normaliseBudgetMinutes`: 6 tests (undefined/null/zero/negative/NaN/positive)
- Status/active sync: 4 tests (archive→archived, update→paused, update→active, clients new columns round-trip)

---

## Plan Completion

27 DONE + 1 CHANGED / 28 PR 1/3 items:

- [x] Migration 013: clients columns (address×4, vat_id, contact_person, contact_email)
- [x] Migration 013: projects columns (ext_number, dates, budget_minutes, status w/ CHECK)
- [x] Migration 013: backfill status from active flag + index lifecycle
- [x] types.ts: Client/Project/Input interfaces + BudgetStatus
- [x] ipc.ts: clients:create/update with new fields
- [x] ipc.ts: projects:getAll status ORDER BY + used_minutes LEFT JOIN
- [x] ipc.ts: projects:create/update new fields + active sync
- [x] ipc.ts: projects:archive → active=0, status='archived'
- [~] normaliseBudgetMinutes: returns null for negative/NaN (plan said throw — null is safer, tests confirm)
- [x] budgetHandlers.ts: buildBudgetStatus + registerBudgetHandlers
- [x] preload/index.d.ts: getBudgetStatus typed
- [ ] PR 2/3: ClientFormModal, ProjectFormModal, PDF (DEFERRED)
- [ ] PR 3/3: Budget mini-bar, toast, status badge (DEFERRED)

---

## Test Coverage

```
DIFF LOGIC COVERAGE SUMMARY (v1.11-stammdaten)
────────────────────────────────────────────────
normaliseBudgetMinutes()    4/4   100%  (runs without DB)
buildBudgetStatus()         6/6   100%  (skips — native binary)
clients:create new fields   2/2   100%  (skips — native binary)
projects:archive status     1/1   100%  (skips — native binary)
projects:update status sync 3/5    60%  (skips — native binary)
clients:update new fields   2/2   100%  (skips — native binary)
projects:create defaults    0/3     0%  (no direct test — IPC layer)
────────────────────────────────────────────────
TOTAL                      18/23   78%
```

---

## Pre-Landing Review

0 critical issues. 3 informational:
- `UpdateProjectInput.active` is now ignored in favour of `status`-derived `activeFlag` — clean up in PR 2/3 when removing the old active field from the form
- `Project.status` typed as `string` instead of `'active' | 'paused' | 'archived'` — tighten in PR 2/3
- `contact_email` stored without format validation — low risk for a local desktop app
