### PR TITLE
feat(#105): project-level contact_person field

### DIFF
--- a/src/main/ipc.test.ts
+++ b/src/main/ipc.test.ts
@@ -848,6 +848,26 @@ describe('projects — SQL contract tests', () => {
     }
     expect(row.project_id).toBe(pid)
   })
+
+  // v1.12 #105 — projects.contact_person persists correctly
+  it('projects:update — persists contact_person', () => {
+    const pid = createProject(1, 'App')
+    db.prepare(
+      `UPDATE projects SET contact_person = 'Max Mustermann' WHERE id = ?`
+    ).run(pid)
+    const row = db.prepare('SELECT contact_person FROM projects WHERE id = ?').get(pid) as {
+      contact_person: string | null
+    }
+    expect(row.contact_person).toBe('Max Mustermann')
+  })
+
+  it('projects:update — contact_person defaults to NULL', () => {
+    const pid = createProject(1, 'App')
+    const row = db.prepare('SELECT contact_person FROM projects WHERE id = ?').get(pid) as {
+      contact_person: string | null
+    }
+    expect(row.contact_person).toBeNull()
+  })
 })
 //
 // Root cause of the bug: julianday() arithmetic in SQLite uses IEEE-754

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -425,8 +425,9 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
         .prepare(
           `INSERT INTO projects
              (client_id, name, color, rate_cent,
-              external_project_number, start_date, end_date, budget_minutes, status)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING *`
+              external_project_number, start_date, end_date, budget_minutes, status,
+              contact_person)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING *`
         )
         .get(
           input.client_id ?? null,
@@ -437,7 +438,8 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
           input.start_date ?? null,
           input.end_date ?? null,
           budget,
-          input.status ?? 'active'
+          input.status ?? 'active',
+          input.contact_person?.trim() || null
         ) as Project
       return ok(result)
     } catch (e) {
@@ -474,7 +476,7 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
           `UPDATE projects SET
              client_id=?, name=?, color=?, rate_cent=?, active=?,
              external_project_number=?, start_date=?, end_date=?,
