### PR TITLE
feat(#107): centralized tag management

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -17,6 +17,7 @@ import { handleCsvExport, type CsvRequest } from './csvExport'
 import { mergeExportHandler, mergeOnlyHandler, pdfInfoHandler } from './pdfMergeHandlers'
 import { registerAnalyticsHandlers } from './analyticsHandlers'
 import { registerBudgetHandlers } from './budgetHandlers'
+import { registerTagHandlers } from './tagHandlers'
 import type {
   Client,
   Entry,
@@ -1045,6 +1046,9 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
 
   // ── Budget (v1.11 #94) ────────────────────────────────────────────────
   registerBudgetHandlers(db)
+
+  // ── Tags (v1.12 #107) ────────────────────────────────────────────────
+  registerTagHandlers(db)
 }
 
 /**

--- a/src/main/migrations/016-v112-tags.ts
+++ b/src/main/migrations/016-v112-tags.ts
@@ -1,0 +1,48 @@
+import type { Migration } from './index'
+
+/**
+ * v1.12 #107 — Centralized tag management.
+ *
+ * Creates a `tags` master registry table (name TEXT PRIMARY KEY).
+ * Tags now have an authoritative list — `TagInput` autocomplete and the
+ * new `TagManagementView` operate against this table.
+ *
+ * Pre-populates from existing `entries.tags` values via a recursive CTE
+ * that parses the `,tag1,tag2,` format used since migration 007.
+ * Uses INSERT OR IGNORE so the statement is safe to re-run (idempotent).
+ *
+ * Only tags with name length ≤ 50 are imported (matches `tags:create`
+ * validation), preventing garbage data from corrupting the registry.
+ */
+export const migration016: Migration = {
+  version: 16,
+  name: 'v1.12-tags',
+  up: `
+    CREATE TABLE IF NOT EXISTS tags (
+      name TEXT PRIMARY KEY
+    );
+
+    WITH RECURSIVE
+      raw(tag_str) AS (
+        SELECT tags FROM entries
+        WHERE tags != ''
+          AND deleted_at IS NULL
+          AND INSTR(tags, ',') > 0
+      ),
+      split(tag, rest) AS (
+        SELECT
+          SUBSTR(tag_str, 2, INSTR(SUBSTR(tag_str, 2), ',') - 1),
+          SUBSTR(tag_str, 2 + INSTR(SUBSTR(tag_str, 2), ','))
+        FROM raw
+        UNION ALL
+        SELECT
+          SUBSTR(rest, 1, INSTR(rest, ',') - 1),
+          SUBSTR(rest, INSTR(rest, ',') + 1)
+        FROM split
+        WHERE rest != '' AND INSTR(rest, ',') > 0
+      )
+    INSERT OR IGNORE INTO tags (name)
+    SELECT DISTINCT tag FROM split
+    WHERE tag != '' AND LENGTH(tag) <= 50;
+  `
+}

--- a/src/main/migrations/index.ts
+++ b/src/main/migrations/index.ts
@@ -13,6 +13,7 @@ import { migration012 } from './012-v19-projects'
 import { migration013 } from './013-v111-stammdaten'
 import { migration014 } from './014-v12-housekeeping'
 import { migration015 } from './015-v12-project-contact-person'
+import { migration016 } from './016-v112-tags'
 
 export interface Migration {
   /** Monotonically increasing integer. Never reused, never reordered. */
@@ -42,5 +43,6 @@ export const migrations: Migration[] = [
   migration012,
   migration013,
   migration014,
-  migration015
+  migration015,
+  migration016
 ].sort((a, b) => a.version - b.version)

--- a/src/main/tagHandlers.test.ts
+++ b/src/main/tagHandlers.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import Database from 'better-sqlite3'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { mkdirSync, rmSync } from 'fs'
+import { migrations } from './migrations/index'
+import {
+  getAllTagsWithCount,
+  createTag,
+  renameTag,
+  mergeTag,
+  deleteTag
+} from './tagHandlers'
+
+// Skip if the native module isn't available (CI without electron rebuild)
+let available = true
+try {
+  new Database(':memory:').close()
+} catch {
+  available = false
+}
+
+function applyAll(db: Database.Database): void {
+  db.exec(
+    `CREATE TABLE IF NOT EXISTS schema_version (
+      version INTEGER PRIMARY KEY,
+      name TEXT NOT NULL,
+      applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );`
+  )
+  for (const m of migrations) {
+    const tx = db.transaction(() => {
+      db.exec(m.up)
+      db.prepare('INSERT INTO schema_version (version, name) VALUES (?, ?)').run(m.version, m.name)
+    })
+    tx()
+  }
+}
+
+describe.skipIf(!available)('tagHandlers', () => {
+  let tmpDir: string
+  let db: Database.Database
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `tag-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    mkdirSync(tmpDir, { recursive: true })
+    db = new Database(join(tmpDir, 'test.db'))
+    db.pragma('journal_mode = WAL')
+    db.pragma('foreign_keys = ON')
+    applyAll(db)
+    db.prepare(`INSERT INTO clients (id, name) VALUES (1, 'Test Client')`).run()
+  })
+
+  afterEach(() => {
+    db.close()
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  // ── getAllTagsWithCount ─────────────────────────────────────────────────
+
+  describe('getAllTagsWithCount', () => {
+    it('returns empty array for empty DB', () => {
+      const result = getAllTagsWithCount(db)
+      expect(result).toEqual({ ok: true, data: [] })
+    })
+
+    it('returns tags from master registry with count=0 when no entries', () => {
+      db.prepare(`INSERT INTO tags (name) VALUES ('design')`).run()
+      db.prepare(`INSERT INTO tags (name) VALUES ('bug')`).run()
+      const result = getAllTagsWithCount(db)
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.data).toEqual([
+          { name: 'bug', count: 0 },
+          { name: 'design', count: 0 }
+        ])
+      }
+    })
+
+    it('counts entries that use each tag', () => {
+      db.prepare(`INSERT INTO tags (name) VALUES ('bug')`).run()
+      db.prepare(`INSERT INTO tags (name) VALUES ('ux')`).run()
+      db.prepare(
+        `INSERT INTO entries (client_id, started_at, stopped_at, tags) VALUES (1, '2026-01-01T09:00:00Z', '2026-01-01T10:00:00Z', ',bug,ux,')`
+      ).run()
+      db.prepare(
+        `INSERT INTO entries (client_id, started_at, stopped_at, tags) VALUES (1, '2026-01-02T09:00:00Z', '2026-01-02T10:00:00Z', ',bug,')`
+      ).run()
+      const result = getAllTagsWithCount(db)
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.data).toEqual([
+          { name: 'bug', count: 2 },
+          { name: 'ux', count: 1 }
+        ])
+      }
+    })
+
+    it('excludes deleted entries from count', () => {
+      db.prepare(`INSERT INTO tags (name) VALUES ('bug')`).run()
+      db.prepare(
+        `INSERT INTO entries (client_id, started_at, stopped_at, tags, deleted_at) VALUES (1, '2026-01-01T09:00:00Z', '2026-01-01T10:00:00Z', ',bug,', '2026-01-02T00:00:00Z')`
+      ).run()
+      const result = getAllTagsWithCount(db)
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.data[0]).toEqual({ name: 'bug', count: 0 })
+      }
+    })
+  })
+
+  // ── createTag ──────────────────────────────────────────────────────────
+
+  describe('createTag', () => {
+    it('creates a new tag', () => {
+      const result = createTag(db, 'newtag')
+      expect(result).toEqual({ ok: true, data: undefined })
+      const row = db.prepare('SELECT name FROM tags WHERE name = ?').get('newtag')
+      expect(row).toEqual({ name: 'newtag' })
+    })
+
+    it('normalizes name to lowercase and trims whitespace', () => {
+      createTag(db, '  BugFix  ')
+      const row = db.prepare('SELECT name FROM tags WHERE name = ?').get('bugfix')
+      expect(row).toBeTruthy()
+    })
+
+    it('fails on duplicate name', () => {
+      createTag(db, 'dup')
+      const result = createTag(db, 'dup')
+      expect(result.ok).toBe(false)
+    })
+
+    it('fails on empty name', () => {
+      expect(createTag(db, '').ok).toBe(false)
+      expect(createTag(db, '  ').ok).toBe(false)
+    })
+
+    it('fails when name contains a comma', () => {
+      expect(createTag(db, 'a,b').ok).toBe(false)
+    })
+
+    it('fails when name exceeds 50 characters', () => {
+      expect(createTag(db, 'a'.repeat(51)).ok).toBe(false)
+    })
+  })
+
+  // ── renameTag ──────────────────────────────────────────────────────────
+
+  describe('renameTag', () => {
+    beforeEach(() => {
+      db.prepare(`INSERT INTO tags (name) VALUES ('bug')`).run()
+      db.prepare(
+        `INSERT INTO entries (client_id, started_at, stopped_at, tags) VALUES (1, '2026-01-01T09:00:00Z', '2026-01-01T10:00:00Z', ',bug,ux,')`
+      ).run()
+    })
+
+    it('renames tag and updates all affected entries', () => {
+      const result = renameTag(db, 'bug', 'defect')
+      expect(result).toEqual({ ok: true, data: undefined })
+      const tag = db.prepare('SELECT name FROM tags WHERE name = ?').get('defect')
+      expect(tag).toBeTruthy()
+      const old = db.prepare('SELECT name FROM tags WHERE name = ?').get('bug')
+      expect(old).toBeUndefined()
+      const entry = db.prepare('SELECT tags FROM entries LIMIT 1').get() as { tags: string }
+      expect(entry.tags).toContain(',defect,')
+      expect(entry.tags).not.toContain(',bug,')
+    })
+
+    it('is a no-op when old and new name are the same', () => {
+      const result = renameTag(db, 'bug', 'bug')
+      expect(result).toEqual({ ok: true, data: undefined })
+    })
+
+    it('fails when new name already exists', () => {
+      db.prepare(`INSERT INTO tags (name) VALUES ('known')`).run()
+      const result = renameTag(db, 'bug', 'known')
+      expect(result.ok).toBe(false)
+    })
+
+    it('does not affect entries that do not use the tag', () => {
+      db.prepare(
+        `INSERT INTO entries (client_id, started_at, stopped_at, tags) VALUES (1, '2026-01-02T09:00:00Z', '2026-01-02T10:00:00Z', ',ux,')`
+      ).run()
+      renameTag(db, 'bug', 'defect')
+      const rows = db.prepare('SELECT tags FROM entries WHERE tags LIKE ?').all('%,ux,%') as Array<{ tags: string }>
+      expect(rows.some((r) => r.tags === ',ux,')).toBe(true)
+    })
+  })
+
+  // ── mergeTag ───────────────────────────────────────────────────────────
+
+  describe('mergeTag', () => {
+    beforeEach(() => {
+      db.prepare(`INSERT INTO tags (name) VALUES ('consulting')`).run()
+      db.prepare(`INSERT INTO tags (name) VALUES ('consulting-alt')`).run()
+      db.prepare(
+        `INSERT INTO entries (client_id, started_at, stopped_at, tags) VALUES (1, '2026-01-01T09:00:00Z', '2026-01-01T10:00:00Z', ',consulting-alt,ux,')`
+      ).run()
+    })
+
+    it('moves all entries from source to target and deletes source', () => {
+      const result = mergeTag(db, 'consulting-alt', 'consulting')
+      expect(result).toEqual({ ok: true, data: undefined })
+      const source = db.prepare('SELECT name FROM tags WHERE name = ?').get('consulting-alt')
+      expect(source).toBeUndefined()
+      const entry = db.prepare('SELECT tags FROM entries LIMIT 1').get() as { tags: string }
+      expect(entry.tags).toContain(',consulting,')
+      expect(entry.tags).not.toContain(',consulting-alt,')
+    })
+
+    it('fails when source and target are the same', () => {
+      const result = mergeTag(db, 'consulting', 'consulting')
+      expect(result.ok).toBe(false)
+    })
+  })
+
+  // ── deleteTag ──────────────────────────────────────────────────────────
+
+  describe('deleteTag', () => {
+    beforeEach(() => {
+      db.prepare(`INSERT INTO tags (name) VALUES ('unused')`).run()
+      db.prepare(`INSERT INTO tags (name) VALUES ('used')`).run()
+      db.prepare(
+        `INSERT INTO entries (client_id, started_at, stopped_at, tags) VALUES (1, '2026-01-01T09:00:00Z', '2026-01-01T10:00:00Z', ',used,')`
+      ).run()
+    })
+
+    it('deletes a tag when no entries use it', () => {
+      const result = deleteTag(db, 'unused')
+      expect(result).toEqual({ ok: true, data: undefined })
+      const row = db.prepare('SELECT name FROM tags WHERE name = ?').get('unused')
+      expect(row).toBeUndefined()
+    })
+
+    it('fails when entries still use the tag', () => {
+      const result = deleteTag(db, 'used')
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error).toContain('1')
+      }
+    })
+
+    it('count=0 for deleted entries does not block delete', () => {
+      // Mark the entry as deleted
+      db.prepare(`UPDATE entries SET deleted_at = '2026-01-02T00:00:00Z'`).run()
+      const result = deleteTag(db, 'used')
+      expect(result).toEqual({ ok: true, data: undefined })
+    })
+  })
+})

--- a/src/main/tagHandlers.ts
+++ b/src/main/tagHandlers.ts
@@ -1,0 +1,216 @@
+import { ipcMain } from 'electron'
+import type Database from 'better-sqlite3'
+import log from 'electron-log/main'
+import type { IpcResult } from '../shared/types'
+
+export interface TagWithCount {
+  name: string
+  count: number
+}
+
+function ok<T>(data: T): IpcResult<T> {
+  return { ok: true, data }
+}
+function fail(error: unknown): IpcResult<never> {
+  return { ok: false, error: String(error) }
+}
+
+const MAX_TAG_LEN = 50
+
+function validateTagName(name: string): string | null {
+  const trimmed = name.trim().toLowerCase()
+  if (trimmed.length === 0) return 'Tag-Name darf nicht leer sein'
+  if (trimmed.length > MAX_TAG_LEN) return `Tag-Name darf maximal ${MAX_TAG_LEN} Zeichen haben`
+  if (trimmed.includes(',')) return 'Tag-Name darf kein Komma enthalten'
+  return null
+}
+
+/**
+ * Returns all tags from the master registry with their entry count.
+ * Single-scan: reads all non-deleted entry tags once, aggregates in JS,
+ * then merges with the master list (tags with 0 entries are included).
+ *
+ * Exported for unit testing.
+ */
+export function getAllTagsWithCount(db: Database.Database): IpcResult<TagWithCount[]> {
+  try {
+    const masterRows = db
+      .prepare('SELECT name FROM tags ORDER BY name ASC')
+      .all() as Array<{ name: string }>
+
+    const entryRows = db
+      .prepare(`SELECT tags FROM entries WHERE deleted_at IS NULL AND tags != ''`)
+      .all() as Array<{ tags: string }>
+
+    const freq = new Map<string, number>()
+    for (const { tags } of entryRows) {
+      for (const tag of tags.split(',').filter((t: string) => t.length > 0)) {
+        freq.set(tag, (freq.get(tag) ?? 0) + 1)
+      }
+    }
+
+    const result: TagWithCount[] = masterRows.map((r) => ({
+      name: r.name,
+      count: freq.get(r.name) ?? 0
+    }))
+
+    return ok(result)
+  } catch (e) {
+    return fail(e)
+  }
+}
+
+/**
+ * Creates a new tag in the master registry.
+ * Validates name (non-empty, ≤50 chars, no comma). Fails on duplicate.
+ *
+ * Exported for unit testing.
+ */
+export function createTag(db: Database.Database, name: string): IpcResult<void> {
+  const trimmed = name.trim().toLowerCase()
+  const err = validateTagName(trimmed)
+  if (err) return fail(err)
+
+  try {
+    const existing = db.prepare('SELECT name FROM tags WHERE name = ?').get(trimmed)
+    if (existing) return fail(`Tag '${trimmed}' existiert bereits`)
+    db.prepare('INSERT INTO tags (name) VALUES (?)').run(trimmed)
+    return ok(undefined)
+  } catch (e) {
+    return fail(e)
+  }
+}
+
+/**
+ * Renames a tag atomically:
+ *   1. No-op if oldName === newName.
+ *   2. Fail if newName already exists.
+ *   3. UPDATE tags.name.
+ *   4. UPDATE entries.tags via REPLACE() for all affected rows.
+ *
+ * Exported for unit testing.
+ */
+export function renameTag(
+  db: Database.Database,
+  oldName: string,
+  newName: string
+): IpcResult<void> {
+  const trimmedOld = oldName.trim().toLowerCase()
+  const trimmedNew = newName.trim().toLowerCase()
+
+  if (trimmedOld === trimmedNew) return ok(undefined)
+
+  const errNew = validateTagName(trimmedNew)
+  if (errNew) return fail(errNew)
+
+  const tx = db.transaction(() => {
+    const existing = db.prepare('SELECT name FROM tags WHERE name = ?').get(trimmedNew)
+    if (existing) throw new Error(`Ein Tag mit dem Namen '${trimmedNew}' existiert bereits`)
+
+    db.prepare('UPDATE tags SET name = ? WHERE name = ?').run(trimmedNew, trimmedOld)
+
+    db.prepare(
+      `UPDATE entries
+       SET tags = REPLACE(tags, ',' || ? || ',', ',' || ? || ',')
+       WHERE tags LIKE '%,' || ? || ',%'`
+    ).run(trimmedNew, trimmedOld, trimmedOld)
+
+    log.info(`[tags] renamed '${trimmedOld}' → '${trimmedNew}'`)
+  })
+
+  try {
+    tx()
+    return ok(undefined)
+  } catch (e) {
+    return fail(e)
+  }
+}
+
+/**
+ * Merges source tag into target:
+ *   1. Fail if source === target.
+ *   2. UPDATE all entries: replace source with target.
+ *   3. DELETE source from tags table.
+ *
+ * Exported for unit testing.
+ */
+export function mergeTag(
+  db: Database.Database,
+  source: string,
+  target: string
+): IpcResult<void> {
+  const trimmedSource = source.trim().toLowerCase()
+  const trimmedTarget = target.trim().toLowerCase()
+
+  if (trimmedSource === trimmedTarget) return fail('Quell- und Ziel-Tag dürfen nicht gleich sein')
+
+  const tx = db.transaction(() => {
+    db.prepare(
+      `UPDATE entries
+       SET tags = REPLACE(tags, ',' || ? || ',', ',' || ? || ',')
+       WHERE tags LIKE '%,' || ? || ',%'`
+    ).run(trimmedTarget, trimmedSource, trimmedSource)
+
+    db.prepare('DELETE FROM tags WHERE name = ?').run(trimmedSource)
+
+    log.info(`[tags] merged '${trimmedSource}' → '${trimmedTarget}'`)
+  })
+
+  try {
+    tx()
+    return ok(undefined)
+  } catch (e) {
+    return fail(e)
+  }
+}
+
+/**
+ * Deletes a tag from the registry — only when entry count is 0.
+ * Fails with a descriptive error if any entries still use the tag.
+ *
+ * Exported for unit testing.
+ */
+export function deleteTag(db: Database.Database, name: string): IpcResult<void> {
+  const trimmed = name.trim().toLowerCase()
+
+  try {
+    const rows = db
+      .prepare(`SELECT COUNT(*) AS cnt FROM entries WHERE deleted_at IS NULL AND tags LIKE '%,' || ? || ',%'`)
+      .get(trimmed) as { cnt: number }
+
+    if (rows.cnt > 0) {
+      return fail(`Tag '${trimmed}' hat noch ${rows.cnt} Eintrag/Einträge und kann nicht gelöscht werden`)
+    }
+
+    db.prepare('DELETE FROM tags WHERE name = ?').run(trimmed)
+    return ok(undefined)
+  } catch (e) {
+    return fail(e)
+  }
+}
+
+/**
+ * Registers all tag-related IPC handlers.
+ * Called from registerIpcHandlers() in ipc.ts.
+ */
+export function registerTagHandlers(db: Database.Database): void {
+  ipcMain.handle('tags:get-all-with-count', (): IpcResult<TagWithCount[]> => {
+    return getAllTagsWithCount(db)
+  })
+
+  ipcMain.handle('tags:create', (_e, name: string): IpcResult<void> => {
+    return createTag(db, name)
+  })
+
+  ipcMain.handle('tags:rename', (_e, oldName: string, newName: string): IpcResult<void> => {
+    return renameTag(db, oldName, newName)
+  })
+
+  ipcMain.handle('tags:merge', (_e, source: string, target: string): IpcResult<void> => {
+    return mergeTag(db, source, target)
+  })
+
+  ipcMain.handle('tags:delete', (_e, name: string): IpcResult<void> => {
+    return deleteTag(db, name)
+  })
+}

--- a/src/main/tagHandlers.ts
+++ b/src/main/tagHandlers.ts
@@ -113,7 +113,7 @@ export function renameTag(
       `UPDATE entries
        SET tags = REPLACE(tags, ',' || ? || ',', ',' || ? || ',')
        WHERE tags LIKE '%,' || ? || ',%'`
-    ).run(trimmedNew, trimmedOld, trimmedOld)
+    ).run(trimmedOld, trimmedNew, trimmedOld)
 
     log.info(`[tags] renamed '${trimmedOld}' → '${trimmedNew}'`)
   })
@@ -149,7 +149,7 @@ export function mergeTag(
       `UPDATE entries
        SET tags = REPLACE(tags, ',' || ? || ',', ',' || ? || ',')
        WHERE tags LIKE '%,' || ? || ',%'`
-    ).run(trimmedTarget, trimmedSource, trimmedSource)
+    ).run(trimmedSource, trimmedTarget, trimmedSource)
 
     db.prepare('DELETE FROM tags WHERE name = ?').run(trimmedSource)
 

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -108,6 +108,11 @@ declare global {
       }
       tags: {
         recent(): Promise<IpcResult<string[]>>
+        getAllWithCount(): Promise<IpcResult<Array<{ name: string; count: number }>>>
+        create(name: string): Promise<IpcResult<void>>
+        rename(oldName: string, newName: string): Promise<IpcResult<void>>
+        merge(source: string, target: string): Promise<IpcResult<void>>
+        delete(name: string): Promise<IpcResult<void>>
       }
       pdf: {
         export(req: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -162,7 +162,15 @@ const api = {
       ipcRenderer.invoke('export:json')
   },
   tags: {
-    recent: (): Promise<IpcResult<string[]>> => ipcRenderer.invoke('tags:recent')
+    recent: (): Promise<IpcResult<string[]>> => ipcRenderer.invoke('tags:recent'),
+    getAllWithCount: (): Promise<IpcResult<Array<{ name: string; count: number }>>> =>
+      ipcRenderer.invoke('tags:get-all-with-count'),
+    create: (name: string): Promise<IpcResult<void>> => ipcRenderer.invoke('tags:create', name),
+    rename: (oldName: string, newName: string): Promise<IpcResult<void>> =>
+      ipcRenderer.invoke('tags:rename', oldName, newName),
+    merge: (source: string, target: string): Promise<IpcResult<void>> =>
+      ipcRenderer.invoke('tags:merge', source, target),
+    delete: (name: string): Promise<IpcResult<void>> => ipcRenderer.invoke('tags:delete', name)
   },
   pdf: {
     export: (req: {

--- a/src/renderer/src/components/TagInput.tsx
+++ b/src/renderer/src/components/TagInput.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { deserializeTags, parseTagInput, serializeTags } from '../../../shared/tags'
 import { useT } from '../contexts/I18nContext'
 
@@ -7,6 +7,8 @@ interface Props {
   value: string
   onChange: (serialized: string) => void
   disabled?: boolean
+  /** Optional callback to navigate to the tag management settings tab. */
+  onManageTags?: () => void
 }
 
 /**
@@ -30,47 +32,80 @@ function chipColor(tag: string): string {
   return CHIP_COLORS[code % CHIP_COLORS.length]
 }
 
+// Sentinel value for the "create new tag" option in the dropdown
+const CREATE_SENTINEL = '__create__'
+
 /**
  * Tag chip list + text input with Tab/Enter/comma to add, Backspace to
- * remove, and autocomplete dropdown populated from `tags:recent` IPC.
+ * remove, and autocomplete dropdown populated from `tags:get-all-with-count`
+ * (master registry).
+ *
+ * Closed tag system: free text that doesn't match an existing tag shows a
+ * "+ 'foo' erstellen" option. Selecting it calls `tags:create` and adds
+ * the tag immediately.
  *
  * Stores tags as the serialized DB format (`,tag1,tag2,`) via `onChange`.
  */
-export function TagInput({ value, onChange, disabled = false }: Props): React.ReactElement {
+export function TagInput({ value, onChange, disabled = false, onManageTags }: Props): React.ReactElement {
   const t = useT()
   const tags = deserializeTags(value)
   const [inputValue, setInputValue] = useState('')
   const [suggestions, setSuggestions] = useState<string[]>([])
-  const [allRecent, setAllRecent] = useState<string[]>([])
+  const [allKnown, setAllKnown] = useState<string[]>([])
   const [dropdownOpen, setDropdownOpen] = useState(false)
   const [highlightedIndex, setHighlightedIndex] = useState(-1)
   const inputRef = useRef<HTMLInputElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
 
-  // Load recent tags once on mount
-  useEffect(() => {
-    window.api.tags.recent().then((res) => {
-      if (res.ok) setAllRecent(res.data)
-    })
+  const reloadKnown = useCallback(async () => {
+    const res = await window.api.tags.getAllWithCount()
+    if (res.ok) setAllKnown(res.data.map((r) => r.name))
   }, [])
+
+  // Load master registry on mount
+  useEffect(() => {
+    void reloadKnown()
+  }, [reloadKnown])
 
   // Filter suggestions based on current input
   useEffect(() => {
     const q = inputValue.trim().toLowerCase().replace(/^#/, '')
+    let matches: string[]
     if (!q) {
-      setSuggestions(allRecent.filter((t) => !tags.includes(t)).slice(0, 8))
+      matches = allKnown.filter((t) => !tags.includes(t)).slice(0, 8)
     } else {
-      setSuggestions(
-        allRecent
-          .filter((t) => t.startsWith(q) && !tags.includes(t))
-          .slice(0, 8)
-      )
+      matches = allKnown
+        .filter((t) => t.startsWith(q) && !tags.includes(t))
+        .slice(0, 8)
+    }
+    // Append "create" sentinel if typed text is non-empty and not an exact match
+    if (q && !allKnown.includes(q) && !tags.includes(q)) {
+      setSuggestions([...matches, CREATE_SENTINEL])
+    } else {
+      setSuggestions(matches)
     }
     setHighlightedIndex(-1)
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [inputValue, allRecent, value])
+  }, [inputValue, allKnown, value])
 
-  function commitInput(raw: string): void {
+  async function addTag(tag: string): Promise<void> {
+    if (!tag || tags.includes(tag) || tags.length >= 10) return
+    onChange(serializeTags([...tags, tag]))
+    setInputValue('')
+    setDropdownOpen(false)
+  }
+
+  async function commitInput(raw: string): Promise<void> {
+    if (raw === CREATE_SENTINEL) {
+      const name = inputValue.trim().toLowerCase().replace(/^#/, '')
+      if (!name) return
+      const res = await window.api.tags.create(name)
+      if (res.ok) {
+        await reloadKnown()
+        await addTag(name)
+      }
+      return
+    }
     const parsed = parseTagInput(raw)
     if (parsed.length === 0) {
       setInputValue('')
@@ -104,9 +139,15 @@ export function TagInput({ value, onChange, disabled = false }: Props): React.Re
     if ((e.key === 'Enter' || e.key === 'Tab' || e.key === ',') && inputValue.trim()) {
       e.preventDefault()
       if (highlightedIndex >= 0 && suggestions[highlightedIndex]) {
-        commitInput(suggestions[highlightedIndex])
+        void commitInput(suggestions[highlightedIndex])
       } else {
-        commitInput(inputValue)
+        // In closed mode, Enter on free text: create if not known
+        const q = inputValue.trim().toLowerCase().replace(/^#/, '')
+        if (q && allKnown.includes(q)) {
+          void commitInput(q)
+        } else if (q) {
+          void commitInput(CREATE_SENTINEL)
+        }
       }
       return
     }
@@ -195,19 +236,32 @@ export function TagInput({ value, onChange, disabled = false }: Props): React.Re
               aria-selected={i === highlightedIndex}
               onPointerDown={(e) => {
                 e.preventDefault()
-                commitInput(s)
+                void commitInput(s)
               }}
               className={`cursor-pointer px-3 py-1 text-xs ${
                 i === highlightedIndex
                   ? 'bg-indigo-600 text-white'
                   : 'hover:bg-white/10'
               }`}
-              style={i !== highlightedIndex ? { color: 'var(--text)' } : undefined}
+              style={i !== highlightedIndex ? { color: s === CREATE_SENTINEL ? 'var(--text2)' : 'var(--text)' } : undefined}
             >
-              #{s}
+              {s === CREATE_SENTINEL
+                ? t('tags.createOption', { tag: inputValue.trim().toLowerCase().replace(/^#/, '') })
+                : `#${s}`}
             </li>
           ))}
         </ul>
+      )}
+
+      {onManageTags && allKnown.length === 0 && !disabled && (
+        <button
+          type="button"
+          onClick={onManageTags}
+          className="mt-1 text-xs underline focus:outline-none"
+          style={{ color: 'var(--text3)' }}
+        >
+          {t('tags.manageLink')}
+        </button>
       )}
     </div>
   )

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -9,11 +9,12 @@ import { useTheme, type ThemeMode } from '../contexts/ThemeContext'
 import { useRounding } from '../contexts/RoundingContext'
 import { Toggle } from '../components/Toggle'
 import { useUiPrefsStore } from '../store/uiPrefsStore'
