### PR TITLE
fix: v1.11.1 Hotfix — QuickNote auto-close + non-billable revenue (#109, #104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to TimeTrack are documented here.
 
+## [1.11.1] — 2026-05-04
+
+### Fixed
+
+- **QuickNote-Modal: Auto-Close beim Tippen unterbrochen** — Der 30-Sekunden-Countdown lief bisher ungehindert durch, auch wenn der Nutzer bereits tippt. Das Modal schloss sich und verwarf den eingegebenen Text. Der Countdown wird jetzt bei jeder Texteingabe zurückgesetzt — das Modal schließt sich erst, wenn der Nutzer 30 Sekunden lang inaktiv ist oder explizit speichert/abbricht. ([#109](https://github.com/skoedr/time-tracking/issues/109))
+
+- **Auswertung: Nicht-abrechenbare Stunden im Umsatz** — In der Monatsübersicht und der Kunden-Aufschlüsselung wurde der Umsatz für alle Einträge berechnet, unabhängig vom `billable`-Flag. Nicht-abrechenbare Stunden zählen weiterhin zur Gesamtdauer, fließen aber jetzt korrekt nicht mehr in den Umsatz ein — konsistent mit PDF- und CSV-Export. 2 neue Regressionstests ergänzt. ([#104](https://github.com/skoedr/time-tracking/issues/104))
+
 ## [1.11.0] — 2026-04-30
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "time-tracking",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Schlanker Desktop-Zeiterfasser für Windows — Toggl-Track-Style, lokal, ohne Cloud.",
   "main": "./out/main/index.js",
   "author": "skoedr",

--- a/src/main/analyticsHandlers.test.ts
+++ b/src/main/analyticsHandlers.test.ts
@@ -322,4 +322,60 @@ describe('buildAnalyticsSummary', () => {
     expect(res.data.weekday).toHaveLength(7)
     expect(res.data.weekday.map((d) => d.d)).toEqual(['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'])
   })
+
+  // ── 13. Non-billable hours excluded from revenue (#104) ─────────────────
+
+  it('excludes non-billable entries from revenue calculation', () => {
+    // 2 hours billable at 100 €/h → 200 € = 20000 cents
+    addEntry(db, {
+      client_id: 1,
+      started_at: '2025-10-01T08:00:00.000Z',
+      stopped_at: '2025-10-01T10:00:00.000Z',
+      billable: 1,
+    })
+    // 3 hours non-billable — must NOT contribute to revenue
+    addEntry(db, {
+      client_id: 1,
+      started_at: '2025-10-01T11:00:00.000Z',
+      stopped_at: '2025-10-01T14:00:00.000Z',
+      billable: 0,
+    })
+
+    const res = buildAnalyticsSummary(db, { year: 2025, month: 10 })
+    expect(res.ok).toBe(true)
+    if (!res.ok) return
+
+    // total hours include both billable + non-billable
+    expect(res.data.month.hours).toBe(18000) // 5 h in seconds
+    // revenue must only count the 2 billable hours: 2 * 85 €/h = 170 € = 17000 cents
+    expect(res.data.month.revenue).toBe(17000)
+  })
+
+  // ── 14. Per-client revenue excludes non-billable entries (#104) ──────────
+
+  it('excludes non-billable entries from per-client revenue breakdown', () => {
+    // 1 hour billable for Acme (85 €/h) → 8500 cents
+    addEntry(db, {
+      client_id: 1,
+      started_at: '2025-11-01T08:00:00.000Z',
+      stopped_at: '2025-11-01T09:00:00.000Z',
+      billable: 1,
+    })
+    // 2 hours non-billable for Acme — must NOT add to rev
+    addEntry(db, {
+      client_id: 1,
+      started_at: '2025-11-01T10:00:00.000Z',
+      stopped_at: '2025-11-01T12:00:00.000Z',
+      billable: 0,
+    })
+
+    const res = buildAnalyticsSummary(db, { year: 2025, month: 11 })
+    expect(res.ok).toBe(true)
+    if (!res.ok) return
+
+    const acme = res.data.byClient.find((c) => c.client_id === 1)
+    expect(acme).toBeDefined()
+    // only 1 billable hour: 85 €/h → 8500 cents
+    expect(acme!.rev).toBe(8500)
+  })
 })

--- a/src/main/analyticsHandlers.ts
+++ b/src/main/analyticsHandlers.ts
@@ -78,9 +78,11 @@ export function buildAnalyticsSummary(
             ELSE 0 END
           ), 0) AS billable_sec,
           COALESCE(SUM(
-            COALESCE(p.rate_cent, c.rate_cent, 0)
-            * ${ENTRY_SEC}
-            / 3600.0
+            CASE WHEN e.billable = 1 THEN
+              COALESCE(p.rate_cent, c.rate_cent, 0)
+              * ${ENTRY_SEC}
+              / 3600.0
+            ELSE 0 END
           ), 0) AS revenue_cent
         FROM entries e
         JOIN clients c ON c.id = e.client_id
@@ -133,9 +135,11 @@ export function buildAnalyticsSummary(
             ${ENTRY_SEC}
           ), 0) AS h,
           COALESCE(SUM(
-            COALESCE(p.rate_cent, c.rate_cent, 0)
-            * ${ENTRY_SEC}
-            / 3600.0
+            CASE WHEN e.billable = 1 THEN
+              COALESCE(p.rate_cent, c.rate_cent, 0)
+              * ${ENTRY_SEC}
+              / 3600.0
+            ELSE 0 END
           ), 0) AS rev
         FROM entries e
         JOIN clients c ON c.id = e.client_id

--- a/src/renderer/src/components/QuickNoteModal.tsx
+++ b/src/renderer/src/components/QuickNoteModal.tsx
@@ -88,7 +88,11 @@ export function QuickNoteModal({ entry, onDone }: Props) {
           ref={inputRef}
           type="text"
           value={text}
-          onChange={(e) => setText(e.target.value)}
+          onChange={(e) => {
+            setText(e.target.value)
+            // Reset deadline so the modal doesn't close while the user is typing
+            deadlineRef.current = Date.now() + TIMEOUT_S * 1000
+          }}
           onKeyDown={handleKeyDown}
           placeholder={t('quicknote.placeholder')}
           className="mb-4 w-full rounded-lg px-3 py-2.5 text-sm border outline-none


### PR DESCRIPTION
## Summary

Hotfix release v1.11.1 — zwei Bugs die aktiv Nutzerdaten und Zahlen verfälschen.

## Fixes

### #109 — QuickNote Modal schließt beim Tippen automatisch
**Root cause:** \deadlineRef.current\ wurde einmalig beim Modal-Öffnen gesetzt und nie zurückgesetzt, egal ob der Nutzer tippt oder nicht.  
**Fix:** \deadlineRef.current\ wird in \onChange\ zurückgesetzt. Der Countdown startet neu bei jeder Eingabe.  
**File:** \src/renderer/src/components/QuickNoteModal.tsx\

### #104 — Nicht-abrechenbare Stunden in der Umsatzberechnung
**Root cause:** \evenue_cent\/\ev\ in beiden SQL-Queries (Monats-Summary + Per-Client) multiplizierte Rate × Dauer für **alle** Einträge ohne Prüfung des \illable\-Flags.  
**Fix:** \CASE WHEN e.billable = 1\ Guard in beiden Queries — identisches Muster wie \illable_sec\ und CSV/PDF-Export.  
**File:** \src/main/analyticsHandlers.ts\  
**Tests:** +2 Regressionstests in \nalyticsHandlers.test.ts\

## Test Results

\\\
Test Files  20 passed | 1 skipped (21)
     Tests  229 passed | 122 skipped (351)
\\\

## Checklist

- [x] Beide Fixes atomar committed
- [x] 2 neue Regressionstests für #104
- [x] 229/229 Tests grün
- [x] Version auf 1.11.1 gebumpt
- [x] CHANGELOG aktualisiert

Closes #109, #104