### PR TITLE
feat(#105): show contact_person on project card

### DIFF
--- a/src/renderer/src/views/ClientsView.tsx
+++ b/src/renderer/src/views/ClientsView.tsx
@@ -702,6 +702,9 @@ function ProjectItem({
             </span>
           )}
         </span>
+        {p.contact_person && (
+          <span className="block text-xs mt-0.5" style={{ color: 'var(--text3)' }}>{p.contact_person}</span>
+        )}
         {statsLabel && (
           <span className="block text-xs mt-0.5" style={{ color: 'var(--text3)' }}>{statsLabel}</span>
         )}


### PR DESCRIPTION
Small follow-up to #112.

Displays \project.contact_person\ below the project name in \ProjectItem\, consistent with how the client card shows \client.contact_person\. Only rendered when the field is non-null.

No new tests needed — pure display change, no logic.