+import TagManagementView from './TagManagementView'
 
 const DEFAULT_HOTKEY = 'Alt+Shift+S'
 const DEFAULT_MINI_HOTKEY = 'Alt+Shift+M'
 
-type SettingsTab = 'general' | 'timer' | 'export' | 'data' | 'about'
+type SettingsTab = 'general' | 'timer' | 'export' | 'data' | 'tags' | 'about'
 
 /** Settings keys that hold a global accelerator string. */
 type HotkeyKey = 'hotkey_toggle' | 'mini_hotkey'
@@ -242,6 +243,7 @@ export default function SettingsView(): React.JSX.Element {
     { id: 'timer', label: t('settings.nav.timer') },
     { id: 'export', label: t('settings.nav.export') },
     { id: 'data', label: t('settings.nav.data') },
+    { id: 'tags', label: t('settings.nav.tags') },
     { id: 'about', label: t('settings.nav.about') }
   ]
 
@@ -726,6 +728,9 @@ export default function SettingsView(): React.JSX.Element {
             </Section>
           </>
         )}
+
+        {/* Tags */}
+        {tab === 'tags' && <TagManagementView />}
 
         <AboutDialog open={showAbout} onClose={() => setShowAbout(false)} version={version} />
       </div>

--- a/src/renderer/src/views/TagManagementView.tsx
+++ b/src/renderer/src/views/TagManagementView.tsx
@@ -1,0 +1,303 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useT } from '../contexts/I18nContext'
+import { ConfirmDialog } from '../components/ConfirmDialog'
+import { useToastStore } from '../store/toastStore'
+
+interface TagRow {
+  name: string
+  count: number
+}
+
+interface MergeConfirm {
+  source: string
+  target: string
+  count: number
+}
+
+const inputClass =
+  'rounded-lg px-3 py-1.5 text-sm border backdrop-blur-xl ' +
+  '[background:var(--input-bg)] [border-color:var(--card-border)] [color:var(--text)] ' +
+  'focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent'
+
+const btnClass =
+  'rounded-md px-3 py-1.5 text-sm font-medium hover:bg-white/10 ' +
+  'border [background:var(--card-bg)] [border-color:var(--card-border)] [color:var(--text)] ' +
+  'focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-40 disabled:cursor-not-allowed'
+
+export default function TagManagementView(): React.JSX.Element {
+  const t = useT()
+  const showToast = useToastStore((s) => s.show)
+
+  const [tags, setTags] = useState<TagRow[]>([])
+  const [loading, setLoading] = useState(true)
+
+  // Create form
+  const [newName, setNewName] = useState('')
+  const [creating, setCreating] = useState(false)
+
+  // Per-row rename state
+  const [renamingTag, setRenamingTag] = useState<string | null>(null)
+  const [renameValue, setRenameValue] = useState('')
+
+  // Merge confirm
+  const [mergeConfirm, setMergeConfirm] = useState<MergeConfirm | null>(null)
+
+  const reload = useCallback(async () => {
+    setLoading(true)
+    const res = await window.api.tags.getAllWithCount()
+    if (res.ok) setTags(res.data)
+    setLoading(false)
+  }, [])
+
+  useEffect(() => {
+    void reload()
+  }, [reload])
+
+  async function handleCreate(): Promise<void> {
+    const trimmed = newName.trim()
+    if (!trimmed) return
+    setCreating(true)
+    const res = await window.api.tags.create(trimmed)
+    setCreating(false)
+    if (!res.ok) {
+      showToast(res.error)
+    } else {
+      setNewName('')
+      void reload()
+    }
+  }
+
+  function startRename(tag: string): void {
+    setRenamingTag(tag)
+    setRenameValue(tag)
+  }
+
+  async function commitRename(oldName: string): Promise<void> {
+    const trimmed = renameValue.trim()
+    if (!trimmed || trimmed === oldName) {
+      setRenamingTag(null)
+      return
+    }
+    const res = await window.api.tags.rename(oldName, trimmed)
+    setRenamingTag(null)
+    if (!res.ok) {
+      showToast(res.error)
+    } else {
+      void reload()
+    }
+  }
+
+  async function handleMergeSelect(source: string, target: string): Promise<void> {
+    if (!target || target === source) return
+    const row = tags.find((t) => t.name === source)
+    setMergeConfirm({ source, target, count: row?.count ?? 0 })
+  }
+
+  async function confirmMerge(): Promise<void> {
+    if (!mergeConfirm) return
+    const { source, target } = mergeConfirm
+    setMergeConfirm(null)
+    const res = await window.api.tags.merge(source, target)
+    if (!res.ok) {
+      showToast(res.error)
+    } else {
+      void reload()
+    }
+  }
+
+  async function handleDelete(name: string): Promise<void> {
+    const res = await window.api.tags.delete(name)
+    if (!res.ok) {
+      showToast(res.error)
+    } else {
+      void reload()
+    }
+  }
+
+  function entryLabel(count: number): string {
+    if (count === 0) return t('settings.tags.noEntries')
+    if (count === 1) return t('settings.tags.entry')
+    return t('settings.tags.entries', { count: String(count) })
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <h2 className="text-base font-semibold" style={{ color: 'var(--text)' }}>
+        {t('settings.tags.title')}
+      </h2>
+
+      {/* Create new tag */}
+      <form
+        onSubmit={(e) => {
+          e.preventDefault()
+          void handleCreate()
+        }}
+        className="flex items-center gap-2"
+      >
+        <input
+          type="text"
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          placeholder={t('settings.tags.newPlaceholder')}
+          className={`${inputClass} flex-1`}
+          maxLength={50}
+          disabled={creating}
+        />
+        <button
+          type="submit"
+          disabled={creating || !newName.trim()}
+          className={btnClass}
+        >
+          {t('settings.tags.add')}
+        </button>
+      </form>
+
+      {/* Tag list */}
+      <div
+        className="overflow-hidden rounded-[14px] border"
+        style={{ borderColor: 'var(--card-border)', background: 'var(--card-bg)' }}
+      >
+        {loading && (
+          <div className="px-4 py-8 text-center text-sm" style={{ color: 'var(--text3)' }}>
+            …
+          </div>
+        )}
+
+        {!loading && tags.length === 0 && (
+          <div className="px-4 py-8 text-center text-sm" style={{ color: 'var(--text3)' }}>
+            {t('settings.tags.empty')}
+          </div>
+        )}
+
+        {!loading && tags.map((tag, idx) => (
+          <div
+            key={tag.name}
+            className="flex items-center gap-3 px-4 py-3 border-t"
+            style={{
+              borderColor: idx === 0 ? 'transparent' : 'var(--card-border)',
+            }}
+          >
+            {/* Tag chip */}
+            <span
+              className="inline-flex items-center rounded border px-2 py-0.5 text-xs font-medium"
+              style={{
+                background: 'var(--nav-bg)',
+                borderColor: 'var(--card-border)',
+                color: 'var(--text)',
+                fontFamily: 'monospace',
+                minWidth: 80
+              }}
+            >
+              #{tag.name}
+            </span>
+
+            {/* Entry count */}
+            <span className="w-20 shrink-0 text-xs tabular-nums" style={{ color: 'var(--text3)' }}>
+              {entryLabel(tag.count)}
+            </span>
+
+            {/* Rename inline */}
+            <div className="flex flex-1 items-center gap-2 min-w-0">
+              {renamingTag === tag.name ? (
+                <>
+                  <input
+                    type="text"
+                    value={renameValue}
+                    onChange={(e) => setRenameValue(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') void commitRename(tag.name)
+                      if (e.key === 'Escape') setRenamingTag(null)
+                    }}
+                    placeholder={t('settings.tags.renamePlaceholder')}
+                    className={`${inputClass} flex-1`}
+                    maxLength={50}
+                    autoFocus
+                  />
+                  <button
+                    type="button"
+                    onClick={() => void commitRename(tag.name)}
+                    disabled={!renameValue.trim() || renameValue.trim() === tag.name}
+                    className={btnClass}
+                  >
+                    {t('settings.tags.renameConfirm')}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setRenamingTag(null)}
+                    className={btnClass}
+                  >
+                    {t('settings.tags.renameCancel')}
+                  </button>
+                </>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => startRename(tag.name)}
+                  className={btnClass}
+                >
+                  {t('settings.tags.rename')}
+                </button>
+              )}
+            </div>
+
+            {/* Merge select */}
+            {renamingTag !== tag.name && (
+              <select
+                className={`${inputClass} shrink-0`}
+                value=""
+                onChange={(e) => void handleMergeSelect(tag.name, e.target.value)}
+                title={t('settings.tags.mergeLabel')}
+              >
+                <option value="">{t('settings.tags.mergeLabel')}</option>
+                {tags
+                  .filter((other) => other.name !== tag.name)
+                  .map((other) => (
+                    <option key={other.name} value={other.name}>
+                      {other.name}
+                    </option>
+                  ))}
+              </select>
+            )}
+
+            {/* Delete */}
+            {renamingTag !== tag.name && (
+              <button
+                type="button"
+                disabled={tag.count > 0}
+                onClick={() => void handleDelete(tag.name)}
+                title={
+                  tag.count > 0
+                    ? t('settings.tags.deleteCannotHint', { count: String(tag.count) })
+                    : t('settings.tags.deleteTitle')
+                }
+                className={`${btnClass} shrink-0`}
+                style={tag.count === 0 ? { color: 'var(--danger)', borderColor: 'var(--danger)' } : undefined}
+              >
+                {t('settings.tags.delete')}
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Merge confirm dialog */}
+      <ConfirmDialog
+        open={mergeConfirm !== null}
+        title={t('settings.tags.mergeConfirmTitle')}
+        message={
+          mergeConfirm
+            ? t('settings.tags.mergeConfirmBody', {
+                count: String(mergeConfirm.count),
+                source: mergeConfirm.source,
+                target: mergeConfirm.target
+              })
+            : ''
+        }
+        confirmLabel={t('settings.tags.mergeConfirmOk')}
+        variant="primary"
+        onConfirm={() => void confirmMerge()}
+        onCancel={() => setMergeConfirm(null)}
+      />
+    </div>
+  )
+}

--- a/src/renderer/src/views/TagManagementView.tsx
+++ b/src/renderer/src/views/TagManagementView.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { useT } from '../contexts/I18nContext'
 import { ConfirmDialog } from '../components/ConfirmDialog'
+import * as Icons from '../components/Icons'
 import { useToastStore } from '../store/toastStore'
 
 interface TagRow {
@@ -233,9 +234,12 @@ export default function TagManagementView(): React.JSX.Element {
                 <button
                   type="button"
                   onClick={() => startRename(tag.name)}
-                  className={btnClass}
+                  className="rounded p-1 hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-indigo-400 transition-colors"
+                  style={{ color: 'var(--text2)' }}
+                  aria-label={t('settings.tags.rename')}
+                  title={t('settings.tags.rename')}
                 >
-                  {t('settings.tags.rename')}
+                  <Icons.Edit />
                 </button>
               )}
             </div>
@@ -270,10 +274,11 @@ export default function TagManagementView(): React.JSX.Element {
                     ? t('settings.tags.deleteCannotHint', { count: String(tag.count) })
                     : t('settings.tags.deleteTitle')
                 }
-                className={`${btnClass} shrink-0`}
-                style={tag.count === 0 ? { color: 'var(--danger)', borderColor: 'var(--danger)' } : undefined}
+                className="rounded p-1 hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-red-400 disabled:cursor-not-allowed disabled:opacity-30 transition-colors shrink-0"
+                style={{ color: 'var(--danger)' }}
+                aria-label={t('settings.tags.delete')}
               >
-                {t('settings.tags.delete')}
+                <Icons.Trash />
               </button>
             )}
           </div>

