### PR TITLE
feat(#106): rounding in UI views

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -12,6 +12,7 @@ import { UpdateBanner } from './components/UpdateBanner'
 import { OnboardingWizard } from './components/OnboardingWizard'
 import { useTimer } from './hooks/useTimer'
 import { useT } from './contexts/I18nContext'
+import { useSettings } from './contexts/SettingsContext'
 import { useProjectsStore } from './store/projectsStore'
 import { useUiPrefsStore } from './store/uiPrefsStore'
 
@@ -19,6 +20,7 @@ type View = 'today' | 'calendar' | 'clients' | 'analytics' | 'settings'
 
 function App(): React.JSX.Element {
   const t = useT()
+  const { settings } = useSettings()
   const [view, setView] = useState<View>('today')
   const [showOnboarding, setShowOnboarding] = useState(false)
   const [showTimerModal, setShowTimerModal] = useState(false)
@@ -40,15 +42,11 @@ function App(): React.JSX.Element {
     })
   }, [runningEntry?.project_id, projectsVersion])
 
-  // Check onboarding flag on mount — show wizard only for fresh installs.
+  // Check onboarding flag — show wizard only for fresh installs.
   useEffect(() => {
-    void window.api.settings.getAll().then((res) => {
-      if (res.ok && res.data.onboarding_completed === '0') {
-        setShowOnboarding(true)
-      }
-    })
+    if (settings?.onboarding_completed === '0') setShowOnboarding(true)
     void useUiPrefsStore.getState().load()
-  }, [])
+  }, [settings?.onboarding_completed])
 
   async function finishOnboarding(): Promise<void> {
     setShowOnboarding(false)

--- a/src/renderer/src/contexts/I18nContext.tsx
+++ b/src/renderer/src/contexts/I18nContext.tsx
@@ -4,6 +4,7 @@ import { translate } from '../../../shared/i18n'
 import type { TranslationKey } from '../../../shared/locales/de'
 import { de } from '../../../shared/locales/de'
 import { en } from '../../../shared/locales/en'
+import { useSettings } from './SettingsContext'
 
 const localeMap: Record<Locale, Record<string, string>> = { de, en }
 
@@ -28,17 +29,13 @@ const I18nContext = createContext<I18nCtx | null>(null)
  * survives app restarts.
  */
 export function I18nProvider({ children }: { children: React.ReactNode }): React.JSX.Element {
+  const { settings } = useSettings()
   const [locale, setLocaleState] = useState<Locale>('de')
 
-  // Load persisted locale once on mount.
+  // Sync locale once settings are loaded.
   useEffect(() => {
-    void window.api.settings.getAll().then((res) => {
-      if (res.ok) {
-        const lang = res.data.language
-        if (lang === 'en') setLocaleState('en')
-      }
-    })
-  }, [])
+    if (settings?.language === 'en') setLocaleState('en')
+  }, [settings?.language])
 
   const setLocale = useCallback(async (l: Locale) => {
     setLocaleState(l)

--- a/src/renderer/src/contexts/RoundingContext.tsx
+++ b/src/renderer/src/contexts/RoundingContext.tsx
@@ -1,0 +1,49 @@
+import { createContext, useContext, useState, useEffect } from 'react'
+import { useSettings } from './SettingsContext'
+
+interface RoundingCtx {
+  /** Rounding step in minutes; 0 = no rounding (pass-through). */
+  roundMinutes: number
+  /** Persist a new rounding step and update local state. */
+  setRoundMinutes: (n: number) => Promise<void>
+}
+
+const RoundingContext = createContext<RoundingCtx>({
+  roundMinutes: 0,
+  setRoundMinutes: async () => {}
+})
+
+/**
+ * Reads `pdf_round_minutes` from SettingsContext (no own IPC call).
+ * Exposes `roundMinutes` and `setRoundMinutes` to the component tree.
+ *
+ * `setRoundMinutes` updates local state immediately and persists via
+ * `window.api.settings.set()`, so the calendar reflects rounding changes
+ * without a reload. v1.12 #106
+ */
+export function RoundingProvider({ children }: { children: React.ReactNode }): React.JSX.Element {
+  const { settings, setSetting } = useSettings()
+  const [roundMinutes, setRoundMinutesState] = useState(0)
+
+  // Sync from SettingsContext once loaded (and whenever it changes).
+  useEffect(() => {
+    const v = parseInt(settings?.pdf_round_minutes ?? '0', 10)
+    setRoundMinutesState(Number.isFinite(v) && v > 0 ? v : 0)
+  }, [settings?.pdf_round_minutes])
+
+  const setRoundMinutes = async (n: number): Promise<void> => {
+    setRoundMinutesState(n)
+    await setSetting('pdf_round_minutes', String(n) as never)
+  }
+
+  return (
+    <RoundingContext.Provider value={{ roundMinutes, setRoundMinutes }}>
+      {children}
+    </RoundingContext.Provider>
+  )
+}
+
+/** Returns `{ roundMinutes, setRoundMinutes }`. Must be inside RoundingProvider. */
+export function useRounding(): RoundingCtx {
+  return useContext(RoundingContext)
+}

--- a/src/renderer/src/contexts/SettingsContext.tsx
+++ b/src/renderer/src/contexts/SettingsContext.tsx
@@ -1,0 +1,48 @@
+import { createContext, useContext, useState, useEffect, useCallback } from 'react'
+import type { Settings } from '../../../shared/types'
+
+interface SettingsCtx {
+  /** All settings, or null while the initial load is in progress. */
+  settings: Settings | null
+  /** Update a single setting both locally and in the DB. */
+  setSetting: <K extends keyof Settings>(key: K, value: Settings[K]) => Promise<void>
+}
+
+const SettingsContext = createContext<SettingsCtx | null>(null)
+
+/**
+ * Outermost provider — calls `window.api.settings.getAll()` once on mount
+ * and makes settings available to the entire React tree.
+ *
+ * Replaces the three independent `getAll()` calls that used to live in
+ * `I18nContext`, `ThemeContext`, and `App.tsx`. v1.12 #106
+ */
+export function SettingsProvider({ children }: { children: React.ReactNode }): React.JSX.Element {
+  const [settings, setSettings] = useState<Settings | null>(null)
+
+  useEffect(() => {
+    void window.api.settings.getAll().then((res) => {
+      if (res.ok) setSettings(res.data)
+    })
+  }, [])
+
+  const setSetting = useCallback(async <K extends keyof Settings>(
+    key: K,
+    value: Settings[K]
+  ): Promise<void> => {
+    setSettings((prev) => (prev ? { ...prev, [key]: value } : prev))
+    await window.api.settings.set(String(key), String(value))
+  }, [])
+
+  return (
+    <SettingsContext.Provider value={{ settings, setSetting }}>
+      {children}
+    </SettingsContext.Provider>
+  )
+}
+
+export function useSettings(): SettingsCtx {
+  const ctx = useContext(SettingsContext)
+  if (!ctx) throw new Error('useSettings must be used within a SettingsProvider')
+  return ctx
+}

--- a/src/renderer/src/contexts/ThemeContext.tsx
+++ b/src/renderer/src/contexts/ThemeContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useState, useEffect } from 'react'
+import { useSettings } from './SettingsContext'
 
 export type ThemeMode = 'light' | 'dark' | 'system'
 
@@ -13,14 +14,13 @@ const ThemeContext = createContext<ThemeContextValue>({
 })
 
 export function ThemeProvider({ children }: { children: React.ReactNode }): React.JSX.Element {
+  const { settings } = useSettings()
   const [mode, setMode] = useState<ThemeMode>('system')
 
-  // Load persisted mode from DB on mount.
+  // Sync theme mode once settings are loaded.
   useEffect(() => {
-    void window.api.settings.getAll().then((res) => {
-      if (res.ok) setMode((res.data.theme_mode as ThemeMode) ?? 'system')
-    })
-  }, [])
+    if (settings?.theme_mode) setMode((settings.theme_mode as ThemeMode) ?? 'system')
+  }, [settings?.theme_mode])
 
   // Apply .dark class and listen for OS preference changes when mode = 'system'.
   useEffect(() => {

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -10,15 +10,21 @@ import 'electron-log/renderer'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'
+import { SettingsProvider } from './contexts/SettingsContext'
 import { I18nProvider } from './contexts/I18nContext'
 import { ThemeProvider } from './contexts/ThemeContext'
+import { RoundingProvider } from './contexts/RoundingContext'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <I18nProvider>
-      <ThemeProvider>
-        <App />
-      </ThemeProvider>
-    </I18nProvider>
+    <SettingsProvider>
+      <I18nProvider>
+        <ThemeProvider>
+          <RoundingProvider>
+            <App />
+          </RoundingProvider>
+        </ThemeProvider>
+      </I18nProvider>
+    </SettingsProvider>
   </StrictMode>
 )

--- a/src/renderer/src/views/AuswertungView.tsx
+++ b/src/renderer/src/views/AuswertungView.tsx
@@ -4,6 +4,8 @@ import type { AnalyticsSummary } from '../../../shared/types'
 import { TrendChart } from '../components/TrendChart'
 import { ClientBars } from '../components/ClientBars'
 import { WeekdayBars } from '../components/WeekdayBars'
+import { useRounding } from '../contexts/RoundingContext'
+import { roundDuration } from '../../../shared/duration'
 
 // ── Helper formatters ──────────────────────────────────────────────────────
 
@@ -102,6 +104,7 @@ function StatCard({ label, value, accent, foot }: StatCardProps): React.JSX.Elem
 
 export default function AuswertungView(): React.JSX.Element {
   const t = useT()
+  const { roundMinutes } = useRounding()
 
   // Month navigation state — default to current month
   const today = new Date()
@@ -278,7 +281,7 @@ export default function AuswertungView(): React.JSX.Element {
           <div className="grid grid-cols-3 gap-3">
             <StatCard
               label={t('analytics.month.hours')}
-              value={fmtHours(data.month.hours)}
+              value={fmtHours(roundDuration(data.month.hours, roundMinutes))}
               foot={
                 <DeltaPill
                   value={deltaRatio(data.month.hours, data.month.hoursPrev)}

--- a/src/renderer/src/views/CalendarView.tsx
+++ b/src/renderer/src/views/CalendarView.tsx
@@ -20,6 +20,8 @@ import { useTimer } from '../hooks/useTimer'
 import { CalendarDrawer } from '../components/CalendarDrawer'
 import { ExportModal } from '../components/ExportModal'
 import { PdfMergeModal } from '../components/PdfMergeModal'
+import { useRounding } from '../contexts/RoundingContext'
+import { roundDuration } from '../../../shared/duration'
 
 /**
  * Month-grid calendar view. 7×N rows, KW column on the left.
@@ -34,6 +36,7 @@ import { PdfMergeModal } from '../components/PdfMergeModal'
 export default function CalendarView(): React.JSX.Element {
   const t = useT()
   const { clients } = useTimer()
+  const { roundMinutes } = useRounding()
   const version = useEntriesStore((s) => s.version)
   const projectsVersion = useProjectsStore((s) => s.version)
 
@@ -256,6 +259,7 @@ export default function CalendarView(): React.JSX.Element {
             projects={projects}
             focusDay={focusDay}
             months={months}
+            roundMinutes={roundMinutes}
             onSelect={(d) => {
               setFocusDay(d)
               setSelectedDay(d)
@@ -298,6 +302,7 @@ function Week({
   projects,
   focusDay,
   months,
+  roundMinutes,
   onSelect
 }: {
   week: WeekData
@@ -307,6 +312,7 @@ function Week({
   projects: Project[]
   focusDay: Date
   months: readonly string[]
+  roundMinutes: number
   onSelect: (d: Date) => void
 }): React.JSX.Element {
   return (
@@ -324,6 +330,7 @@ function Week({
         const isToday = isSameDay(day, new Date())
         const isFocus = isSameDay(day, focusDay)
         const totalSeconds = dayEntries.reduce((sum, e) => sum + entryDurationSeconds(e), 0)
+        const displaySeconds = roundDuration(totalSeconds, roundMinutes)
         return (
           <button
             key={key}
@@ -353,12 +360,14 @@ function Week({
                 {day.getDate()}
               </span>
               {dayEntries.length > 0 && (
-                <span className="text-[10px] tabular-nums" style={{ color: 'var(--text2)', fontFamily: "'JetBrains Mono', monospace" }}>
-                  {formatHHMM(totalSeconds)}
+                <span className="text-[10px] tabular-nums" style={{ color: 'var(--text2)', fontFamily: "'JetBrains Mono', monospace" }}
+                  title={displaySeconds !== totalSeconds ? formatHHMM(totalSeconds) : undefined}
+                >
+                  {formatHHMM(displaySeconds)}
                 </span>
               )}
             </div>
-            <DayBars entries={dayEntries} clients={clients} projects={projects} />
+            <DayBars entries={dayEntries} clients={clients} projects={projects} roundMinutes={roundMinutes} />
           </button>
         )
       })}
@@ -376,11 +385,13 @@ const DEFAULT_BAR_COLOR = '#6366f1'
 function DayBars({
   entries,
   clients,
-  projects
+  projects,
+  roundMinutes
 }: {
   entries: Entry[]
   clients: Client[]
   projects: Project[]
+  roundMinutes: number
 }): React.JSX.Element | null {
   if (entries.length === 0) return null
   const visible = entries.slice(0, MAX_BARS)
@@ -394,12 +405,17 @@ function DayBars({
         const color = (projectColor || colorById.get(e.client_id)) ?? DEFAULT_BAR_COLOR
         const clientName = clients.find((c) => c.id === e.client_id)?.name ?? 'Eintrag'
         const label = e.description ? `${clientName} — ${e.description}` : clientName
+        const rawSec = entryDurationSeconds(e)
+        const dispSec = roundDuration(rawSec, roundMinutes)
+        const tooltip = rawSec !== dispSec
+          ? `${label} (${formatHHMM(dispSec)} · exakt: ${formatHHMM(rawSec)})`
+          : `${label} (${formatHHMM(rawSec)})`
         return (
           <div
             key={e.id}
             className="h-[3px] rounded-sm"
             style={{ backgroundColor: color }}
-            title={`${label} (${formatHHMM(entryDurationSeconds(e))})`}
+            title={tooltip}
           />
         )
       })}

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -6,6 +6,7 @@ import type { Locale } from '../../../shared/i18n'
 import { AboutDialog } from '../components/AboutDialog'
 import { ConfirmDialog } from '../components/ConfirmDialog'
 import { useTheme, type ThemeMode } from '../contexts/ThemeContext'
+import { useRounding } from '../contexts/RoundingContext'
 import { Toggle } from '../components/Toggle'
 import { useUiPrefsStore } from '../store/uiPrefsStore'
 
@@ -44,6 +45,7 @@ export default function SettingsView(): React.JSX.Element {
   const t = useT()
   const { locale, setLocale } = useLocale()
   const { themeMode, setThemeMode } = useTheme()
+  const { setRoundMinutes } = useRounding()
   const [settings, setSettings] = useState<Settings | null>(null)
   const [paths, setPaths] = useState<{
     db: string
@@ -534,7 +536,10 @@ export default function SettingsView(): React.JSX.Element {
                   { value: '30', label: '30 min' }
                 ]}
                 value={settings.pdf_round_minutes || '0'}
-                onChange={(v) => update('pdf_round_minutes', v)}
+                onChange={(v) => {
+                  void update('pdf_round_minutes', v)
+                  void setRoundMinutes(parseInt(v, 10) || 0)
+                }}
               />
             </Row>
           </Section>

--- a/src/renderer/src/views/TodayView.tsx
+++ b/src/renderer/src/views/TodayView.tsx
@@ -11,6 +11,8 @@ import { EntryEditForm } from '../components/EntryEditForm'
 import * as Icons from '../components/Icons'
 import type { TFunction } from '../contexts/I18nContext'
 import { useT } from '../contexts/I18nContext'
+import { useRounding } from '../contexts/RoundingContext'
+import { roundDuration } from '../../../shared/duration'
 
 /**
  * `Heute` view — the new default tab in v1.2 (D1).
@@ -28,6 +30,7 @@ import { useT } from '../contexts/I18nContext'
  */
 export default function TodayView(): React.JSX.Element {
   const t = useT()
+  const { roundMinutes } = useRounding()
   const { runningEntry, clients, startWithClient, stop } = useTimer()
   const version = useEntriesStore((s) => s.version)
   const projectsVersion = useProjectsStore((s) => s.version)
@@ -117,8 +120,8 @@ export default function TodayView(): React.JSX.Element {
       {status === 'ready' && summary && (
         <>
           <div className="grid grid-cols-2 gap-4">
-            <StatCard label={t('today.stats.today')} seconds={summary.todaySeconds} accentColor="var(--accent)" />
-            <StatCard label={t('today.stats.week')} seconds={summary.weekSeconds} accentColor="var(--green)" />
+            <StatCard label={t('today.stats.today')} seconds={roundDuration(summary.todaySeconds, roundMinutes)} rawSeconds={summary.todaySeconds} accentColor="var(--accent)" />
+            <StatCard label={t('today.stats.week')} seconds={roundDuration(summary.weekSeconds, roundMinutes)} rawSeconds={summary.weekSeconds} accentColor="var(--green)" />
           </div>
 
           <QuickStartRow
@@ -133,6 +136,7 @@ export default function TodayView(): React.JSX.Element {
             entries={summary.recentEntries}
             clientsById={clientsById}
             projectsById={projectsById}
+            roundMinutes={roundMinutes}
             onEdit={(e) => setEditEntry(e)}
             onDelete={(e) => setDeleteCandidate(e)}
           />
@@ -279,10 +283,12 @@ function ActiveTimerPill({
 function StatCard({
   label,
   seconds,
+  rawSeconds,
   accentColor
 }: {
   label: string
   seconds: number
+  rawSeconds?: number
   accentColor: string
 }): React.JSX.Element {
   return (
@@ -294,6 +300,7 @@ function StatCard({
       <p
         className="mt-2 tabular-nums"
         style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 40, fontWeight: 700, lineHeight: 1, letterSpacing: 2, color: accentColor }}
+        title={rawSeconds !== undefined && rawSeconds !== seconds ? formatHHMM(rawSeconds) : undefined}
       >
         {formatHHMM(seconds)}
       </p>
@@ -667,12 +674,14 @@ function RecentList({
   entries,
   clientsById,
   projectsById,
+  roundMinutes,
   onEdit,
   onDelete
 }: {
   entries: Entry[]
   clientsById: Map<number, Client>
   projectsById: Map<number, Project>
+  roundMinutes: number
   onEdit: (e: Entry) => void
   onDelete: (e: Entry) => void
 }): React.JSX.Element {
@@ -734,8 +743,10 @@ function RecentList({
             <span className="truncate pr-2" style={{ color: 'var(--text2)' }} title={e.description}>
               {e.description || <span style={{ color: 'var(--text3)' }}>—</span>}
             </span>
-            <span className="text-right text-xs tabular-nums" style={{ color: 'var(--text2)', fontFamily: "'JetBrains Mono', monospace" }}>
-              {formatHHMM(durationSeconds(e))}
+            <span className="text-right text-xs tabular-nums" style={{ color: 'var(--text2)', fontFamily: "'JetBrains Mono', monospace" }}
+              title={(() => { const raw = durationSeconds(e); const disp = roundDuration(raw, roundMinutes); return disp !== raw ? formatHHMM(raw) : undefined })()}
+            >
+              {formatHHMM(roundDuration(durationSeconds(e), roundMinutes))}
             </span>
             <span className="flex justify-end gap-1">
               <button

--- a/src/shared/duration.test.ts
+++ b/src/shared/duration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { formatDuration } from './duration'
+import { formatDuration, roundDuration } from './duration'
 
 describe('formatDuration', () => {
   it('formats zero as 00:00:00', () => {
@@ -33,5 +33,57 @@ describe('formatDuration', () => {
   it('clamps non-finite values to 00:00:00', () => {
     expect(formatDuration(NaN)).toBe('00:00:00')
     expect(formatDuration(Infinity)).toBe('00:00:00')
+  })
+})
+
+// v1.12 #106
+describe('roundDuration', () => {
+  it('pass-through when roundMinutes is 0', () => {
+    expect(roundDuration(3723, 0)).toBe(3723)
+    expect(roundDuration(0, 0)).toBe(0)
+  })
+
+  it('pass-through when roundMinutes is negative', () => {
+    expect(roundDuration(3723, -5)).toBe(3723)
+  })
+
+  it('returns 0 for negative seconds', () => {
+    expect(roundDuration(-1, 15)).toBe(0)
+    expect(roundDuration(-3600, 30)).toBe(0)
+  })
+
+  it('exact multiples are unchanged', () => {
+    expect(roundDuration(900, 15)).toBe(900)   // 15min exact
+    expect(roundDuration(1800, 30)).toBe(1800) // 30min exact
+    expect(roundDuration(0, 5)).toBe(0)
+  })
+
+  it('rounds up to next 5-minute interval (ceiling)', () => {
+    expect(roundDuration(1, 5)).toBe(300)       // 0s → 5min
+    expect(roundDuration(299, 5)).toBe(300)     // 4:59 → 5min
+    expect(roundDuration(301, 5)).toBe(600)     // 5:01 → 10min
+  })
+
+  it('rounds up to next 15-minute interval', () => {
+    expect(roundDuration(60, 15)).toBe(900)     // 1min → 15min
+    expect(roundDuration(899, 15)).toBe(900)    // 14:59 → 15min
+    expect(roundDuration(901, 15)).toBe(1800)   // 15:01 → 30min
+    expect(roundDuration(1380, 15)).toBe(1800)  // 23min → 30min
+  })
+
+  it('rounds up to next 30-minute interval', () => {
+    expect(roundDuration(1, 30)).toBe(1800)
+    expect(roundDuration(1799, 30)).toBe(1800)
+    expect(roundDuration(1801, 30)).toBe(3600)
+  })
+
+  it('rounds up to next 60-minute interval', () => {
+    expect(roundDuration(3599, 60)).toBe(3600)
+    expect(roundDuration(3601, 60)).toBe(7200)
+  })
+
+  it('handles non-finite seconds gracefully', () => {
+    expect(roundDuration(NaN, 15)).toBe(0)
+    expect(roundDuration(Infinity, 15)).toBe(0)
   })
 })

--- a/src/shared/duration.ts
+++ b/src/shared/duration.ts
@@ -10,3 +10,20 @@ export function formatDuration(seconds: number): string {
   const s = total % 60
   return [h, m, s].map((v) => String(v).padStart(2, '0')).join(':')
 }
+
+/**
+ * Round a duration (in seconds) up to the next multiple of `roundMinutes`
+ * using ceiling arithmetic.
+ *
+ * - `roundMinutes <= 0`: pass-through (returns `seconds` unchanged).
+ * - Already an exact multiple: no change.
+ * - Negative `seconds`: returns 0.
+ *
+ * v1.12 #106
+ */
+export function roundDuration(seconds: number, roundMinutes: number): number {
+  if (!Number.isFinite(seconds) || seconds < 0) return 0
+  if (!Number.isFinite(roundMinutes) || roundMinutes <= 0) return seconds
+  const stepSeconds = roundMinutes * 60
+  return Math.ceil(seconds / stepSeconds) * stepSeconds
+}


### PR DESCRIPTION
## Summary

Implements Issue #106 — time rounding UI integration.

### Changes

**Shared layer**
- oundDuration(seconds, roundMinutes) added to shared/duration.ts (ceiling rounding; passthrough when oundMinutes <= 0)
- 9 unit tests covering edge cases (exact multiples, 5/15/30/60 min, non-finite, negative)

**New contexts**
- SettingsContext — single getAll() IPC call, shared across contexts (eliminates duplicate calls)
- RoundingContext — reads pdf_round_minutes from SettingsContext, exposes oundMinutes + setRoundMinutes

**Context refactors**
- I18nContext + ThemeContext now read from SettingsContext instead of own getAll() calls
- Provider stack in main.tsx: SettingsProvider wraps I18nProvider > ThemeProvider > RoundingProvider

**View wiring**
- SettingsView — setRoundMinutes() called when picker changes (live sync)
- CalendarView — day total badge shows rounded duration; exact value in 	itle tooltip; bar tooltips show rounded + exact if they differ
- TodayView — StatCards (today/week) + RecentList entry durations rounded; exact value in 	itle tooltip when different
- AuswertungView — hours stat card rounded

All 253 tests passing, pnpm typecheck clean.