-             budget_minutes=?, status=?
+             budget_minutes=?, status=?, contact_person=?
            WHERE id=? RETURNING *`
         )
         .get(
@@ -488,6 +490,7 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
           input.end_date ?? null,
           budget,
           status,
+          input.contact_person?.trim() || null,
           input.id
         ) as Project
       return ok(result)

--- a/src/main/migrations/015-v12-project-contact-person.ts
+++ b/src/main/migrations/015-v12-project-contact-person.ts
@@ -1,0 +1,18 @@
+import type { Migration } from './index'
+
+/**
+ * v1.12 #105 — Projektspezifischer Ansprechpartner.
+ *
+ * Adds `contact_person TEXT DEFAULT NULL` to the `projects` table.
+ * When set, this value takes precedence over `clients.contact_person`
+ * in the PDF recipient block (`effective_contact = project.contact_person ?? client.contact_person`).
+ *
+ * Nullable — existing projects are unaffected (NULL = fall back to client AP).
+ */
+export const migration015: Migration = {
+  version: 15,
+  name: 'v1.12-project-contact-person',
+  up: `
+    ALTER TABLE projects ADD COLUMN contact_person TEXT DEFAULT NULL;
+  `
+}

--- a/src/main/migrations/index.ts
+++ b/src/main/migrations/index.ts
@@ -12,6 +12,7 @@ import { migration011 } from './011-v18-theme'
 import { migration012 } from './012-v19-projects'
 import { migration013 } from './013-v111-stammdaten'
 import { migration014 } from './014-v12-housekeeping'
+import { migration015 } from './015-v12-project-contact-person'
 
 export interface Migration {
   /** Monotonically increasing integer. Never reused, never reordered. */
@@ -40,5 +41,6 @@ export const migrations: Migration[] = [
   migration011,
   migration012,
   migration013,
-  migration014
+  migration014,
+  migration015
 ].sort((a, b) => a.version - b.version)

--- a/src/main/pdf.test.ts
+++ b/src/main/pdf.test.ts
@@ -235,6 +235,44 @@ describe('buildPdfPayload', () => {
     expect(p.sender.taxId).toBe('DE12345')
     expect(p.accentColor).toBe('#ff0000')
   })
+
+  // v1.12 #105 — project contact person overrides client contact person
+  it('uses project.contact_person when set (overrides client)', () => {
+    db.prepare(
+      `INSERT INTO projects (id, client_id, name, color, status, contact_person)
+       VALUES (10, 1, 'Alpha', '#6366f1', 'active', 'Projekt-AP')`
+    ).run()
+    db.prepare(
+      `UPDATE clients SET contact_person = 'Kunden-AP' WHERE id = 1`
+    ).run()
+    const p = buildPdfPayload(
+      db,
+      { clientId: 1, fromIso: '2026-04-01', toIso: '2026-04-30', projectId: 10 },
+      ''
+    )
+    expect(p.effectiveContactPerson).toBe('Projekt-AP')
+  })
+
+  it('falls back to client.contact_person when project has none', () => {
+    db.prepare(
+      `INSERT INTO projects (id, client_id, name, color, status) VALUES (11, 1, 'Beta', '#6366f1', 'active')`
+    ).run()
+    db.prepare(
+      `UPDATE clients SET contact_person = 'Kunden-AP' WHERE id = 1`
+    ).run()
+    const p = buildPdfPayload(
+      db,
+      { clientId: 1, fromIso: '2026-04-01', toIso: '2026-04-30', projectId: 11 },
+      ''
+    )
+    expect(p.effectiveContactPerson).toBe('Kunden-AP')
+  })
+
+  it('uses client.contact_person when no project filter is set', () => {
+    db.prepare(`UPDATE clients SET contact_person = 'Kunden-AP' WHERE id = 1`).run()
+    const p = buildPdfPayload(db, { clientId: 1, fromIso: '2026-04-01', toIso: '2026-04-30' }, '')
+    expect(p.effectiveContactPerson).toBe('Kunden-AP')
+  })
 })
 
 describe('buildPdfHtml', () => {
@@ -380,5 +418,21 @@ describe('buildPdfHtml', () => {
 
     const htmlAbsent = buildPdfHtml(makePayload())
     expect(htmlAbsent).not.toContain('class="entry-ref"')
+  })
+
+  // v1.12 #105 — effectiveContactPerson in recipient block
+  it('renders z.Hd. line when effectiveContactPerson is set', () => {
+    const html = buildPdfHtml(makePayload({ effectiveContactPerson: 'Max Mustermann' }))
+    expect(html).toContain('z.Hd. Max Mustermann')
+  })
+
+  it('omits z.Hd. line when effectiveContactPerson is absent', () => {
+    const html = buildPdfHtml(makePayload())
+    expect(html).not.toContain('z.Hd.')
+  })
+
+  it('omits z.Hd. line when effectiveContactPerson is null', () => {
+    const html = buildPdfHtml(makePayload({ effectiveContactPerson: null }))
+    expect(html).not.toContain('z.Hd.')
   })
 })

--- a/src/main/pdf.ts
+++ b/src/main/pdf.ts
@@ -103,6 +103,12 @@ export interface PdfPayload {
    * is filtered to a single project. Undefined = all projects (no label shown).
    */
   projectName?: string
+  /**
+   * v1.12 #105: effective contact person for the recipient block.
+   * Priority: project.contact_person ?? client.contact_person.
+   * Undefined / null = no "z.Hd." line rendered.
+   */
+  effectiveContactPerson?: string | null
 }
 
 const DATE_FMT = new Intl.DateTimeFormat('de-DE', {
@@ -283,13 +289,22 @@ export function buildPdfPayload(
   }
 
   // v1.9 #75: load project name when filtered to a specific project
+  // v1.12 #105: also load project.contact_person for the recipient fallback
   let projectName: string | undefined
+  let projectContactPerson: string | null | undefined
   if (req.projectId != null) {
     const proj = db
-      .prepare(`SELECT name FROM projects WHERE id = ?`)
-      .get(req.projectId) as { name: string } | undefined
+      .prepare(`SELECT name, contact_person FROM projects WHERE id = ?`)
+      .get(req.projectId) as { name: string; contact_person: string | null } | undefined
     projectName = proj?.name
+    projectContactPerson = proj?.contact_person ?? null
   }
+
+  // v1.12 #105: project contact person overrides client contact person
+  const effectiveContactPerson =
+    req.projectId != null
+      ? (projectContactPerson ?? client.contact_person)
+      : client.contact_person
 
   return {
     client,
@@ -309,7 +324,8 @@ export function buildPdfPayload(
     includeSignatures: req.includeSignatures === true,
     generatedAtIso,
     groups,
-    projectName
+    projectName,
+    effectiveContactPerson
   }
 }
 
@@ -591,7 +607,7 @@ export function buildPdfHtml(p: PdfPayload): string {
           .map((l) => `<div>${esc(l as string)}</div>`)
           .join('\n        ')}
         ${p.client.vat_id ? `<div style="margin-top:2px;font-size:9pt;color:#475569;">USt-IdNr. ${esc(p.client.vat_id)}</div>` : ''}
-        ${p.client.contact_person ? `<div style="margin-top:2px;font-size:9pt;color:#475569;">z.Hd. ${esc(p.client.contact_person)}</div>` : ''}
+        ${p.effectiveContactPerson ? `<div style="margin-top:2px;font-size:9pt;color:#475569;">z.Hd. ${esc(p.effectiveContactPerson)}</div>` : ''}
         ${p.projectName ? `<div class="project-label">Projekt: ${esc(p.projectName)}</div>` : ''}
       </div>
       <div class="range">

--- a/src/renderer/src/views/ClientsView.tsx
+++ b/src/renderer/src/views/ClientsView.tsx
@@ -218,6 +218,7 @@ export default function ClientsView() {
     end_date: string | null
     budget_minutes: number | null
     status: 'active' | 'paused' | 'archived'
+    contact_person: string | null
   }) {
     if (!projectFormClientId && projectFormClientId !== 0) return
     if (editingProject) {
@@ -1111,6 +1112,7 @@ function ProjectFormModal({
     end_date: string | null
     budget_minutes: number | null
     status: 'active' | 'paused' | 'archived'
+    contact_person: string | null
   }) => Promise<void>
   onClose: () => void
 }) {
@@ -1139,6 +1141,8 @@ function ProjectFormModal({
     const hours = project.budget_minutes / 60
     return hours % 1 === 0 ? String(hours) : hours.toFixed(2)
   })
+  // v1.12 #105
+  const [contactPerson, setContactPerson] = useState(project?.contact_person ?? '')
 
   function nullIfEmpty(v: string): string | null {
     return v.trim() === '' ? null : v.trim()
@@ -1183,6 +1187,7 @@ function ProjectFormModal({
       end_date: nullIfEmpty(endDate),
       budget_minutes,
       status,
+      contact_person: nullIfEmpty(contactPerson),
     })
     setIsSaving(false)
   }
@@ -1336,6 +1341,22 @@ function ProjectFormModal({
             value={externalNumber}
             onChange={(e) => setExternalNumber(e.target.value)}
             placeholder={t('projects.form.externalNumberPlaceholder')}
+            className="rounded-lg px-3 py-2.5 border backdrop-blur-xl focus:outline-none
+              focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+            style={{ background: 'var(--input-bg)', borderColor: 'var(--card-border)', color: 'var(--text)' }}
+          />
+        </div>
+
+        {/* Contact person */}
+        <div className="flex flex-col gap-1.5">
+          <label className="text-xs font-medium uppercase tracking-wide" style={{ color: 'var(--text2)' }}>
+            {t('projects.form.contactPersonLabel')}
+          </label>
+          <input
+            type="text"
+            value={contactPerson}
+            onChange={(e) => setContactPerson(e.target.value)}
+            placeholder={t('projects.form.contactPersonPlaceholder')}
             className="rounded-lg px-3 py-2.5 border backdrop-blur-xl focus:outline-none
               focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
             style={{ background: 'var(--input-bg)', borderColor: 'var(--card-border)', color: 'var(--text)' }}

--- a/src/shared/locales/de.ts
+++ b/src/shared/locales/de.ts
@@ -291,6 +291,8 @@ export const de = {
   'projects.form.statusActive': 'Aktiv',
   'projects.form.statusPaused': 'Pausiert',
   'projects.form.statusArchived': 'Archiviert',
+  'projects.form.contactPersonLabel': 'Ansprechpartner',
+  'projects.form.contactPersonPlaceholder': 'Max Mustermann (überschreibt Kunden-AP)',
   // PDF
   'pdf.recipient.vatId': 'USt-IdNr.',
   'pdf.recipient.attn': 'z.Hd.',

--- a/src/shared/locales/en.ts
+++ b/src/shared/locales/en.ts
@@ -290,6 +290,8 @@ export const en: Record<TranslationKey, string> = {
   'projects.form.statusActive': 'Active',
   'projects.form.statusPaused': 'Paused',
   'projects.form.statusArchived': 'Archived',
+  'projects.form.contactPersonLabel': 'Contact person',
+  'projects.form.contactPersonPlaceholder': 'Jane Doe (overrides client contact)',
   // PDF
   'pdf.recipient.vatId': 'VAT ID',
   'pdf.recipient.attn': 'Attn.',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -108,6 +108,13 @@ export interface Project {
    * null when no entries exist or budget_minutes is null.
    */
   used_minutes?: number | null
+  // v1.12 #105 — Project-level contact person
+  /**
+   * Project-specific contact person. When set, takes precedence over
+   * `clients.contact_person` in the PDF recipient block.
+   * null = fall back to the client's contact_person.
+   */
+  contact_person?: string | null
 }
 
 /** Project guaranteed to include entry_count (returned by projects:getAll). */
@@ -124,6 +131,8 @@ export interface CreateProjectInput {
   end_date?: string | null
   budget_minutes?: number | null
   status?: 'active' | 'paused' | 'archived'
+  // v1.12 #105
+  contact_person?: string | null
 }
 
 export interface UpdateProjectInput {
@@ -139,6 +148,8 @@ export interface UpdateProjectInput {
   end_date?: string | null
   budget_minutes?: number | null
   status?: 'active' | 'paused' | 'archived'
+  // v1.12 #105
+  contact_person?: string | null
 }
 
 export interface Settings {


### PR DESCRIPTION
## Summary

Implements issue #105: projects can now override the client's contact person for the PDF recipient block.

## Changes

- **Migration 015**: \ALTER TABLE projects ADD COLUMN contact_person TEXT DEFAULT NULL\
- **\shared/types.ts\**: add \contact_person?: string | null\ to \Project\, \CreateProjectInput\, \UpdateProjectInput\
- **\ipc.ts\**: persist \contact_person\ in \projects:create\ and \projects:update\
- **\pdf.ts\**: \ffectiveContactPerson = project.contact_person ?? client.contact_person\ — project-level AP overrides client AP; falls back when project has none
- **\ClientsView.tsx\ / \ProjectFormModal\**: new *Ansprechpartner* input field after External Number
- **Locales**: \projects.form.contactPersonLabel\ / \projects.form.contactPersonPlaceholder\ (de + en)
- **\pdf.test.ts\**: 6 new tests (3 × payload fallback, 3 × HTML rendering)
- **\ipc.test.ts\**: 2 new tests (NULL default, UPDATE persists value)

## Test results

244 passed, 129 skipped — all green. \pnpm typecheck\ clean.

Closes #105