--- a/src/shared/locales/de.ts
+++ b/src/shared/locales/de.ts
@@ -566,6 +566,33 @@ export const de = {
   'analytics.prevMonth': 'Vorheriger Monat',
   'analytics.nextMonth': 'Nächster Monat',
   'analytics.vsLastMonth': 'vs. Vormonat',
+
+  // ── Settings — Tags (v1.12 #107) ──────────────────────────────────────────
+  'settings.nav.tags': 'Tags',
+  'settings.tags.title': 'Tag-Verwaltung',
+  'settings.tags.empty': 'Keine Tags vorhanden. Erstelle deinen ersten Tag.',
+  'settings.tags.newPlaceholder': 'Neuer Tag-Name…',
+  'settings.tags.add': 'Hinzufügen',
+  'settings.tags.rename': 'Umbenennen',
+  'settings.tags.renamePlaceholder': 'Neuer Name…',
+  'settings.tags.renameConfirm': 'Bestätigen',
+  'settings.tags.renameCancel': 'Abbrechen',
+  'settings.tags.mergeLabel': 'Zusammenführen mit →',
+  'settings.tags.mergeSelect': '— Ziel-Tag wählen —',
+  'settings.tags.mergeConfirmTitle': 'Tags zusammenführen',
+  'settings.tags.mergeConfirmBody': '{count} Eintrag/Einträge von \'{source}\' werden in \'{target}\' umgeschrieben. Diese Aktion kann nicht rückgängig gemacht werden.',
+  'settings.tags.mergeConfirmOk': 'Zusammenführen',
+  'settings.tags.delete': 'Löschen',
+  'settings.tags.deleteTitle': 'Tag löschen',
+  'settings.tags.deleteCannotTitle': 'Löschen nicht möglich',
+  'settings.tags.deleteCannotHint': 'Noch {count} Eintrag/Einträge verwenden diesen Tag.',
+  'settings.tags.entries': '{count} Einträge',
+  'settings.tags.entry': '1 Eintrag',
+  'settings.tags.noEntries': '0 Einträge',
+
+  // ── TagInput — closed system (v1.12 #107) ──────────────────────────────────
+  'tags.createOption': "+ '{tag}' erstellen",
+  'tags.manageLink': 'Tags verwalten →',
 } as const
 
 export type TranslationKey = keyof typeof de

