### PR TITLE
feat: v1.11 #94 - Budget Mini-Bar, Status-Badge, Budget-Warn-Toast (PR 3/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,35 @@
 
 All notable changes to TimeTrack are documented here.
 
-## [1.10.1] — unreleased
+## [1.11.0] — 2026-04-30
 
 ### Added
 
-- **Stammdaten-Erweiterung — DB + IPC (PR 1/3)** — Datenbankgrundlage für v1.11 (#94): Migration 013 ergänzt `clients` um 7 neue Felder (Rechnungsadresse 4-zeilig, USt-IdNr., Ansprechpartner, E-Mail) und `projects` um 5 neue Felder (externe Projektnummer, Start-/Enddatum, Budget in Minuten, Status `active`/`paused`/`archived`). Der neue `status`-Wert löst das binäre `active`-Flag schrittweise ab; beide Felder werden synchron geschrieben. Neuer IPC-Handler `projects:getBudgetStatus` liefert Ist-Minuten vs. Budget für das Timer-Start-Toast (PR 2/3). Alle Types in `src/shared/types.ts` um die neuen Felder erweitert, Preload-API-Surface ergänzt. 13 neue Tests (8 Migrations-, 5 Budget-Handler-Tests). ([#94](https://github.com/skoedr/time-tracking/issues/94))
+- **Stammdaten-Erweiterung Kunden + Projekte** — Vollständige Verwaltung erweiterter Kunden- und Projektdaten (#94). Drei aufeinander aufbauende PRs:
+
+  **Datenbank + IPC (PR 1/3):** Migration 013 ergänzt `clients` um 7 neue Felder (Rechnungsadresse 4-zeilig, USt-IdNr., Ansprechpartner, E-Mail) und `projects` um 5 neue Felder (externe Projektnummer, Start-/Enddatum, Budget in Minuten, Status `active`/`paused`/`archived`). Der `status`-Wert löst das binäre `active`-Flag schrittweise ab. Neuer IPC-Handler `projects:getBudgetStatus`. 13 neue Tests.
+
+  **UI-Formulare + PDF-Empfängerblock (PR 2/3):** `ClientFormModal` mit Rechnungsadresse, USt-IdNr., Ansprechpartner und Kontakt-E-Mail. `ProjectFormModal` mit Status-Toggle (Aktiv / Pausiert / Archiviert), externer Projektnummer, Datumsbereich und Budget in Dezimalstunden. PDF-Empfängerblock rendert Adresszeilen, USt-IdNr. (`USt-IdNr.`-Prefix) und Ansprechpartner (`z. Hd.`-Prefix) konditionell.
+
+  **Budget-UX (PR 3/3):** Horizontaler Budget-Mini-Balken auf jeder Projektkarte (Farb-Codierung: Akzent → Amber ab 80 % → Rot bei Überschreitung, numerisches Label `32.0 h / 40.0 h`). Amber-Status-Badge „Pausiert“ neben pausierten Projektnamen. Budget-Warn-Banner im Timer-Start-Modal wenn das gewählte Projekt ≥ 80 % verbraucht hat. ([#94](https://github.com/skoedr/time-tracking/issues/94))
+
+- **Externe Projektnummer im UI** — Optionale externe Projektnummer (z. B. Bestellnummer) wird in eckigen Klammern hinter dem Projektnamen angezeigt — in der laufenden Timer-Pill, in der Heute-Tabelle, im QuickStart-Modal und auf der Projektkarte. Kann in den Einstellungen (Allgemein › „Projektnummer anzeigen“) ein- und ausgeblendet werden. ([#94](https://github.com/skoedr/time-tracking/issues/94))
+
+- **Ansprechpartner + Enddatum auf Kunden-/Projektkarte** — Ist ein Ansprechpartner hinterlegt, erscheint er als zweite Zeile unter dem Kundennamen in der Kundenliste. Ist ein Enddatum gesetzt, wird es als „bis TT.MM.JJJJ“ neben dem Projektsatz angezeigt. ([#94](https://github.com/skoedr/time-tracking/issues/94))
+
+### Fixed
+
+- **Auswertung: Rundungsparitat mit PDF** — Die Auswertung berechnete bisher Rohdauern in Sekunden. Jetzt wird dieselbe Ceil-Rundungslogik wie im PDF angewendet (`pdf_round_minutes`-Setting): Stunden und Umsätze in der Auswertung stimmen nun exakt mit dem generierten PDF überein. ([#94](https://github.com/skoedr/time-tracking/issues/94))
+
+- **Timer-Modal: Vorausgewähltes Projekt beibehalten** — Beim Öffnen des Timer-Start-Modals mit einer Vorauswahl (letztes Projekt) wurde die Auswahl durch den asynchronen Projekt-Ladevorgang zurückgesetzt, bevor sie gerendert werden konnte. Die gültige Vorauswahl bleibt jetzt erhalten; die Budget-Warnung erscheint sofort wenn nötig. ([#94](https://github.com/skoedr/time-tracking/issues/94))
+
+### Changed
+
+- **Heute-Tabelle: 2-zeilige Kunden-/Projektanzeige** — Die Kunden-/Projektspalte zeigt jetzt Kundenname (fett) und Projektname (klein, gedimmt) in zwei Zeilen statt einzeilig. Die Spalte wurde auf `1.5fr` verbreitert. ([#94](https://github.com/skoedr/time-tracking/issues/94))
+
+- **Einstellungen: Timer-Rundungs-Settings entfernt** — Die toten Einstellungen „Intervall“ und „Methode“ im Timer-Abschnitt wurden aus UI und Types entfernt (die DB-Rows bleiben bestehen und werden bei der nächsten Migration bereinigt). Maßgebliche Rundung für PDF und Auswertung ist ausschließlich „Stunden runden auf“ im PDF-Abschnitt. ([#94](https://github.com/skoedr/time-tracking/issues/94))
+
+- **Hint-Text für PDF-Rundung aktualisiert** — Der Hinweistext unter „Stunden runden auf“ macht jetzt deutlich, dass die Einstellung für PDF *und* Auswertung gilt. ([#94](https://github.com/skoedr/time-tracking/issues/94))
 
 ## [1.10.0] — 2026-04-30
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "time-tracking",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "description": "Schlanker Desktop-Zeiterfasser für Windows — Toggl-Track-Style, lokal, ohne Cloud.",
   "main": "./out/main/index.js",
   "author": "skoedr",

--- a/src/renderer/src/components/StartTimerModal.tsx
+++ b/src/renderer/src/components/StartTimerModal.tsx
@@ -171,6 +171,34 @@ export function StartTimerModal({ open, onClose }: StartTimerModalProps): React.
           </div>
         )}
 
+        {/* Budget warning — shows when selected project is ≥80% consumed */}
+        {selectedProject?.budget_minutes != null && selectedProject.budget_minutes > 0 && (() => {
+          const usedMin = selectedProject.used_minutes ?? 0
+          const budgetMin = selectedProject.budget_minutes
+          const pct = Math.round((usedMin / budgetMin) * 100)
+          if (pct < 80) return null
+          const usedH = (usedMin / 60).toFixed(1)
+          const totalH = (budgetMin / 60).toFixed(1)
+          const over = usedMin > budgetMin
+          return (
+            <div
+              className="flex items-start gap-2 rounded-[10px] px-3 py-2.5 text-xs"
+              style={{
+                background: over ? 'rgba(239,68,68,0.12)' : 'rgba(245,158,11,0.12)',
+                color: over ? 'var(--danger)' : '#f59e0b'
+              }}
+            >
+              <span className="shrink-0 mt-0.5">⚠</span>
+              <span>
+                {over
+                  ? t('timer.budget.overBudget', { used: usedH, total: totalH })
+                  : t('timer.budget.warning', { percent: String(pct), used: usedH, total: totalH })
+                }
+              </span>
+            </div>
+          )
+        })()}
+
         {/* Description */}
         <div className="flex flex-col gap-1.5">
           <label className="text-xs font-semibold uppercase tracking-wide" style={{ color: 'var(--text3)' }}>

--- a/src/renderer/src/components/StartTimerModal.tsx
+++ b/src/renderer/src/components/StartTimerModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useTimer } from '../hooks/useTimer'
 import { useT } from '../contexts/I18nContext'
 import { useUiPrefsStore } from '../store/uiPrefsStore'
+import { useTimerStore } from '../store/timerStore'
 import * as Icons from './Icons'
 import type { Project } from '../../../shared/types'
 
@@ -38,7 +39,10 @@ export function StartTimerModal({ open, onClose }: StartTimerModalProps): React.
       if (res.ok) {
         const active = res.data.filter((p) => p.active === 1)
         setProjects(active)
-        if (active.length === 1) {
+        const currentId = useTimerStore.getState().selectedProjectId
+        if (currentId !== null && active.some((p) => p.id === currentId)) {
+          // keep valid pre-selection — don't reset
+        } else if (active.length === 1) {
           setSelectedProjectId(active[0].id)
         } else {
           setSelectedProjectId(null)

--- a/src/renderer/src/views/ClientsView.tsx
+++ b/src/renderer/src/views/ClientsView.tsx
@@ -672,20 +672,56 @@ function ProjectItem({
     return `${countStr} · ${rel}`
   })()
 
+  const hasBudget = (p.budget_minutes ?? 0) > 0
+  const usedMin = p.used_minutes ?? 0
+  const budgetMin = p.budget_minutes ?? 0
+  const budgetPct = hasBudget ? Math.min(100, Math.round((usedMin / budgetMin) * 100)) : 0
+  const overBudget = hasBudget && usedMin > budgetMin
+  const budgetWarn = hasBudget && budgetPct >= 80
+
   return (
     <li className="flex items-center gap-2.5 rounded-lg px-2 py-1.5 group"
       style={{ background: 'var(--input-bg)' }}
     >
       <span
-        className="w-3 h-3 rounded-full shrink-0"
+        className="w-3 h-3 rounded-full shrink-0 self-start mt-1"
         style={{ backgroundColor: dotColor }}
       />
       <span className="flex-1 min-w-0">
-        <span className="block text-sm font-medium" style={{ color: 'var(--text)' }}>
+        <span className="flex items-center gap-1.5 flex-wrap">
+          <span className="text-sm font-medium" style={{ color: 'var(--text)' }}>
             {p.name}{showProjectNumber && p.external_project_number ? <span style={{ color: 'var(--text3)' }}> [{p.external_project_number}]</span> : null}
           </span>
+          {p.status === 'paused' && (
+            <span
+              className="text-xs px-1.5 py-0.5 rounded-full leading-none shrink-0"
+              style={{ background: 'rgba(245,158,11,0.15)', color: '#f59e0b' }}
+            >
+              {t('projects.form.statusPaused')}
+            </span>
+          )}
+        </span>
         {statsLabel && (
           <span className="block text-xs mt-0.5" style={{ color: 'var(--text3)' }}>{statsLabel}</span>
+        )}
+        {hasBudget && (
+          <span className="flex items-center gap-1.5 mt-1">
+            <span className="flex-1 h-1 rounded-full overflow-hidden" style={{ background: 'var(--card-border)' }}>
+              <span
+                className="h-full rounded-full block transition-all"
+                style={{
+                  width: `${budgetPct}%`,
+                  background: overBudget ? 'var(--danger)' : budgetWarn ? '#f59e0b' : 'var(--accent)'
+                }}
+              />
+            </span>
+            <span
+              className="text-xs shrink-0 tabular-nums"
+              style={{ color: overBudget ? 'var(--danger)' : budgetWarn ? '#f59e0b' : 'var(--text3)' }}
+            >
+              {(usedMin / 60).toFixed(1)}h / {(budgetMin / 60).toFixed(1)}h
+            </span>
+          </span>
         )}
       </span>
       <span className="flex flex-col items-end gap-0.5">

--- a/src/shared/locales/de.ts
+++ b/src/shared/locales/de.ts
@@ -528,6 +528,9 @@ export const de = {
   'timer.project.label': 'Projekt',
   'timer.project.placeholder': '— Kein Projekt —',
   'timer.project.effectiveRate': 'Effektiver Satz: {rate} €/h (Projekt überschreibt Kunden)',
+  // v1.11 #94 — Budget-Warnung
+  'timer.budget.warning': 'Achtung: {percent} % des Budgets bereits verbucht ({used} h / {total} h).',
+  'timer.budget.overBudget': 'Budget überschritten: {used} h von {total} h verbucht.',
 
   // ── EntryEditForm — Projekt (v1.9 #75 PR 3) ───────────────────────────────
   'entry.project': 'Projekt',

--- a/src/shared/locales/en.ts
+++ b/src/shared/locales/en.ts
@@ -520,6 +520,9 @@ export const en: Record<TranslationKey, string> = {
   'timer.project.label': 'Project',
   'timer.project.placeholder': '— No project —',
   'timer.project.effectiveRate': 'Effective rate: {rate} €/h (project overrides client)',
+  // v1.11 #94 — Budget warning
+  'timer.budget.warning': 'Warning: {percent} % of the budget already booked ({used} h / {total} h).',
+  'timer.budget.overBudget': 'Budget exceeded: {used} h of {total} h booked.',
 
   // ── EntryEditForm — Project (v1.9 #75 PR 3) ──────────────────────────────
   'entry.project': 'Project',


### PR DESCRIPTION
Budget UX for v1.11 Stammdaten-Erweiterung. Builds on PR 1/3 (#101) and PR 2/3 (#102).

## What's new

### Budget Mini-Bar on ProjectCard
- Progress bar: used_minutes / budget_minutes
- Color: accent → amber at 80pct → red when over budget
- Label: 32.0h / 40.0h
- Only shown when budget_minutes is set

### Status-Badge on ProjectCard
- Amber pill badge next to project name when status === paused
- No badge for active projects

### Budget-Warn in StartTimerModal
- Inline banner between project picker and description
- Amber warning at 80pct, red when over budget
- Shows percent + used/total hours

### i18n
- 2 new keys: timer.budget.warning + timer.budget.overBudget (DE + EN)

## Tests
- 229 passed, 0 failed, pnpm typecheck clean

## Related
- PR 1/3: #101 (merged)
- PR 2/3: #102 (merged)