### PR TITLE
hotfix: v1.13.1 — mini widget crash fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to TimeTrack are documented here.
 
+## [1.13.1] — 2026-05-29
+
+### Fixed
+
+- **Mini-Widget startete nicht mehr** — Beim Öffnen des Mini-Widgets crashte der Renderer mit `useSettings must be used within a SettingsProvider`. Ursache: Seit v1.12 (#106) liest der `I18nProvider` die Sprache aus dem zentralen `SettingsProvider`, der Einstiegspunkt des Mini-Widgets (`mini.tsx`) hatte den `SettingsProvider` aber nie nachgezogen. Mini-Widget ist jetzt wieder benutzbar.
+
 ## [1.13.0] — 2026-05-29
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "time-tracking",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Schlanker Desktop-Zeiterfasser für Windows — Toggl-Track-Style, lokal, ohne Cloud.",
   "main": "./out/main/index.js",
   "author": "skoedr",

--- a/src/renderer/src/mini.tsx
+++ b/src/renderer/src/mini.tsx
@@ -3,12 +3,15 @@ import './assets/main.css'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import MiniApp from './MiniApp'
+import { SettingsProvider } from './contexts/SettingsContext'
 import { I18nProvider } from './contexts/I18nContext'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <I18nProvider>
-      <MiniApp />
-    </I18nProvider>
+    <SettingsProvider>
+      <I18nProvider>
+        <MiniApp />
+      </I18nProvider>
+    </SettingsProvider>
   </StrictMode>
 )


### PR DESCRIPTION
hotfix: v1.13.1 — mini widget crash fix

## Was war kaputt

Beim Öffnen des Mini-Widgets crashte der Renderer sofort mit:
```
Uncaught Error: useSettings must be used within a SettingsProvider
An error occurred in the <I18nProvider> component.
```

## Root cause

Seit v1.12 (#106, zentrale Settings) liest `I18nProvider` die Sprache aus dem `SettingsProvider`. `main.tsx` wickelt das korrekt ein — `mini.tsx` aber nicht. Dort stand seit v1.0 nur:

```tsx
<I18nProvider>
  <MiniApp />
</I18nProvider>
```

Solange `I18nProvider` autark war, ging das. Seit v1.12 nicht mehr — der Bug ist aber erst jetzt aufgefallen, weil das Mini-Widget selten frisch gestartet wird.

## Fix

`mini.tsx` zieht jetzt `SettingsProvider` außen herum, analog `main.tsx`.

## Test

- 283 tests passed, 170 skipped (DB-native ohne Binding lokal)
- Lokal verifiziert: Mini-Widget öffnet sich ohne Crash

Closes #—  (kein Issue, intern entdeckt direkt nach v1.13.0)