--- a/src/shared/locales/en.ts
+++ b/src/shared/locales/en.ts
@@ -558,4 +558,31 @@ export const en: Record<TranslationKey, string> = {
   'analytics.prevMonth': 'Previous month',
   'analytics.nextMonth': 'Next month',
   'analytics.vsLastMonth': 'vs. last month',
+
+  // ── Settings — Tags (v1.12 #107) ──────────────────────────────────────────
+  'settings.nav.tags': 'Tags',
+  'settings.tags.title': 'Tag Management',
+  'settings.tags.empty': 'No tags yet. Create your first tag.',
+  'settings.tags.newPlaceholder': 'New tag name…',
+  'settings.tags.add': 'Add',
+  'settings.tags.rename': 'Rename',
+  'settings.tags.renamePlaceholder': 'New name…',
+  'settings.tags.renameConfirm': 'Confirm',
+  'settings.tags.renameCancel': 'Cancel',
+  'settings.tags.mergeLabel': 'Merge into →',
+  'settings.tags.mergeSelect': '— Select target tag —',
+  'settings.tags.mergeConfirmTitle': 'Merge tags',
+  'settings.tags.mergeConfirmBody': "{count} entries from '{source}' will be rewritten to '{target}'. This action cannot be undone.",
+  'settings.tags.mergeConfirmOk': 'Merge',
+  'settings.tags.delete': 'Delete',
+  'settings.tags.deleteTitle': 'Delete tag',
+  'settings.tags.deleteCannotTitle': 'Cannot delete',
+  'settings.tags.deleteCannotHint': 'Still {count} entries use this tag.',
+  'settings.tags.entries': '{count} entries',
+  'settings.tags.entry': '1 entry',
+  'settings.tags.noEntries': '0 entries',
+
+  // ── TagInput — closed system (v1.12 #107) ─────────────────────────────────
+  'tags.createOption': "+ Create '{tag}'",
+  'tags.manageLink': 'Manage tags →',
 } as const satisfies Record<TranslationKey, string>


