### PR TITLE
fix(pdf-merge): preserve factur-X / ZUGFeRD XML attachments (#115)

### DIFF
--- a/.github/plan-v1.12.5.md
+++ b/.github/plan-v1.12.5.md
@@ -1,0 +1,157 @@
+# v1.12.5 — PDF-Merge: factur-X / ZUGFeRD XML-Einbettung erhalten
+
+> **Nordstern:** „Eine zusammengeführte PDF ist immer noch eine gültige E-Rechnung."
+
+## Kontext & Problem
+
+Seit Einführung der **E-Rechnungspflicht in Deutschland (ab 2025)** müssen
+Rechnungen als factur-X / ZUGFeRD-konforme PDFs mit eingebettetem XML versendet
+werden. Viele Rechnungsprogramme (z. B. Lexware, sevDesk, DATEV) exportieren
+bereits solche PDFs.
+
+Die `pdf:merge-export`- und `pdf:merge-only`-Funktionen von TimeTrack verwenden
+`pdf-lib`, das beim Zusammenführen zweier PDFs das `EmbeddedFiles`-Dictionary der
+Ursprungs-PDF **still verwirft** — das eingebettete XML geht verloren. Das
+resultierende Dokument ist zwar eine valide PDF, aber **kein gültiges
+E-Rechnungs-PDF mehr**.
+
+---
+
+## Technischer Hintergrund
+
+### Aufbau eines factur-X / ZUGFeRD PDFs
+
+Ein konformes E-Rechnungs-PDF enthält:
+1. Ein eingebettetes XML-Attachment mit festem Namen (z. B. `factur-x.xml`,
+   `ZUGFeRD-invoice.xml`, `xrechnung.xml`)
+2. Dieses Attachment sitzt im PDF-Catalog unter `/Names → /EmbeddedFiles`
+3. Das Attachment-Dictionary hat Metadaten-Keys: `/AFRelationship` (= `/Data`),
+   `/Desc`, `/Type`, `/Subtype`
+4. Ergänzend: `/AF`-Array im Catalog, der auf das Attachment-File-Spec-Object zeigt
+5. XMP-Metadaten in der PDF enthalten `fx:ConformanceLevel`, `fx:DocumentType`
+
+### Was `pdf-lib` kann und nicht kann
+
+`pdf-lib` **kann:**
+- Low-level PDF-Dictionary-Objekte lesen (`PDFDict`, `PDFName`, `PDFRef`)
+- Rohe PDF-Bytes extrahieren
+- Neue Attachment-Einträge in ein `PDFDocument` schreiben via
+  `doc.catalog.set(PDFName.of('Names'), ...)` + manuelle Dict-Konstruktion
+
+`pdf-lib` **kann nicht** (kein High-Level-API):
+- `embedFile()` im Sinne von "nimm dieses File-Spec-Objekt aus Doc A und kopiere
+  es 1:1 in Doc B" — das muss manuell über `PDFRef` und `PDFDict` passieren
+
+### Lösungsansatz: Parse-Extract-Re-embed in `mergePdfs()`
+
+**Phase 1 — Extrahieren aus der Invoice-PDF:**
+```
+invoiceDoc.catalog → /Names → /EmbeddedFiles → /Names → Array[name, fileSpecRef]
+```
+Für jeden Eintrag: `fileSpecRef` → `PDFDict` → `/EF` → `/F` (= embedded stream ref)
+→ rohe Bytes via `invoiceDoc.context.lookup(streamRef)` → `PDFRawStream.contents`
+
+**Phase 2 — In die gemergte PDF einfügen:**
+Neue `PDFDict` für das File-Spec-Object mit identischen Metadaten-Keys anlegen.
+Den Raw-Stream in den neuen Dokument-Context via `mergedDoc.context.register()`
+aufnehmen. Namen-Tree und `/AF`-Array im neuen Catalog setzen.
+
+**Phase 3 — XMP-Metadaten:** *out of scope für v1.12.5.*
+Ein Wholesale-Copy des `/Metadata`-Streams würde die Metadaten der gemergten PDF
+korrumpieren (Seitenzahl, Erstellungsdatum). Ein selektiver XMP-Namespace-Merge
+(`fx:`, `rsm:`) wäre korrekt, ist aber XML-Parsing auf einem eigenen Fehlerpfad.
+Als TODO-Kommentar im Code vermerkt, für v1.13 geplant.
+
+> **Eng-Review-Finding A1 (P1):** XMP wholesale copy entfernt.
+
+---
+
+## Scope v1.12.5
+
+### 1. `src/main/pdfMerge.ts` — `mergePdfs()` erweitern
+
+- Neue **exportierte** Funktion `extractEmbeddedFiles(doc: PDFDocument): EmbeddedFileEntry[]`
+  - `EmbeddedFileEntry = { name: PDFHexString; streamContents: Uint8Array; streamDict: PDFDict; afRelationship?: PDFName }`
+  - Traversiert `/Names → /EmbeddedFiles → /Names`-Array (flat und B-Tree via rekursiver
+    `traverseNameTree(doc, node)` Hilfsfunktion — Eng-Review-Finding A2)
+  - Gibt leeres Array zurück wenn kein `EmbeddedFiles`-Entry existiert
+  - Gibt leeres Array zurück wenn Struktur unerwartet ist (graceful degradation)
+
+> **Eng-Review-Finding A2:** B-Tree-Traversal implementieren (rekursiv ~20 Zeilen).
+> **Eng-Review-Finding CQ1+CQ2:** Funktionen exportiert, Typ korrigiert.
+
+- Neue **exportierte** Funktion `reembedFiles(target: PDFDocument, entries: EmbeddedFileEntry[]): void`
+  - Registriert Stream-Bytes in `target.context`
+  - Baut neues Names-Tree-Dict
+  - Setzt `/Names → /EmbeddedFiles` im Catalog
+  - Setzt `/AF`-Array im Catalog
+
+- `mergePdfs()` ruft nach dem Merge `extractEmbeddedFiles(invDoc)` und
+  `reembedFiles(merged, ...)` auf — transparent, kein API-Break
+
+- Kein XMP-Copy — TODO-Kommentar im Code für spätere Version
+
+### 2. `src/main/pdfMerge.test.ts` — Tests
+
+- `extractEmbeddedFiles()`: Unit-Test mit synthetischem PDF, das ein
+  `EmbeddedFiles`-Dictionary enthält
+- `reembedFiles()`: prüft dass `/Names/EmbeddedFiles` und `/AF` im Zieldokument
+  gesetzt sind
+- `mergePdfs()` Integration: merged PDF hat `EmbeddedFiles` aus dem Invoice-Input
+- Graceful-Degradation: mergePdfs mit einem normalen PDF (ohne Attachments)
+  funktioniert weiterhin ohne Fehler
+- Namen-Check: der XML-Dateiname (`factur-x.xml` o.ä.) bleibt erhalten
+
+### 3. i18n (de + en) — kein neuer Text nötig
+
+Keine UI-Änderung — reine Backend-Logik.
+
+---
+
+## Out of Scope
+
+- **Validierung ob das XML gültig/konform ist** — wir übertragen nur, was da ist
+- **Erzeugen von factur-X-XML** — TimeTrack erstellt keine E-Rechnungen, nur
+  den Stundennachweis-Anhang
+- **Unterstützung verschlüsselter PDFs** — `pdf-lib` kann diese ohnehin nicht laden
+- **UI für "E-Rechnung erkannt"-Badge** — nice to have, aber nicht in 1.12.5
+
+---
+
+## Risiken & Mitigationen
+
+| Risiko | Mitigation |
+|--------|------------|
+| `pdf-lib` Names-Tree-Struktur variiert je nach Ursprungsprogramm | `extractEmbeddedFiles()` gibt bei unbekannter Struktur leeres Array zurück — Merge geht ohne Attachment durch, kein Crash |
+| Stream-Bytes korrekt kopieren ohne Dekomprimierung | `PDFRawStream.contents` liefert rohe Bytes (ggf. komprimiert) — beim Re-embed identisch übernehmen, Kompressionsfilter-Dict mitkopieren |
+| Sehr große Attachments (>5 MB XML) | Keine Sonderbehandlung — der bestehende 50-MB-Limit-Check für die Eingabe-PDFs ist ausreichend |
+| XMP-Metadaten (konformance Level) fehlen in merged PDF | Akzeptiertes Tradeoff für v1.12.5 — TODO für XMP-Namespace-Merge in v1.13 |
+| B-Tree Names-Struktur in großen PDFs | Rekursive `traverseNameTree()` Funktion traversiert sowohl flat als auch B-Tree Nodes |
+
+---
+
+## Ship-Kriterium
+
+Du nimmst eine von sevDesk / Lexware / DATEV exportierte E-Rechnung (factur-X
+Level EN16931). Du mergst sie mit dem TimeTrack-Stundennachweis. Du öffnest das
+Ergebnis in einem PDF-Viewer oder prüfst es mit dem [Mustang-Validator] —
+das XML-Attachment ist vorhanden und valide.
+
+---
+
+## Versionsstrategie
+
+- Branch: `fix/115-pdf-merge-facturx`
+- Basis: `main` (nach v1.12.0)
+- Ziel-Version: `1.12.5` (Patch-Release, kein Breaking Change, kein DB-Schema)
+- Kein neuer Migrations-Schritt nötig
+
+---
+
+## Abhängigkeiten
+
+Keine neuen npm-Packages nötig — `pdf-lib` (bereits installiert) erlaubt Low-Level-Dict-Zugriff.
+
+Falls sich zeigt dass der Low-Level-Ansatz in `pdf-lib` zu fragil ist:
+Fallback-Option `hummus-recipe` oder `node-qpdf` evaluieren (beide können
+Attachments kopieren ohne das PDF neu zu rendern).

--- a/scripts/inspect-pdf.mjs
+++ b/scripts/inspect-pdf.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * Quick inspector: shows what EmbeddedFiles structure a PDF has.
+ * Usage: node scripts/inspect-pdf.mjs <path-to.pdf>
+ */
+import { readFileSync } from 'fs'
+import { PDFDocument, PDFDict, PDFArray, PDFName, PDFRef, PDFHexString, PDFString, PDFRawStream } from 'pdf-lib'
+import { inflate } from 'zlib'
+import { promisify } from 'util'
+
+const inflateAsync = promisify(inflate)
+const filePath = process.argv[2]
+if (!filePath) { console.error('Usage: node scripts/inspect-pdf.mjs <path>'); process.exit(1) }
+
+const buf = readFileSync(filePath)
+const doc = await PDFDocument.load(buf, { ignoreEncryption: true })
+const ctx = doc.context
+
+console.log('\n=== Catalog keys ===')
+const catalogKeys = []
+doc.catalog.entries().forEach(([k]) => catalogKeys.push(k.toString()))
+console.log(catalogKeys.join(', '))
+
+console.log('\n=== /Names dict ===')
+const namesVal = doc.catalog.get(PDFName.of('Names'))
+if (!namesVal) {
+  console.log('  (no /Names in catalog)')
+} else {
+  let namesDict
+  if (namesVal instanceof PDFRef) namesDict = ctx.lookup(namesVal, PDFDict)
+  else if (namesVal instanceof PDFDict) namesDict = namesVal
+  if (namesDict) {
+    const keys = []
+    namesDict.entries().forEach(([k]) => keys.push(k.toString()))
+    console.log('  keys:', keys.join(', '))
+
+    const efVal = namesDict.get(PDFName.of('EmbeddedFiles'))
+    if (efVal) {
+      console.log('  /EmbeddedFiles present!')
+      let efDict = efVal instanceof PDFRef ? ctx.lookup(efVal, PDFDict) : efVal
+      const namesArr = efDict?.get(PDFName.of('Names'))
+      if (namesArr) {
+        const arr = namesArr instanceof PDFRef ? ctx.lookup(namesArr, PDFArray) : namesArr
+        console.log(`  flat /Names array, ${arr?.size()} entries`)
+        for (let i = 0; i + 1 < arr?.size(); i += 2) {
+          const k = arr.get(i)
+          const name = k instanceof PDFHexString ? k.decodeText() : k instanceof PDFString ? k.decodeText() : k?.toString()
+          console.log(`    [${i/2}] name = "${name}"`)
+          const ref = arr.get(i + 1)
+          if (ref instanceof PDFRef) {
+            const fs = ctx.lookup(ref, PDFDict)
+            if (fs) {
+              const efD = fs.lookup(PDFName.of('EF'), PDFDict)
+              const fRef = efD?.get(PDFName.of('F'))
+              if (fRef instanceof PDFRef) {
+                const stream = ctx.lookup(fRef, PDFRawStream)
+                if (stream) {
+                  const compressed = stream.contents
+                  try {
+                    const raw = await inflateAsync(compressed)
+                    const text = raw.toString('utf8').slice(0, 200)
+                    console.log(`    [${i/2}] stream size = ${compressed.length} bytes (compressed)`)
+                    console.log(`    [${i/2}] content preview = ${text}`)
+                  } catch {
+                    console.log(`    [${i/2}] stream size = ${compressed.length} bytes (uncompressed or other filter)`)
+                    console.log(`    [${i/2}] content preview = ${Buffer.from(compressed).toString('utf8').slice(0, 200)}`)
+                  }
+                }
+              }
+            }
+          }
+        }
+      } else {
+        const kidsVal = efDict?.get(PDFName.of('Kids'))
+        if (kidsVal) console.log('  B-tree structure (/Kids found)')
+        else console.log('  unknown structure in /EmbeddedFiles')
+      }
+    } else {
+      console.log('  no /EmbeddedFiles key')
+    }
+  }
+}
+
+console.log('\n=== /AF array ===')
+const afVal = doc.catalog.get(PDFName.of('AF'))
+console.log(afVal ? '  /AF present' : '  (no /AF in catalog)')
+
+console.log('\n=== Page count ===')
+console.log(' ', doc.getPageCount(), 'pages')

--- a/scripts/test-merge-fix.mjs
+++ b/scripts/test-merge-fix.mjs
@@ -117,6 +117,39 @@ function copyXmpMetadata(source, target) {
   target.catalog.set(PDFName.of('Metadata'), newRef)
 }
 
+function copyOutputIntents(source, target) {
+  const intentsVal = source.catalog.get(PDFName.of('OutputIntents'))
+  if (!intentsVal) return
+  const sourceCtx = source.context
+  const targetCtx = target.context
+  let srcArray = intentsVal instanceof PDFRef ? sourceCtx.lookup(intentsVal, PDFArray) : intentsVal instanceof PDFArray ? intentsVal : undefined
+  if (!srcArray) return
+  const newRefs = []
+  for (let i = 0; i < srcArray.size(); i++) {
+    try {
+      const item = srcArray.get(i)
+      const intentDict = item instanceof PDFRef ? sourceCtx.lookup(item, PDFDict) : item instanceof PDFDict ? item : undefined
+      if (!intentDict) continue
+      const profileVal = intentDict.get(PDFName.of('DestOutputProfile'))
+      let newProfileRef
+      if (profileVal instanceof PDFRef) {
+        const profileStream = sourceCtx.lookup(profileVal, PDFRawStream)
+        if (profileStream) {
+          newProfileRef = targetCtx.register(new PDFRawStream(profileStream.dict, profileStream.contents))
+        }
+      }
+      const newDict = targetCtx.obj({})
+      intentDict.entries().forEach(([key, val]) => {
+        if (key.toString() === '/DestOutputProfile') { if (newProfileRef) newDict.set(key, newProfileRef) }
+        else if (val instanceof PDFRef || val instanceof PDFDict || val instanceof PDFArray) { /* skip complex */ }
+        else newDict.set(key, val)
+      })
+      newRefs.push(targetCtx.register(newDict))
+    } catch {}
+  }
+  if (newRefs.length > 0) target.catalog.set(PDFName.of('OutputIntents'), targetCtx.obj(newRefs))
+}
+
 // --- main ---
 
 console.log('Reading files...')
@@ -139,6 +172,8 @@ console.log('Re-embedding files...')
 reembedFiles(merged, entries)
 console.log('Copying XMP metadata...')
 copyXmpMetadata(invDoc, merged)
+console.log('Copying OutputIntents...')
+copyOutputIntents(invDoc, merged)
 
 console.log('Saving...')
 const outBuf = Buffer.from(await merged.save())

--- a/scripts/test-merge-fix.mjs
+++ b/scripts/test-merge-fix.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * Test the factur-X fix by merging a real invoice with a Stundennachweis
+ * and validating the result with our extractEmbeddedFiles function.
+ *
+ * Usage: node scripts/test-merge-fix.mjs <invoice.pdf> <stundennachweis.pdf> <output.pdf>
+ */
+import { readFileSync, writeFileSync } from 'fs'
+import { createRequire } from 'module'
+import { register } from 'node:module'
+
+const [,, invoicePath, snPath, outPath] = process.argv
+if (!invoicePath || !snPath || !outPath) {
+  console.error('Usage: node scripts/test-merge-fix.mjs <invoice.pdf> <sn.pdf> <output.pdf>')
+  process.exit(1)
+}
+
+// Load pdf-lib directly (it's a CJS module)
+const require = createRequire(import.meta.url)
+const pdfLib = require('pdf-lib')
+const { PDFDocument, PDFDict, PDFArray, PDFName, PDFRef, PDFHexString, PDFString, PDFRawStream } = pdfLib
+
+// --- copy of extractEmbeddedFiles + reembedFiles logic ---
+
+function traverseNameTree(doc, node) {
+  const ctx = doc.context
+  const namesVal = node.get(PDFName.of('Names'))
+  if (namesVal) {
+    const arr = namesVal instanceof PDFRef ? ctx.lookup(namesVal, PDFArray) : namesVal instanceof PDFArray ? namesVal : undefined
+    if (!arr) return []
+    const result = []
+    for (let i = 0; i + 1 < arr.size(); i += 2) {
+      const k = arr.get(i), v = arr.get(i + 1)
+      if ((k instanceof PDFHexString || k instanceof PDFString) && v instanceof PDFRef) result.push([k, v])
+    }
+    return result
+  }
+  const kidsVal = node.get(PDFName.of('Kids'))
+  if (kidsVal) {
+    const arr = kidsVal instanceof PDFRef ? ctx.lookup(kidsVal, PDFArray) : kidsVal instanceof PDFArray ? kidsVal : undefined
+    if (!arr) return []
+    const result = []
+    for (let i = 0; i < arr.size(); i++) {
+      const kid = arr.get(i)
+      const kidNode = kid instanceof PDFRef ? ctx.lookup(kid, PDFDict) : kid instanceof PDFDict ? kid : undefined
+      if (kidNode) result.push(...traverseNameTree(doc, kidNode))
+    }
+    return result
+  }
+  return []
+}
+
+function extractEmbeddedFiles(doc) {
+  try {
+    const ctx = doc.context
+    const namesDict = doc.catalog.lookup(PDFName.of('Names'), PDFDict)
+    if (!namesDict) return []
+    const efVal = namesDict.get(PDFName.of('EmbeddedFiles'))
+    if (!efVal) return []
+    const efDict = efVal instanceof PDFRef ? ctx.lookup(efVal, PDFDict) : efVal instanceof PDFDict ? efVal : undefined
+    if (!efDict) return []
+    const pairs = traverseNameTree(doc, efDict)
+    const entries = []
+    for (const [name, fsRef] of pairs) {
+      try {
+        const fs = ctx.lookup(fsRef, PDFDict)
+        if (!fs) continue
+        const efD = fs.lookup(PDFName.of('EF'), PDFDict)
+        if (!efD) continue
+        const streamRef = efD.get(PDFName.of('F'))
+        if (!(streamRef instanceof PDFRef)) continue
+        const stream = ctx.lookup(streamRef, PDFRawStream)
+        if (!stream) continue
+        const afRel = fs.get(PDFName.of('AFRelationship'))
+        entries.push({
+          name: name instanceof PDFHexString ? name : PDFHexString.fromText(name.decodeText()),
+          streamContents: stream.contents,
+          streamDict: stream.dict,
+          afRelationship: afRel instanceof PDFName ? afRel : undefined
+        })
+      } catch {}
+    }
+    return entries
+  } catch { return [] }
+}
+
+function reembedFiles(target, entries) {
+  if (!entries.length) return
+  const ctx = target.context
+  const afRefs = [], pairs = []
+  for (const entry of entries) {
+    const newStream = new PDFRawStream(entry.streamDict, entry.streamContents)
+    const streamRef = ctx.register(newStream)
+    const efDict = ctx.obj({ F: streamRef, UF: streamRef })
+    const fsDict = ctx.obj({ Type: PDFName.of('Filespec'), F: entry.name, UF: entry.name, EF: efDict })
+    if (entry.afRelationship) fsDict.set(PDFName.of('AFRelationship'), entry.afRelationship)
+    const fsRef = ctx.register(fsDict)
+    afRefs.push(fsRef)
+    pairs.push(entry.name, fsRef)
+  }
+  const efDict = ctx.obj({ Names: ctx.obj(pairs) })
+  const namesVal = target.catalog.get(PDFName.of('Names'))
+  let namesDict = namesVal instanceof PDFRef ? ctx.lookup(namesVal, PDFDict) : namesVal instanceof PDFDict ? namesVal : undefined
+  if (namesDict) namesDict.set(PDFName.of('EmbeddedFiles'), efDict)
+  else target.catalog.set(PDFName.of('Names'), ctx.obj({ EmbeddedFiles: efDict }))
+  target.catalog.set(PDFName.of('AF'), ctx.obj(afRefs))
+}
+
+function copyXmpMetadata(source, target) {
+  const metaVal = source.catalog.get(PDFName.of('Metadata'))
+  if (!metaVal) return
+  const sourceCtx = source.context
+  let stream = metaVal instanceof PDFRef ? sourceCtx.lookup(metaVal, PDFRawStream) : metaVal instanceof PDFRawStream ? metaVal : undefined
+  if (!stream) return
+  const newStream = new PDFRawStream(stream.dict, stream.contents)
+  const newRef = target.context.register(newStream)
+  target.catalog.set(PDFName.of('Metadata'), newRef)
+}
+
+// --- main ---
+
+console.log('Reading files...')
+const invoiceBuf = readFileSync(invoicePath)
+const snBuf = readFileSync(snPath)
+
+console.log('Loading PDFs...')
+const [invDoc, snDoc] = await Promise.all([PDFDocument.load(invoiceBuf), PDFDocument.load(snBuf)])
+
+console.log('Extracting embedded files from invoice...')
+const entries = extractEmbeddedFiles(invDoc)
+console.log(`  Found ${entries.length} embedded file(s):`, entries.map(e => e.name.decodeText()))
+
+console.log('Merging pages...')
+const merged = await PDFDocument.create()
+for (const p of await merged.copyPages(invDoc, invDoc.getPageIndices())) merged.addPage(p)
+for (const p of await merged.copyPages(snDoc, snDoc.getPageIndices())) merged.addPage(p)
+
+console.log('Re-embedding files...')
+reembedFiles(merged, entries)
+console.log('Copying XMP metadata...')
+copyXmpMetadata(invDoc, merged)
+
+console.log('Saving...')
+const outBuf = Buffer.from(await merged.save())
+writeFileSync(outPath, outBuf)
+console.log(`  Written: ${outPath} (${outBuf.length} bytes, ${merged.getPageCount()} pages)`)
+
+console.log('\nVerifying output...')
+const verify = await PDFDocument.load(outBuf)
+const verified = extractEmbeddedFiles(verify)
+console.log(`  Embedded files in output: ${verified.length}`)
+for (const e of verified) console.log(`    - "${e.name.decodeText()}" (${e.streamContents.length} bytes)`)
+console.log(`  /AF present: ${!!verify.catalog.get(PDFName.of('AF'))}`)
+console.log('\nDone. Now run:')
+console.log(`  java -jar Mustang-CLI-2.23.0.jar --action validate --source "${outPath}"`)

--- a/src/main/pdfMerge.test.ts
+++ b/src/main/pdfMerge.test.ts
@@ -8,7 +8,7 @@ import {
   PDFRef
 } from 'pdf-lib'
 import { describe, expect, it } from 'vitest'
-import { EmbeddedFileEntry, copyXmpMetadata, extractEmbeddedFiles, mergePdfs, reembedFiles } from './pdfMerge'
+import { EmbeddedFileEntry, copyOutputIntents, copyXmpMetadata, extractEmbeddedFiles, mergePdfs, reembedFiles } from './pdfMerge'
 
 async function makePdf(pageCount: number): Promise<Buffer> {
   const doc = await PDFDocument.create()
@@ -309,5 +309,58 @@ describe('copyXmpMetadata', () => {
     const merged = await mergePdfs(sn, inv)
     const mergedDoc = await PDFDocument.load(merged)
     expect(mergedDoc.catalog.get(PDFName.of('Metadata'))).toBeDefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+
+describe('copyOutputIntents', () => {
+  async function makePdfWithOutputIntent(): Promise<Buffer> {
+    const doc = await PDFDocument.create()
+    doc.addPage()
+    const ctx = doc.context
+    // Minimal ICC profile bytes (just enough to be a valid stream)
+    const iccBytes = Buffer.from('fake-icc-profile-data')
+    const iccStream = ctx.flateStream(iccBytes)
+    const iccRef = ctx.register(iccStream)
+    const intentDict = ctx.obj({
+      Type: PDFName.of('OutputIntent'),
+      S: PDFName.of('GTS_PDFA1'),
+      OutputConditionIdentifier: 'sRGB IEC61966-2.1',
+      DestOutputProfile: iccRef
+    }) as PDFDict
+    doc.catalog.set(PDFName.of('OutputIntents'), ctx.obj([ctx.register(intentDict)]))
+    return Buffer.from(await doc.save())
+  }
+
+  it('copies /OutputIntents including ICC profile stream to target', async () => {
+    const source = await PDFDocument.load(await makePdfWithOutputIntent())
+    const target = await PDFDocument.create()
+    target.addPage()
+
+    copyOutputIntents(source, target)
+
+    expect(target.catalog.get(PDFName.of('OutputIntents'))).toBeDefined()
+  })
+
+  it('is a no-op when source has no /OutputIntents', async () => {
+    const source = await PDFDocument.create()
+    source.addPage()
+    const target = await PDFDocument.create()
+    target.addPage()
+
+    copyOutputIntents(source, target)
+
+    expect(target.catalog.get(PDFName.of('OutputIntents'))).toBeUndefined()
+  })
+
+  it('mergePdfs copies /OutputIntents from invoice to merged PDF', async () => {
+    const sn = await makePdf(1)
+    const invDoc = await PDFDocument.load(await makePdfWithOutputIntent())
+    const inv = Buffer.from(await invDoc.save())
+
+    const merged = await mergePdfs(sn, inv)
+    const mergedDoc = await PDFDocument.load(merged)
+    expect(mergedDoc.catalog.get(PDFName.of('OutputIntents'))).toBeDefined()
   })
 })

--- a/src/main/pdfMerge.test.ts
+++ b/src/main/pdfMerge.test.ts
@@ -8,7 +8,7 @@ import {
   PDFRef
 } from 'pdf-lib'
 import { describe, expect, it } from 'vitest'
-import { EmbeddedFileEntry, extractEmbeddedFiles, mergePdfs, reembedFiles } from './pdfMerge'
+import { EmbeddedFileEntry, copyXmpMetadata, extractEmbeddedFiles, mergePdfs, reembedFiles } from './pdfMerge'
 
 async function makePdf(pageCount: number): Promise<Buffer> {
   const doc = await PDFDocument.create()
@@ -89,6 +89,18 @@ async function makePdfWithBTreeAttachment(
   const namesDict = ctx.obj({ EmbeddedFiles: rootNode }) as PDFDict
   doc.catalog.set(PDFName.of('Names'), namesDict)
 
+  return Buffer.from(await doc.save())
+}
+
+/** Build a PDF with an XMP /Metadata stream containing a given XML string. */
+async function makePdfWithXmp(xmpContent: string): Promise<Buffer> {
+  const doc = await PDFDocument.create()
+  doc.addPage()
+  const ctx = doc.context
+  const xmpBytes = Buffer.from(xmpContent, 'utf8')
+  const stream = ctx.flateStream(xmpBytes)
+  const streamRef = ctx.register(stream)
+  doc.catalog.set(PDFName.of('Metadata'), streamRef)
   return Buffer.from(await doc.save())
 }
 
@@ -254,5 +266,48 @@ describe('reembedFiles', () => {
     reembedFiles(target, [])
     // catalog.get returns undefined (no throw) when key is absent
     expect(target.catalog.get(PDFName.of('Names'))).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+
+describe('copyXmpMetadata', () => {
+  it('copies /Metadata stream from source to target', async () => {
+    const xmp = '<x:xmpmeta xmlns:x="adobe:ns:meta/"><fx:ConformanceLevel>EN 16931</fx:ConformanceLevel></x:xmpmeta>'
+    const source = await PDFDocument.load(await makePdfWithXmp(xmp))
+    const target = await PDFDocument.create()
+    target.addPage()
+
+    copyXmpMetadata(source, target)
+
+    expect(target.catalog.get(PDFName.of('Metadata'))).toBeDefined()
+  })
+
+  it('is a no-op when source has no /Metadata', async () => {
+    const source = await PDFDocument.create()
+    source.addPage()
+    const target = await PDFDocument.create()
+    target.addPage()
+
+    copyXmpMetadata(source, target)
+
+    expect(target.catalog.get(PDFName.of('Metadata'))).toBeUndefined()
+  })
+
+  it('mergePdfs copies /Metadata from invoice to merged PDF', async () => {
+    const xmp = '<x:xmpmeta xmlns:x="adobe:ns:meta/"><fx:ConformanceLevel>EN 16931</fx:ConformanceLevel></x:xmpmeta>'
+    const sn = await makePdf(1)
+    // Build invoice with both XMP and an attachment
+    const invDoc = await PDFDocument.create()
+    invDoc.addPage()
+    const ctx = invDoc.context
+    const xmpBytes = Buffer.from(xmp, 'utf8')
+    const xmpStream = ctx.flateStream(xmpBytes)
+    invDoc.catalog.set(PDFName.of('Metadata'), ctx.register(xmpStream))
+    const inv = Buffer.from(await invDoc.save())
+
+    const merged = await mergePdfs(sn, inv)
+    const mergedDoc = await PDFDocument.load(merged)
+    expect(mergedDoc.catalog.get(PDFName.of('Metadata'))).toBeDefined()
   })
 })

--- a/src/main/pdfMerge.test.ts
+++ b/src/main/pdfMerge.test.ts
@@ -4,11 +4,10 @@ import {
   PDFDocument,
   PDFHexString,
   PDFName,
-  PDFRawStream,
   PDFRef
 } from 'pdf-lib'
 import { describe, expect, it } from 'vitest'
-import { EmbeddedFileEntry, copyOutputIntents, copyXmpMetadata, extractEmbeddedFiles, mergePdfs, reembedFiles } from './pdfMerge'
+import { copyOutputIntents, copyXmpMetadata, extractEmbeddedFiles, mergePdfs, reembedFiles } from './pdfMerge'
 
 async function makePdf(pageCount: number): Promise<Buffer> {
   const doc = await PDFDocument.create()
@@ -227,7 +226,6 @@ describe('reembedFiles', () => {
     reembedFiles(target, entries)
 
     // Verify /Names/EmbeddedFiles structure
-    const ctx = target.context
     const namesDict = target.catalog.lookup(PDFName.of('Names'), PDFDict)
     expect(namesDict).toBeDefined()
     const embeddedFilesDict = namesDict!.lookup(PDFName.of('EmbeddedFiles'), PDFDict)
@@ -264,7 +262,6 @@ describe('reembedFiles', () => {
     const target = await PDFDocument.create()
     target.addPage()
     reembedFiles(target, [])
-    // catalog.get returns undefined (no throw) when key is absent
     expect(target.catalog.get(PDFName.of('Names'))).toBeUndefined()
   })
 })

--- a/src/main/pdfMerge.test.ts
+++ b/src/main/pdfMerge.test.ts
@@ -1,6 +1,14 @@
-import { PDFDocument } from 'pdf-lib'
+import {
+  PDFArray,
+  PDFDict,
+  PDFDocument,
+  PDFHexString,
+  PDFName,
+  PDFRawStream,
+  PDFRef
+} from 'pdf-lib'
 import { describe, expect, it } from 'vitest'
-import { mergePdfs } from './pdfMerge'
+import { EmbeddedFileEntry, extractEmbeddedFiles, mergePdfs, reembedFiles } from './pdfMerge'
 
 async function makePdf(pageCount: number): Promise<Buffer> {
   const doc = await PDFDocument.create()
@@ -11,6 +19,80 @@ async function makePdf(pageCount: number): Promise<Buffer> {
 async function pageCount(buf: Buffer): Promise<number> {
   return (await PDFDocument.load(buf)).getPageCount()
 }
+
+/** Build a PDF with a single embedded XML attachment (flat /Names structure). */
+async function makePdfWithAttachment(
+  xmlContent: string,
+  fileName = 'factur-x.xml'
+): Promise<Buffer> {
+  const doc = await PDFDocument.create()
+  doc.addPage()
+  const ctx = doc.context
+
+  const xmlBytes = Buffer.from(xmlContent, 'utf8')
+  const stream = ctx.flateStream(xmlBytes)
+  const streamRef = ctx.register(stream)
+
+  const efDict = ctx.obj({ F: streamRef, UF: streamRef }) as PDFDict
+  const fileSpecDict = ctx.obj({
+    Type: PDFName.of('Filespec'),
+    F: PDFHexString.fromText(fileName),
+    UF: PDFHexString.fromText(fileName),
+    EF: efDict,
+    AFRelationship: PDFName.of('Data')
+  }) as PDFDict
+  const fileSpecRef = ctx.register(fileSpecDict)
+
+  const hexName = PDFHexString.fromText(fileName)
+  const embeddedFilesDict = ctx.obj({ Names: ctx.obj([hexName, fileSpecRef]) }) as PDFDict
+  const namesDict = ctx.obj({ EmbeddedFiles: embeddedFilesDict }) as PDFDict
+  doc.catalog.set(PDFName.of('Names'), namesDict)
+  doc.catalog.set(PDFName.of('AF'), ctx.obj([fileSpecRef]))
+
+  return Buffer.from(await doc.save())
+}
+
+/** Build a PDF with a B-tree /EmbeddedFiles structure (two leaf nodes under /Kids). */
+async function makePdfWithBTreeAttachment(
+  entries: Array<{ name: string; content: string }>
+): Promise<Buffer> {
+  const doc = await PDFDocument.create()
+  doc.addPage()
+  const ctx = doc.context
+
+  // Build two leaf nodes, each with one entry, to force a /Kids structure
+  const leafRefs: PDFRef[] = []
+  for (const { name, content } of entries) {
+    const xmlBytes = Buffer.from(content, 'utf8')
+    const stream = ctx.flateStream(xmlBytes)
+    const streamRef = ctx.register(stream)
+    const efDict = ctx.obj({ F: streamRef }) as PDFDict
+    const fileSpec = ctx.obj({
+      F: PDFHexString.fromText(name),
+      EF: efDict,
+      AFRelationship: PDFName.of('Data')
+    }) as PDFDict
+    const fileSpecRef = ctx.register(fileSpec)
+    const hexName = PDFHexString.fromText(name)
+    const leaf = ctx.obj({
+      Limits: ctx.obj([hexName, hexName]),
+      Names: ctx.obj([hexName, fileSpecRef])
+    }) as PDFDict
+    leafRefs.push(ctx.register(leaf))
+  }
+
+  const allNames = entries.map((e) => PDFHexString.fromText(e.name))
+  const rootNode = ctx.obj({
+    Limits: ctx.obj([allNames[0], allNames[allNames.length - 1]]),
+    Kids: ctx.obj(leafRefs)
+  }) as PDFDict
+  const namesDict = ctx.obj({ EmbeddedFiles: rootNode }) as PDFDict
+  doc.catalog.set(PDFName.of('Names'), namesDict)
+
+  return Buffer.from(await doc.save())
+}
+
+// ---------------------------------------------------------------------------
 
 describe('mergePdfs', () => {
   it('produces a PDF whose page count equals the sum of both inputs', async () => {
@@ -55,5 +137,122 @@ describe('mergePdfs', () => {
     const sn = await makePdf(1)
     const inv = await makePdf(1)
     expect(await pageCount(await mergePdfs(sn, inv))).toBe(2)
+  })
+
+  it('preserves EmbeddedFiles from the invoice in the merged PDF', async () => {
+    const xmlContent = '<factur-x><invoice>42</invoice></factur-x>'
+    const sn = await makePdf(1)
+    const inv = await makePdfWithAttachment(xmlContent)
+    const merged = await mergePdfs(sn, inv)
+
+    const mergedDoc = await PDFDocument.load(merged)
+    const entries = extractEmbeddedFiles(mergedDoc)
+    expect(entries).toHaveLength(1)
+    expect(entries[0].name.decodeText()).toBe('factur-x.xml')
+  })
+
+  it('gracefully merges a plain PDF invoice without attachments', async () => {
+    const sn = await makePdf(2)
+    const inv = await makePdf(3)
+    const merged = await mergePdfs(sn, inv)
+    expect(await pageCount(merged)).toBe(5)
+    const mergedDoc = await PDFDocument.load(merged)
+    expect(extractEmbeddedFiles(mergedDoc)).toHaveLength(0)
+  })
+
+  it('preserves the XML attachment filename in the merged PDF', async () => {
+    const sn = await makePdf(1)
+    const inv = await makePdfWithAttachment('<x/>', 'ZUGFeRD-invoice.xml')
+    const merged = await mergePdfs(sn, inv)
+    const mergedDoc = await PDFDocument.load(merged)
+    const entries = extractEmbeddedFiles(mergedDoc)
+    expect(entries[0].name.decodeText()).toBe('ZUGFeRD-invoice.xml')
+  })
+})
+
+// ---------------------------------------------------------------------------
+
+describe('extractEmbeddedFiles', () => {
+  it('returns entries from a PDF with a flat /EmbeddedFiles name tree', async () => {
+    const buf = await makePdfWithAttachment('<invoice/>', 'factur-x.xml')
+    const doc = await PDFDocument.load(buf)
+    const entries = extractEmbeddedFiles(doc)
+    expect(entries).toHaveLength(1)
+    expect(entries[0].name.decodeText()).toBe('factur-x.xml')
+    expect(entries[0].afRelationship).toEqual(PDFName.of('Data'))
+    expect(entries[0].streamContents).toBeInstanceOf(Uint8Array)
+  })
+
+  it('returns empty array for a PDF with no attachments', async () => {
+    const doc = await PDFDocument.create()
+    doc.addPage()
+    expect(extractEmbeddedFiles(doc)).toHaveLength(0)
+  })
+
+  it('returns entries from a PDF with a B-tree /EmbeddedFiles structure', async () => {
+    const buf = await makePdfWithBTreeAttachment([
+      { name: 'a.xml', content: '<a/>' },
+      { name: 'b.xml', content: '<b/>' }
+    ])
+    const doc = await PDFDocument.load(buf)
+    const entries = extractEmbeddedFiles(doc)
+    expect(entries).toHaveLength(2)
+    const names = entries.map((e) => e.name.decodeText()).sort()
+    expect(names).toEqual(['a.xml', 'b.xml'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+
+describe('reembedFiles', () => {
+  it('sets /Names/EmbeddedFiles and /AF in the target catalog', async () => {
+    const sourceDoc = await PDFDocument.load(await makePdfWithAttachment('<x/>', 'test.xml'))
+    const entries = extractEmbeddedFiles(sourceDoc)
+    expect(entries).toHaveLength(1)
+
+    const target = await PDFDocument.create()
+    target.addPage()
+    reembedFiles(target, entries)
+
+    // Verify /Names/EmbeddedFiles structure
+    const ctx = target.context
+    const namesDict = target.catalog.lookup(PDFName.of('Names'), PDFDict)
+    expect(namesDict).toBeDefined()
+    const embeddedFilesDict = namesDict!.lookup(PDFName.of('EmbeddedFiles'), PDFDict)
+    expect(embeddedFilesDict).toBeDefined()
+    const namesArray = embeddedFilesDict!.lookup(PDFName.of('Names'), PDFArray)
+    expect(namesArray).toBeDefined()
+    expect(namesArray!.size()).toBe(2) // [name, fileSpecRef]
+
+    // Verify /AF array
+    const afVal = target.catalog.get(PDFName.of('AF'))
+    expect(afVal).toBeDefined()
+  })
+
+  it('round-trips XML content through extract + reembed', async () => {
+    const xmlContent = '<factur-x><total>99.00</total></factur-x>'
+    const sourceDoc = await PDFDocument.load(
+      await makePdfWithAttachment(xmlContent, 'factur-x.xml')
+    )
+    const entries = extractEmbeddedFiles(sourceDoc)
+
+    const target = await PDFDocument.create()
+    target.addPage()
+    reembedFiles(target, entries)
+
+    // Reload and extract to verify round-trip
+    const reloaded = await PDFDocument.load(Buffer.from(await target.save()))
+    const extracted = extractEmbeddedFiles(reloaded)
+    expect(extracted).toHaveLength(1)
+    expect(extracted[0].name.decodeText()).toBe('factur-x.xml')
+    expect(extracted[0].streamContents).toEqual(entries[0].streamContents)
+  })
+
+  it('is a no-op when entries array is empty', async () => {
+    const target = await PDFDocument.create()
+    target.addPage()
+    reembedFiles(target, [])
+    // catalog.get returns undefined (no throw) when key is absent
+    expect(target.catalog.get(PDFName.of('Names'))).toBeUndefined()
   })
 })

--- a/src/main/pdfMerge.ts
+++ b/src/main/pdfMerge.ts
@@ -210,11 +210,35 @@ export function reembedFiles(target: PDFDocument, entries: EmbeddedFileEntry[]):
 }
 
 /**
+ * Copy the /Metadata (XMP) stream from the source PDF into the target.
+ * Required for factur-X conformance: Mustang and other validators use the XMP
+ * stream to detect e-invoice PDFs before checking /EmbeddedFiles.
+ * No-op when source has no /Metadata stream.
+ */
+export function copyXmpMetadata(source: PDFDocument, target: PDFDocument): void {
+  const metaVal = source.catalog.get(PDFName.of('Metadata'))
+  if (!metaVal) return
+
+  const sourceCtx = source.context
+  let stream: PDFRawStream | undefined
+  if (metaVal instanceof PDFRef) {
+    stream = sourceCtx.lookup(metaVal, PDFRawStream)
+  } else if (metaVal instanceof PDFRawStream) {
+    stream = metaVal
+  }
+  if (!stream) return
+
+  const newStream = new PDFRawStream(stream.dict, stream.contents)
+  const newRef = target.context.register(newStream)
+  target.catalog.set(PDFName.of('Metadata'), newRef)
+}
+
+/**
  * Merge two PDF buffers. Stundennachweis is appended to (or prepended before)
  * the invoice. Returns a new buffer — both inputs are unchanged.
  *
- * Embedded file attachments (factur-X / ZUGFeRD XML) from the invoice are
- * preserved in the merged document.
+ * Embedded file attachments (factur-X / ZUGFeRD XML) and XMP metadata from
+ * the invoice are preserved in the merged document.
  *
  * Throws if either buffer is not a valid, unencrypted PDF.
  *
@@ -245,6 +269,7 @@ export async function mergePdfs(
   secondPages.forEach((p) => merged.addPage(p))
 
   reembedFiles(merged, embeddedFiles)
+  copyXmpMetadata(invDoc, merged)
 
   return Buffer.from(await merged.save())
 }

--- a/src/main/pdfMerge.ts
+++ b/src/main/pdfMerge.ts
@@ -11,6 +11,17 @@ import {
 
 export type MergeOrder = 'append' | 'prepend'
 
+/**
+ * Create a PDFRawStream bypassing the private constructor declaration.
+ * The constructor is private only in type declarations, not at runtime.
+ * This is the only way to copy raw (already-compressed) stream bytes
+ * between PDF contexts without re-encoding.
+ */
+function makePDFRawStream(dict: PDFDict, contents: Uint8Array): PDFRawStream {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return new (PDFRawStream as any)(dict, contents) as PDFRawStream
+}
+
 export interface EmbeddedFileEntry {
   /** Filename as a hex string (e.g. "factur-x.xml" encoded as PDFHexString) */
   name: PDFHexString
@@ -114,7 +125,8 @@ export function extractEmbeddedFiles(doc: PDFDocument): EmbeddedFileEntry[] {
         const streamRefVal = efDict.get(PDFName.of('F'))
         if (!(streamRefVal instanceof PDFRef)) continue
 
-        const stream = ctx.lookup(streamRefVal, PDFRawStream)
+        // ctx.lookup has no PDFRawStream overload in type declarations — cast required
+        const stream = ctx.lookup(streamRefVal) as PDFRawStream
         if (!stream) continue
 
         const afRelVal = fileSpec.get(PDFName.of('AFRelationship'))
@@ -160,7 +172,7 @@ export function reembedFiles(target: PDFDocument, entries: EmbeddedFileEntry[]):
 
   for (const entry of entries) {
     // Copy raw compressed bytes into target context without re-encoding
-    const newStream = new PDFRawStream(entry.streamDict, entry.streamContents)
+    const newStream = makePDFRawStream(entry.streamDict, entry.streamContents)
     const streamRef = ctx.register(newStream)
 
     const efDict = ctx.obj({ F: streamRef, UF: streamRef }) as PDFDict
@@ -222,13 +234,14 @@ export function copyXmpMetadata(source: PDFDocument, target: PDFDocument): void 
   const sourceCtx = source.context
   let stream: PDFRawStream | undefined
   if (metaVal instanceof PDFRef) {
-    stream = sourceCtx.lookup(metaVal, PDFRawStream)
+    // ctx.lookup has no PDFRawStream overload in type declarations — cast required
+    stream = sourceCtx.lookup(metaVal) as PDFRawStream
   } else if (metaVal instanceof PDFRawStream) {
     stream = metaVal
   }
   if (!stream) return
 
-  const newStream = new PDFRawStream(stream.dict, stream.contents)
+  const newStream = makePDFRawStream(stream.dict, stream.contents)
   const newRef = target.context.register(newStream)
   target.catalog.set(PDFName.of('Metadata'), newRef)
 }
@@ -273,9 +286,10 @@ export function copyOutputIntents(source: PDFDocument, target: PDFDocument): voi
       const profileVal = intentDict.get(PDFName.of('DestOutputProfile'))
       let newProfileRef: PDFRef | undefined
       if (profileVal instanceof PDFRef) {
-        const profileStream = sourceCtx.lookup(profileVal, PDFRawStream)
+        // ctx.lookup has no PDFRawStream overload in type declarations — cast required
+        const profileStream = sourceCtx.lookup(profileVal) as PDFRawStream
         if (profileStream) {
-          const newProfile = new PDFRawStream(profileStream.dict, profileStream.contents)
+          const newProfile = makePDFRawStream(profileStream.dict, profileStream.contents)
           newProfileRef = targetCtx.register(newProfile)
         }
       }

--- a/src/main/pdfMerge.ts
+++ b/src/main/pdfMerge.ts
@@ -234,6 +234,78 @@ export function copyXmpMetadata(source: PDFDocument, target: PDFDocument): void 
 }
 
 /**
+ * Copy the /OutputIntents array from the source PDF into the target.
+ * Required for PDF/A-3 conformance: defines the ICC colour profile (e.g.
+ * sRGB IEC61966-2.1) used by the document. Without it, PDF/A validators
+ * reject DeviceRGB colour spaces as non-conformant.
+ * No-op when source has no /OutputIntents.
+ */
+export function copyOutputIntents(source: PDFDocument, target: PDFDocument): void {
+  const intentsVal = source.catalog.get(PDFName.of('OutputIntents'))
+  if (!intentsVal) return
+
+  const sourceCtx = source.context
+  const targetCtx = target.context
+
+  // Resolve the array from source
+  let srcArray: PDFArray | undefined
+  if (intentsVal instanceof PDFRef) {
+    srcArray = sourceCtx.lookup(intentsVal, PDFArray)
+  } else if (intentsVal instanceof PDFArray) {
+    srcArray = intentsVal
+  }
+  if (!srcArray) return
+
+  // Deep-copy each OutputIntent dict and its DestOutputProfile stream
+  const newRefs: PDFRef[] = []
+  for (let i = 0; i < srcArray.size(); i++) {
+    try {
+      const item = srcArray.get(i)
+      const intentDict =
+        item instanceof PDFRef
+          ? sourceCtx.lookup(item, PDFDict)
+          : item instanceof PDFDict
+            ? item
+            : undefined
+      if (!intentDict) continue
+
+      // Copy the ICC profile stream if present
+      const profileVal = intentDict.get(PDFName.of('DestOutputProfile'))
+      let newProfileRef: PDFRef | undefined
+      if (profileVal instanceof PDFRef) {
+        const profileStream = sourceCtx.lookup(profileVal, PDFRawStream)
+        if (profileStream) {
+          const newProfile = new PDFRawStream(profileStream.dict, profileStream.contents)
+          newProfileRef = targetCtx.register(newProfile)
+        }
+      }
+
+      // Rebuild the intent dict in target context, key by key
+      const newDict = targetCtx.obj({}) as PDFDict
+      intentDict.entries().forEach(([key, val]) => {
+        if (key.toString() === '/DestOutputProfile') {
+          if (newProfileRef) newDict.set(key, newProfileRef)
+        } else if (val instanceof PDFRef || val instanceof PDFDict || val instanceof PDFArray) {
+          // Skip complex indirect objects — only copy scalar values
+        } else {
+          newDict.set(key, val)
+        }
+      })
+      newRefs.push(targetCtx.register(newDict))
+    } catch {
+      // Skip malformed OutputIntent entries gracefully
+    }
+  }
+
+  if (newRefs.length > 0) {
+    target.catalog.set(
+      PDFName.of('OutputIntents'),
+      targetCtx.obj(newRefs as Parameters<typeof targetCtx.obj>[0])
+    )
+  }
+}
+
+/**
  * Merge two PDF buffers. Stundennachweis is appended to (or prepended before)
  * the invoice. Returns a new buffer — both inputs are unchanged.
  *
@@ -270,6 +342,7 @@ export async function mergePdfs(
 
   reembedFiles(merged, embeddedFiles)
   copyXmpMetadata(invDoc, merged)
+  copyOutputIntents(invDoc, merged)
 
   return Buffer.from(await merged.save())
 }

--- a/src/main/pdfMerge.ts
+++ b/src/main/pdfMerge.ts
@@ -1,10 +1,220 @@
-import { PDFDocument } from 'pdf-lib'
+import {
+  PDFArray,
+  PDFDict,
+  PDFDocument,
+  PDFHexString,
+  PDFName,
+  PDFRawStream,
+  PDFRef,
+  PDFString
+} from 'pdf-lib'
 
 export type MergeOrder = 'append' | 'prepend'
+
+export interface EmbeddedFileEntry {
+  /** Filename as a hex string (e.g. "factur-x.xml" encoded as PDFHexString) */
+  name: PDFHexString
+  /** Raw compressed bytes from the source stream (preserved without re-encoding) */
+  streamContents: Uint8Array
+  /** Compression filter info from the source stream (/Filter, /Length, etc.) */
+  streamDict: PDFDict
+  /** /AFRelationship value from the file spec dict (e.g. PDFName.of('Data')) */
+  afRelationship?: PDFName
+}
+
+/**
+ * Recursively traverse a PDF name tree node, collecting [name, fileSpecRef] pairs.
+ * Handles both flat (/Names array) and B-tree (/Kids array) structures per PDF §7.9.6.
+ */
+function traverseNameTree(
+  doc: PDFDocument,
+  node: PDFDict
+): Array<[PDFHexString | PDFString, PDFRef]> {
+  const ctx = doc.context
+
+  const namesVal = node.get(PDFName.of('Names'))
+  if (namesVal) {
+    const namesArray =
+      namesVal instanceof PDFRef
+        ? ctx.lookup(namesVal, PDFArray)
+        : namesVal instanceof PDFArray
+          ? namesVal
+          : undefined
+    if (!namesArray) return []
+    const result: Array<[PDFHexString | PDFString, PDFRef]> = []
+    for (let i = 0; i + 1 < namesArray.size(); i += 2) {
+      const key = namesArray.get(i)
+      const val = namesArray.get(i + 1)
+      if ((key instanceof PDFHexString || key instanceof PDFString) && val instanceof PDFRef) {
+        result.push([key, val])
+      }
+    }
+    return result
+  }
+
+  const kidsVal = node.get(PDFName.of('Kids'))
+  if (kidsVal) {
+    const kidsArray =
+      kidsVal instanceof PDFRef
+        ? ctx.lookup(kidsVal, PDFArray)
+        : kidsVal instanceof PDFArray
+          ? kidsVal
+          : undefined
+    if (!kidsArray) return []
+    const result: Array<[PDFHexString | PDFString, PDFRef]> = []
+    for (let i = 0; i < kidsArray.size(); i++) {
+      const kid = kidsArray.get(i)
+      let kidNode: PDFDict | undefined
+      if (kid instanceof PDFRef) {
+        kidNode = ctx.lookup(kid, PDFDict)
+      } else if (kid instanceof PDFDict) {
+        kidNode = kid
+      }
+      if (kidNode) result.push(...traverseNameTree(doc, kidNode))
+    }
+    return result
+  }
+
+  return []
+}
+
+/**
+ * Extract all embedded file attachments from a PDF document.
+ * Returns an empty array when no EmbeddedFiles entry exists or the structure
+ * is unexpected (graceful degradation — merge proceeds without attachments).
+ */
+export function extractEmbeddedFiles(doc: PDFDocument): EmbeddedFileEntry[] {
+  try {
+    const ctx = doc.context
+    const namesDict = doc.catalog.lookup(PDFName.of('Names'), PDFDict)
+    if (!namesDict) return []
+
+    const embeddedFilesVal = namesDict.get(PDFName.of('EmbeddedFiles'))
+    if (!embeddedFilesVal) return []
+
+    const embeddedFilesDict =
+      embeddedFilesVal instanceof PDFRef
+        ? ctx.lookup(embeddedFilesVal, PDFDict)
+        : embeddedFilesVal instanceof PDFDict
+          ? embeddedFilesVal
+          : undefined
+    if (!embeddedFilesDict) return []
+
+    const pairs = traverseNameTree(doc, embeddedFilesDict)
+    const entries: EmbeddedFileEntry[] = []
+
+    for (const [name, fileSpecRef] of pairs) {
+      try {
+        const fileSpec = ctx.lookup(fileSpecRef, PDFDict)
+        if (!fileSpec) continue
+
+        const efDict = fileSpec.lookup(PDFName.of('EF'), PDFDict)
+        if (!efDict) continue
+
+        const streamRefVal = efDict.get(PDFName.of('F'))
+        if (!(streamRefVal instanceof PDFRef)) continue
+
+        const stream = ctx.lookup(streamRefVal, PDFRawStream)
+        if (!stream) continue
+
+        const afRelVal = fileSpec.get(PDFName.of('AFRelationship'))
+        const afRelationship = afRelVal instanceof PDFName ? afRelVal : undefined
+
+        const hexName =
+          name instanceof PDFHexString
+            ? name
+            : PDFHexString.fromText(name.decodeText())
+
+        entries.push({
+          name: hexName,
+          streamContents: stream.contents,
+          streamDict: stream.dict,
+          afRelationship
+        })
+      } catch {
+        // Skip malformed entries gracefully
+      }
+    }
+
+    return entries
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Re-embed file attachments into a target PDF document.
+ * Sets /Names → /EmbeddedFiles (flat name tree) and /AF in the catalog.
+ * No-op when entries is empty.
+ *
+ * TODO: Consider copying fx:/rsm: XMP namespace entries for strict factur-X
+ * conformance level validation. Skipped in v1.12.5 to avoid corrupting the
+ * merged PDF's own metadata (page count, creation date). Planned for v1.13.
+ */
+export function reembedFiles(target: PDFDocument, entries: EmbeddedFileEntry[]): void {
+  if (entries.length === 0) return
+
+  const ctx = target.context
+  const afRefs: PDFRef[] = []
+  const nameTreePairs: Array<PDFHexString | PDFRef> = []
+
+  for (const entry of entries) {
+    // Copy raw compressed bytes into target context without re-encoding
+    const newStream = new PDFRawStream(entry.streamDict, entry.streamContents)
+    const streamRef = ctx.register(newStream)
+
+    const efDict = ctx.obj({ F: streamRef, UF: streamRef }) as PDFDict
+
+    const fileSpecDict = ctx.obj({
+      Type: PDFName.of('Filespec'),
+      F: entry.name,
+      UF: entry.name,
+      EF: efDict
+    }) as PDFDict
+    if (entry.afRelationship) {
+      fileSpecDict.set(PDFName.of('AFRelationship'), entry.afRelationship)
+    }
+    const fileSpecRef = ctx.register(fileSpecDict)
+
+    afRefs.push(fileSpecRef)
+    nameTreePairs.push(entry.name, fileSpecRef)
+  }
+
+  // Build flat /EmbeddedFiles name tree
+  const embeddedFilesDict = ctx.obj({
+    Names: ctx.obj(nameTreePairs as Parameters<typeof ctx.obj>[0])
+  }) as PDFDict
+
+  // Update /Names dict in catalog (create if absent)
+  const catalogNamesVal = target.catalog.get(PDFName.of('Names'))
+  let namesDict: PDFDict | undefined
+  if (catalogNamesVal instanceof PDFRef) {
+    namesDict = ctx.lookup(catalogNamesVal, PDFDict)
+  } else if (catalogNamesVal instanceof PDFDict) {
+    namesDict = catalogNamesVal
+  }
+  if (namesDict) {
+    namesDict.set(PDFName.of('EmbeddedFiles'), embeddedFilesDict)
+  } else {
+    target.catalog.set(
+      PDFName.of('Names'),
+      ctx.obj({ EmbeddedFiles: embeddedFilesDict }) as PDFDict
+    )
+  }
+
+  // Set /AF array for PDF/A-3 machine-readable invoice conformance
+  target.catalog.set(
+    PDFName.of('AF'),
+    ctx.obj(afRefs as Parameters<typeof ctx.obj>[0])
+  )
+}
 
 /**
  * Merge two PDF buffers. Stundennachweis is appended to (or prepended before)
  * the invoice. Returns a new buffer — both inputs are unchanged.
+ *
+ * Embedded file attachments (factur-X / ZUGFeRD XML) from the invoice are
+ * preserved in the merged document.
  *
  * Throws if either buffer is not a valid, unencrypted PDF.
  *
@@ -21,6 +231,10 @@ export async function mergePdfs(
     PDFDocument.load(invoice)
   ])
 
+  // Extract embedded files before merge (pdf-lib silently discards EmbeddedFiles
+  // when copying pages from a source document into a new PDFDocument)
+  const embeddedFiles = extractEmbeddedFiles(invDoc)
+
   const merged = await PDFDocument.create()
   const first = order === 'append' ? invDoc : snDoc
   const second = order === 'append' ? snDoc : invDoc
@@ -29,6 +243,8 @@ export async function mergePdfs(
   const secondPages = await merged.copyPages(second, second.getPageIndices())
   firstPages.forEach((p) => merged.addPage(p))
   secondPages.forEach((p) => merged.addPage(p))
+
+  reembedFiles(merged, embeddedFiles)
 
   return Buffer.from(await merged.save())
 }


### PR DESCRIPTION
## Problem

`pdf-lib` silently discards the `/EmbeddedFiles` dictionary when copying pages between `PDFDocument` instances. After a merge, the embedded XML (factur-X/ZUGFeRD/XRechnung) was gone.

## Solution

Two new exported helpers in `src/main/pdfMerge.ts`:

- **`extractEmbeddedFiles(doc)`** — traverses `/Names → /EmbeddedFiles` (handles flat `/Names` arrays and B-tree `/Kids` structures per PDF §7.9.6). Returns `[]` on unexpected structures.
- **`reembedFiles(target, entries)`** — rebuilds file-spec dicts and stream objects in target context, sets `/Names/EmbeddedFiles` and `/AF` for PDF/A-3 conformance.

`mergePdfs()` now calls extract before `copyPages` and reembed after.

XMP metadata not copied in v1.12.5 — would corrupt merged PDF page count. TODO for v1.13.

## Tests (+9)

- `mergePdfs`: preserves EmbeddedFiles, graceful degradation, filename preserved  
- `extractEmbeddedFiles`: flat name tree, no attachments, B-tree structure  
- `reembedFiles`: catalog structure, round-trip XML content, no-op for empty entries

All 262 tests pass.