### PR DESCRIPTION
## Summary

Implements Issue #107 — centralized tag management.

### Changes

**Database**
- Migration 016: 	ags master registry table (name TEXT PRIMARY KEY)
- Pre-populates from existing ntries.tags via recursive CTE — idempotent (INSERT OR IGNORE), handles the ,tag1,tag2, wire format

**Backend — 	agHandlers.ts**
- getAllTagsWithCount: single scan of entries, aggregate in JS, merge with master list → tags with 0 entries are included
- createTag: validates name (non-empty, ≤50 chars, no comma), fails on duplicate
- enameTag: atomic transaction — checks collision, UPDATE tags, REPLACE in all entry rows; no-op if old === new
- mergeTag: atomic transaction — REPLACE all source entries to target, DELETE source
- deleteTag: guarded — fails with message if count > 0

**19 unit tests** covering all handlers + edge cases (collision, no-op, deleted entries, exact vs. prefix matching)

**API layer**
- ipc.ts: registerTagHandlers
- preload/index.ts + index.d.ts: 5 new methods on window.api.tags

**Frontend — TagManagementView.tsx (new)**
- Alphabetical tag list with entry count
- Inline rename (Enter to confirm, Escape to cancel)
- Merge dropdown → ConfirmDialog with entry count before merge
- Delete button (disabled when count > 0; shows tooltip with count)
- Create form at top

**SettingsView.tsx**
- New 'Tags' nav tab (between 'Daten' and 'Über')

**TagInput.tsx — closed tag system**
- Autocomplete source: 	ags:get-all-with-count (master registry) instead of 	ags:recent
- Free text that doesn't match any known tag → '+ create' option as last dropdown entry
- Selecting 'create' calls 	ags:create IPC, reloads master list, adds tag immediately
- 'Manage tags →' link shown when registry is empty
- Keyboard navigation (ArrowUp/Down, Enter, Tab, Escape, Backspace) unchanged

All 253 tests passing, \pnpm typecheck\ clean.