### PR TITLE
feat: MCP Write-Mode (abgesichert) + Release v1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@ All notable changes to TimeTrack are documented here.
 
 ## [Unreleased]
 
+## [1.14.0] — 2026-07-24
+
 ### Added
 
-- **MCP-Server (read-only)** — TimeTrack stellt einen [Model-Context-Protocol](https://modelcontextprotocol.io)-Server über stdio bereit, mit dem Werkzeuge wie Claude Code die lokale Zeiterfassung **auslesen** können: `list_clients`, `list_projects`, `list_entries` (Monat oder Datumsspanne, Filter nach Kunde/Projekt/Tag), `get_running_timer`, `get_dashboard` und `get_analytics`. Die Datenbank wird strikt schreibgeschützt geöffnet — es existieren keine Schreib-Tools. Stundensätze/Umsätze und interne Notizen sind standardmäßig ausgeblendet und lassen sich in der App (siehe unten) oder per Umgebungsvariable (`TIMETRACK_MCP_EXPOSE_RATES`, `TIMETRACK_MCP_EXPOSE_PRIVATE_NOTES`) einschalten. Build via `pnpm build:mcp`, Start via `pnpm mcp`; Registrierung und Native-ABI-Hinweise siehe README → „MCP-Integration". Der abgesicherte Schreibpfad ist als separates Opt-in-Feature geplant.
+- **MCP-Server (Lesen + Schreiben)** — TimeTrack stellt einen [Model-Context-Protocol](https://modelcontextprotocol.io)-Server über stdio bereit, mit dem Werkzeuge wie Claude Code die lokale Zeiterfassung nutzen können. **Lesen** (read-only, direkt auf der DB): `list_clients`, `list_projects`, `list_entries` (Monat oder Datumsspanne, Filter nach Kunde/Projekt/Tag), `get_running_timer`, `get_dashboard`, `get_analytics`. Stundensätze/Umsätze und interne Notizen sind standardmäßig ausgeblendet und lassen sich in der App oder per Umgebungsvariable (`TIMETRACK_MCP_EXPOSE_RATES`, `TIMETRACK_MCP_EXPOSE_PRIVATE_NOTES`) einschalten. Build via `pnpm build:mcp`, Start via `pnpm mcp`; Registrierung und Native-ABI-Hinweise siehe README → „MCP-Integration".
 
-- **Einstellungen → Integrationen** — Neues Settings-Submenü als Einstiegspunkt für die MCP-Integration: zeigt den Datenbank-Pfad und die kopierbare `.mcp.json`-Registrierung für Claude Code, bietet Schalter für „Stundensätze/Umsätze einblenden" und „Interne Notizen einblenden" (persistiert in der DB, vom Server pro Anfrage berücksichtigt) und einen — vorerst ausgegrauten — Schalter für den späteren, abgesicherten Schreibzugriff.
+- **MCP-Write-Mode** — Optionaler, standardmäßig deaktivierter Schreibzugriff: Claude kann Einträge nachtragen/ändern und Timer starten/stoppen (`create_manual_entry`, `update_entry_fields`, `start_timer`, `stop_running_timer`). Sicherheit steht im Vordergrund: Schreiben läuft **nie** direkt in die DB, sondern über einen lokalen, tokengesicherten Socket an die **laufende App**, die es durch ihre validierte Logik ausführt (Cross-Midnight-Split, Overlap-Prüfung usw.). Abgesichert durch Opt-in, Token (mode 0600, Rotation je App-Start), Allowlist, Vorschau (`preview`), ein **Pre-Write-Backup** je Sitzung und ein Append-only-**Audit-Log** (`mcp-writes.log`). Bestätigung pro Schreibaktion wählbar (bei jeder Änderung / einmal pro Sitzung / nie).
+
+- **Einstellungen → Integrationen** — Neues Settings-Submenü als Einstiegspunkt für die MCP-Integration: zeigt den Datenbank-Pfad und die kopierbare `.mcp.json`-Registrierung für Claude Code, bietet Schalter für „Stundensätze/Umsätze einblenden" und „Interne Notizen einblenden" sowie den **Schreibzugriff-Schalter** mit **Bestätigungs-Modus-Auswahl** und „Audit-Log öffnen".
 
 ## [1.13.2] — 2026-07-17
 

--- a/README.md
+++ b/README.md
@@ -43,15 +43,15 @@ Vollständige Roadmap: [ROADMAP.md](ROADMAP.md) · Issues: [github.com/skoedr/ti
 
 ## Tech Stack
 
-| Layer | Library |
-|---|---|
-| Shell | Electron 39 |
-| Build | electron-vite 5 |
-| UI | React 19 + TypeScript 5 |
-| Styling | Tailwind CSS 4 |
-| State | Zustand 5 |
-| Database | better-sqlite3 12 |
-| Dates | date-fns 4 |
+| Layer    | Library                 |
+| -------- | ----------------------- |
+| Shell    | Electron 39             |
+| Build    | electron-vite 5         |
+| UI       | React 19 + TypeScript 5 |
+| Styling  | Tailwind CSS 4          |
+| State    | Zustand 5               |
+| Database | better-sqlite3 12       |
+| Dates    | date-fns 4              |
 
 ## Development
 
@@ -142,6 +142,13 @@ Integrationen → Schreibzugriff**. Sicherheitsmodell:
   im Append-only-**Audit-Log** `mcp-writes.log` (Token/interne Notizen werden nie protokolliert).
 
 Empfehlung: Schreib-Tools zuerst mit `preview: true` aufrufen, dann committen.
+
+> **Hinweis zu `TIMETRACK_DB_PATH`:** Socket und Token liegen **neben der DB** der
+> laufenden App. `TIMETRACK_DB_PATH` (der Lese-Override) muss daher auf die **echte DB
+> der laufenden App** zeigen — sonst liest der Server aus der einen DB, während die
+> Schreib-Bridge die App an ihrer eigenen Stelle adressiert. Ohne Override greift auf
+> beiden Seiten der Standardpfad; nur im Dev-Modus (abweichendes `userData`) ist der
+> Override nötig.
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -74,17 +74,18 @@ pnpm test
 pnpm build:win
 ```
 
-## MCP-Integration (read-only)
+## MCP-Integration
 
-TimeTrack ships a **read-only [MCP](https://modelcontextprotocol.io) server** so
-tools like **Claude Code** können die lokale Zeiterfassung auslesen — z. B. „summiere
-meine Stunden für Kunde X im Juni nach Projekt". Der Server öffnet die SQLite-DB
-**strikt schreibgeschützt**; es gibt keine Schreib-Tools. Der abgesicherte Schreibpfad
-ist ein separates, bewusst opt-in gestaltetes Feature (siehe Issues).
+TimeTrack bringt einen **[MCP](https://modelcontextprotocol.io)-Server** mit, damit
+Werkzeuge wie **Claude Code** die lokale Zeiterfassung nutzen können — z. B. „summiere
+meine Stunden für Kunde X im Juni nach Projekt" oder „trag den vergessenen Termin nach".
 
-**Tools:** `list_clients`, `list_projects`, `list_entries` (Monat oder Datumsspanne,
-Filter nach Kunde/Projekt/Tag), `get_running_timer`, `get_dashboard`, `get_analytics`
-(Monatsstunden, optional Umsatz).
+**Lese-Tools** (der Server öffnet die SQLite-DB **strikt schreibgeschützt**): `list_clients`,
+`list_projects`, `list_entries` (Monat oder Datumsspanne, Filter nach Kunde/Projekt/Tag),
+`get_running_timer`, `get_dashboard`, `get_analytics` (Monatsstunden, optional Umsatz).
+
+**Schreib-Tools** (opt-in, siehe unten): `create_manual_entry`, `update_entry_fields`,
+`start_timer`, `stop_running_timer` — jeweils mit `preview: true` für eine Vorschau ohne Commit.
 
 **Bauen & starten:**
 
@@ -123,8 +124,24 @@ Schalter werden pro Anfrage frisch aus der DB gelesen) oder per Umgebungsvariabl
 - `TIMETRACK_MCP_EXPOSE_RATES=1` — Stundensätze und Umsätze einblenden
 - `TIMETRACK_MCP_EXPOSE_PRIVATE_NOTES=1` — interne Notizen einblenden
 
-Das Submenü **Einstellungen → Integrationen** zeigt außerdem den DB-Pfad, die kopierbare
-`.mcp.json`-Registrierung und (ausgegraut) den späteren Schreibzugriff-Schalter.
+Das Submenü **Einstellungen → Integrationen** zeigt außerdem den DB-Pfad und die kopierbare
+`.mcp.json`-Registrierung.
+
+**Schreibzugriff (opt-in, standardmäßig aus).** Aktivierbar unter **Einstellungen →
+Integrationen → Schreibzugriff**. Sicherheitsmodell:
+
+- Der MCP-Server schreibt **nie** direkt in die DB. Schreib-Tools senden über einen lokalen
+  **Named Pipe / Unix-Socket** an die **laufende App**, die die Änderung durch ihre eigene
+  validierte Logik ausführt (Overlap-Prüfung, Cross-Midnight-Split usw.). Ist die App zu, oder
+  Schreiben aus, antworten die Tools mit einer klaren Fehlermeldung.
+- **Token:** Beim Aktivieren erzeugt die App ein Zufallstoken (`<userData>/mcp-write.token`,
+  mode `0600`), das je App-Start rotiert; jede Schreibanfrage muss es tragen.
+- **Bestätigung** je Schreibaktion wählbar: bei jeder Änderung nachfragen (Default), einmal pro
+  Sitzung, oder nicht nachfragen.
+- **Pre-Write-Backup** einmal je Sitzung vor der ersten Änderung; jede ausgeführte Aktion landet
+  im Append-only-**Audit-Log** `mcp-writes.log` (Token/interne Notizen werden nie protokolliert).
+
+Empfehlung: Schreib-Tools zuerst mit `preview: true` aufrufen, dann committen.
 
 ## Releases
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "time-tracking",
-  "version": "1.13.2",
+  "version": "1.14.0",
   "description": "Schlanker Desktop-Zeiterfasser für Windows — Toggl-Track-Style, lokal, ohne Cloud.",
   "main": "./out/main/index.js",
   "author": "skoedr",

--- a/src/main/backup.ts
+++ b/src/main/backup.ts
@@ -1,16 +1,9 @@
 import type Database from 'better-sqlite3'
 import { app } from 'electron'
 import { join, normalize } from 'path'
-import {
-  mkdirSync,
-  existsSync,
-  copyFileSync,
-  readdirSync,
-  statSync,
-  unlinkSync
-} from 'fs'
+import { mkdirSync, existsSync, copyFileSync, readdirSync, statSync, unlinkSync } from 'fs'
 
-export type BackupReason = 'daily' | 'manual' | 'pre-migration'
+export type BackupReason = 'daily' | 'manual' | 'pre-migration' | 'mcp'
 
 export interface BackupInfo {
   filename: string
@@ -60,12 +53,15 @@ function buildFilename(reason: BackupReason, fromVersion?: number): string {
       return `backup-manual-${isoTimestamp()}.sqlite`
     case 'pre-migration':
       return `backup-pre-migration-v${fromVersion ?? 0}-${isoTimestamp()}.sqlite`
+    case 'mcp':
+      return `backup-mcp-${isoTimestamp()}.sqlite`
   }
 }
 
 function classify(filename: string): BackupReason | null {
   if (filename.startsWith('backup-daily-')) return 'daily'
   if (filename.startsWith('backup-manual-')) return 'manual'
+  if (filename.startsWith('backup-mcp-')) return 'mcp'
   if (filename.startsWith('backup-pre-migration-')) return 'pre-migration'
   // Legacy v1.1.0 pre-migration filename.
   if (filename.startsWith('pre-migration-')) return 'pre-migration'
@@ -182,9 +178,9 @@ export async function runDailyBackupIfNeeded(db: Database.Database): Promise<voi
  */
 export function readBackupPathSetting(db: Database.Database): string | undefined {
   try {
-    const row = db
-      .prepare("SELECT value FROM settings WHERE key = 'backup_path'")
-      .get() as { value: string } | undefined
+    const row = db.prepare("SELECT value FROM settings WHERE key = 'backup_path'").get() as
+      | { value: string }
+      | undefined
     return row?.value?.trim() || undefined
   } catch {
     return undefined

--- a/src/main/entryMutations.test.ts
+++ b/src/main/entryMutations.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Tests for the extracted entry-mutation core. Same in-memory-DB approach as
+ * ipc.test.ts / migrations.test.ts; skips when better-sqlite3 can't load.
+ */
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import type Database from 'better-sqlite3'
+import { migrations } from './migrations'
+import {
+  createManualEntry,
+  updateManualEntry,
+  startTimer,
+  stopEntry,
+  stopRunningTimer
+} from './entryMutations'
+
+type DatabaseCtor = new (path: string) => Database.Database
+let DatabaseImpl: DatabaseCtor | null = null
+
+beforeAll(async () => {
+  try {
+    const mod = await import('better-sqlite3')
+    const Ctor = mod.default as unknown as DatabaseCtor
+    const probe = new Ctor(':memory:')
+    probe.close()
+    DatabaseImpl = Ctor
+  } catch {
+    DatabaseImpl = null
+  }
+})
+
+function seed(db: Database.Database): void {
+  db.pragma('foreign_keys = ON')
+  db.exec(
+    `CREATE TABLE schema_version (version INTEGER PRIMARY KEY, name TEXT NOT NULL, applied_at TEXT NOT NULL DEFAULT (datetime('now')))`
+  )
+  for (const m of migrations) {
+    db.transaction(() => {
+      db.exec(m.up)
+      db.prepare('INSERT INTO schema_version (version, name) VALUES (?, ?)').run(m.version, m.name)
+    })()
+  }
+  db.prepare(
+    `INSERT INTO clients (id, name, color, active, rate_cent) VALUES (1,'Acme','#111',1,0)`
+  ).run()
+}
+
+describe('entryMutations', () => {
+  let db: Database.Database
+
+  beforeEach((ctx) => {
+    if (!DatabaseImpl) {
+      ctx.skip()
+      return
+    }
+    db = new DatabaseImpl(':memory:')
+    seed(db)
+  })
+
+  it('createManualEntry inserts a single-day entry', () => {
+    const r = createManualEntry(db, {
+      client_id: 1,
+      description: 'Feature',
+      started_at: '2026-06-10T09:00:00.000Z',
+      stopped_at: '2026-06-10T10:00:00.000Z',
+      tags: ',bug,',
+      reference: 'JIRA-1',
+      billable: 1
+    })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.data.description).toBe('Feature')
+    expect(r.data.link_id).toBeNull()
+    expect(r.data.rounded_min).toBe(60)
+    expect(r.data.tags).toBe(',bug,')
+  })
+
+  it('createManualEntry splits across local midnight into linked halves', () => {
+    // Build local 23:00 → 01:00 next day so it crosses LOCAL midnight in any
+    // timezone while staying under the 24h cap.
+    const start = new Date(2026, 5, 10, 23, 0, 0)
+    const stop = new Date(2026, 5, 11, 1, 0, 0)
+    const r = createManualEntry(db, {
+      client_id: 1,
+      description: 'Nacht',
+      started_at: start.toISOString(),
+      stopped_at: stop.toISOString()
+    })
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.data.link_id).not.toBeNull()
+    const rows = db
+      .prepare(`SELECT * FROM entries WHERE link_id = ?`)
+      .all(r.data.link_id) as Array<{ id: number }>
+    expect(rows.length).toBe(2)
+  })
+
+  it('createManualEntry rejects overlap, bad times, unknown client', () => {
+    createManualEntry(db, {
+      client_id: 1,
+      description: 'A',
+      started_at: '2026-06-10T09:00:00.000Z',
+      stopped_at: '2026-06-10T10:00:00.000Z'
+    })
+    const overlap = createManualEntry(db, {
+      client_id: 1,
+      description: 'B',
+      started_at: '2026-06-10T09:30:00.000Z',
+      stopped_at: '2026-06-10T10:30:00.000Z'
+    })
+    expect(overlap.ok).toBe(false)
+
+    const reversed = createManualEntry(db, {
+      client_id: 1,
+      description: 'C',
+      started_at: '2026-06-12T10:00:00.000Z',
+      stopped_at: '2026-06-12T09:00:00.000Z'
+    })
+    expect(reversed.ok).toBe(false)
+
+    const noClient = createManualEntry(db, {
+      client_id: 999,
+      description: 'D',
+      started_at: '2026-06-13T09:00:00.000Z',
+      stopped_at: '2026-06-13T10:00:00.000Z'
+    })
+    expect(noClient.ok).toBe(false)
+  })
+
+  it('updateManualEntry changes fields and rejects unknown id', () => {
+    const created = createManualEntry(db, {
+      client_id: 1,
+      description: 'Old',
+      started_at: '2026-06-10T09:00:00.000Z',
+      stopped_at: '2026-06-10T10:00:00.000Z'
+    })
+    if (!created.ok) throw new Error('setup failed')
+    const upd = updateManualEntry(db, {
+      id: created.data.id,
+      client_id: 1,
+      description: 'New',
+      started_at: '2026-06-10T09:00:00.000Z',
+      stopped_at: '2026-06-10T11:00:00.000Z',
+      tags: ',x,'
+    })
+    expect(upd.ok).toBe(true)
+    if (!upd.ok) return
+    expect(upd.data.description).toBe('New')
+    expect(upd.data.rounded_min).toBe(120)
+    expect(upd.data.tags).toBe(',x,')
+
+    const bad = updateManualEntry(db, {
+      id: 99999,
+      client_id: 1,
+      description: 'X',
+      started_at: '2026-06-10T09:00:00.000Z',
+      stopped_at: '2026-06-10T10:00:00.000Z'
+    })
+    expect(bad.ok).toBe(false)
+  })
+
+  it('startTimer creates a running entry and stops the previous one', () => {
+    const first = startTimer(db, {
+      client_id: 1,
+      description: 'One',
+      started_at: '2026-06-10T09:00:00.000Z'
+    })
+    expect(first.ok).toBe(true)
+    if (!first.ok) return
+    expect(first.data.stopped_at).toBeNull()
+
+    const second = startTimer(db, {
+      client_id: 1,
+      description: 'Two',
+      started_at: '2026-06-10T10:00:00.000Z'
+    })
+    expect(second.ok).toBe(true)
+    // The first entry must now be stopped.
+    const firstRow = db
+      .prepare(`SELECT stopped_at FROM entries WHERE id = ?`)
+      .get(first.data.id) as {
+      stopped_at: string | null
+    }
+    expect(firstRow.stopped_at).not.toBeNull()
+
+    // Exactly one running entry remains.
+    const running = db
+      .prepare(`SELECT COUNT(*) AS n FROM entries WHERE stopped_at IS NULL`)
+      .get() as {
+      n: number
+    }
+    expect(running.n).toBe(1)
+  })
+
+  it('startTimer rejects unknown client', () => {
+    const r = startTimer(db, {
+      client_id: 42,
+      description: 'x',
+      started_at: '2026-06-10T09:00:00.000Z'
+    })
+    expect(r.ok).toBe(false)
+  })
+
+  it('stopRunningTimer stops the open entry and returns null when none run', () => {
+    expect(stopRunningTimer(db)).toEqual({ ok: true, data: null })
+    startTimer(db, { client_id: 1, description: 'run', started_at: '2026-06-10T09:00:00.000Z' })
+    const stopped = stopRunningTimer(db)
+    expect(stopped.ok).toBe(true)
+    if (!stopped.ok) return
+    expect(stopped.data?.stopped_at).not.toBeNull()
+    // Now nothing runs.
+    expect(stopRunningTimer(db)).toEqual({ ok: true, data: null })
+  })
+
+  it('stopEntry stops a specific entry by id', () => {
+    const started = startTimer(db, {
+      client_id: 1,
+      description: 'run',
+      started_at: '2026-06-10T09:00:00.000Z'
+    })
+    if (!started.ok) throw new Error('setup failed')
+    const r = stopEntry(db, started.data.id)
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.data.stopped_at).not.toBeNull()
+    expect(stopEntry(db, 99999).ok).toBe(false)
+  })
+})

--- a/src/main/entryMutations.ts
+++ b/src/main/entryMutations.ts
@@ -1,0 +1,245 @@
+/**
+ * Entry mutation core — extracted from the `entries:*` IPC handlers so both
+ * the Electron IPC layer (src/main/ipc.ts) and the MCP write bridge
+ * (src/main/mcpBridge.ts) can execute the exact same validated logic.
+ *
+ * Deliberately Electron-free: it takes a better-sqlite3 handle structurally,
+ * imports only `crypto`, the shared midnight-split helper, and shared types.
+ * That keeps it trivially unit-testable against an in-memory DB and safe to
+ * import from a non-Electron context.
+ *
+ * Behaviour is identical to the previous inline handlers: validate the full
+ * un-split range first, then split at local midnight into linked halves
+ * (shared `link_id`), insert in one transaction, and return the first row.
+ */
+import type Database from 'better-sqlite3'
+import { randomUUID } from 'crypto'
+import { splitAtMidnight } from '../shared/midnightSplit'
+import type {
+  Entry,
+  CreateEntryInput,
+  CreateManualEntryInput,
+  UpdateEntryInput,
+  IpcResult
+} from '../shared/types'
+
+// Server-side limits (were module-private constants in ipc.ts).
+export const MAX_DESCRIPTION_LEN = 500
+export const MAX_REFERENCE_LEN = 200
+export const MAX_NOTE_LEN = 1000
+export const MAX_DURATION_SECONDS = 24 * 3600
+
+type Db = Database.Database
+
+function ok<T>(data: T): IpcResult<T> {
+  return { ok: true, data }
+}
+function fail(error: string): IpcResult<never> {
+  return { ok: false, error }
+}
+
+/**
+ * Validate a manual entry's full (un-split) range. Returns a German error
+ * message string, or null when valid. `excludeId` / `excludeLinkId` let the
+ * update path skip the row(s) it's about to replace in the overlap check.
+ */
+export function validateManualEntry(
+  db: Db,
+  input: {
+    client_id: number
+    description: string
+    started_at: string
+    stopped_at: string
+    reference?: string
+    private_note?: string
+  },
+  excludeId?: number,
+  excludeLinkId?: string
+): string | null {
+  const start = new Date(input.started_at)
+  const stop = new Date(input.stopped_at)
+  if (Number.isNaN(start.getTime())) return 'Startzeit ist ungültig'
+  if (Number.isNaN(stop.getTime())) return 'Endzeit ist ungültig'
+  const now = Date.now()
+  if (start.getTime() > now) return 'Startzeit darf nicht in der Zukunft liegen'
+  if (stop.getTime() <= start.getTime()) return 'Endzeit muss nach der Startzeit liegen'
+  const durationSec = (stop.getTime() - start.getTime()) / 1000
+  if (durationSec > MAX_DURATION_SECONDS) return 'Dauer überschreitet 24 Stunden'
+  if ((input.description ?? '').length > MAX_DESCRIPTION_LEN) {
+    return `Beschreibung überschreitet ${MAX_DESCRIPTION_LEN} Zeichen`
+  }
+  if ((input.reference ?? '').length > MAX_REFERENCE_LEN) {
+    return `Referenz überschreitet ${MAX_REFERENCE_LEN} Zeichen`
+  }
+  if ((input.private_note ?? '').length > MAX_NOTE_LEN) {
+    return `Notiz überschreitet ${MAX_NOTE_LEN} Zeichen`
+  }
+  const clientRow = db.prepare(`SELECT id FROM clients WHERE id = ?`).get(input.client_id) as
+    | { id: number }
+    | undefined
+  if (!clientRow) return 'Kunde existiert nicht'
+  // Overlap: any non-deleted entry of the same client whose time range
+  // intersects [start, stop). Two intervals overlap iff
+  //   existing.started_at < stop AND COALESCE(existing.stopped_at, now) > start
+  const params: Array<string | number> = [input.client_id, input.stopped_at, input.started_at]
+  let overlapSql = `SELECT id FROM entries
+                     WHERE client_id = ? AND deleted_at IS NULL
+                       AND started_at < ?
+                       AND COALESCE(stopped_at, datetime('now')) > ?`
+  if (excludeId !== undefined) {
+    overlapSql += ` AND id != ?`
+    params.push(excludeId)
+  }
+  if (excludeLinkId !== undefined) {
+    overlapSql += ` AND (link_id IS NULL OR link_id != ?)`
+    params.push(excludeLinkId)
+  }
+  const overlap = db.prepare(overlapSql).get(...params) as { id: number } | undefined
+  if (overlap) return 'Eintrag überlappt mit einem bestehenden Eintrag desselben Kunden'
+  return null
+}
+
+/**
+ * Insert one or more time segments produced by `splitAtMidnight`. Single
+ * segment → plain insert (link_id stays NULL). Multiple segments → all rows
+ * share a fresh UUID `link_id`. Returns the FIRST inserted row (matching the
+ * user's input.started_at). Caller must have validated the full range first.
+ */
+export function insertEntrySegments(
+  db: Db,
+  input: { client_id: number; description: string },
+  segments: Array<{ start: Date; stop: Date }>,
+  tags = '',
+  reference = '',
+  billable = 1,
+  private_note = '',
+  project_id: number | null = null
+): Entry {
+  const linkId = segments.length > 1 ? randomUUID() : null
+  const description = input.description.trim()
+  const insertStmt = db.prepare(
+    `INSERT INTO entries (client_id, description, started_at, stopped_at, heartbeat_at, rounded_min, link_id, project_id, tags, reference, billable, private_note)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  )
+  const tx = db.transaction((): Entry => {
+    let firstId = 0
+    for (const seg of segments) {
+      const startedAt = seg.start.toISOString()
+      const stoppedAt = seg.stop.toISOString()
+      const info = insertStmt.run(
+        input.client_id,
+        description,
+        startedAt,
+        stoppedAt,
+        stoppedAt,
+        Math.round((seg.stop.getTime() - seg.start.getTime()) / 60000),
+        linkId,
+        project_id,
+        tags,
+        reference,
+        billable,
+        private_note
+      )
+      if (firstId === 0) firstId = Number(info.lastInsertRowid)
+    }
+    return db.prepare(`SELECT * FROM entries WHERE id = ?`).get(firstId) as Entry
+  })
+  return tx()
+}
+
+/** Create a manual (already-stopped) entry. Mirrors the `entries:create` handler. */
+export function createManualEntry(db: Db, input: CreateManualEntryInput): IpcResult<Entry> {
+  const err = validateManualEntry(db, input)
+  if (err) return fail(err)
+  const segments = splitAtMidnight(new Date(input.started_at), new Date(input.stopped_at))
+  const row = insertEntrySegments(
+    db,
+    input,
+    segments,
+    input.tags ?? '',
+    input.reference ?? '',
+    input.billable ?? 1,
+    input.private_note ?? '',
+    input.project_id ?? null
+  )
+  return ok(row)
+}
+
+/** Update an entry (delete-and-reinsert with cross-midnight bookkeeping). Mirrors `entries:update`. */
+export function updateManualEntry(db: Db, input: UpdateEntryInput): IpcResult<Entry> {
+  const existing = db.prepare(`SELECT link_id FROM entries WHERE id = ?`).get(input.id) as
+    | { link_id: string | null }
+    | undefined
+  if (!existing) return fail('Eintrag existiert nicht')
+  const existingLinkId = existing.link_id ?? undefined
+  const err = validateManualEntry(db, input, input.id, existingLinkId)
+  if (err) return fail(err)
+  const segments = splitAtMidnight(new Date(input.started_at), new Date(input.stopped_at))
+  const tx = db.transaction((): Entry => {
+    if (existingLinkId) {
+      db.prepare(`DELETE FROM entries WHERE link_id = ?`).run(existingLinkId)
+    } else {
+      db.prepare(`DELETE FROM entries WHERE id = ?`).run(input.id)
+    }
+    return insertEntrySegments(
+      db,
+      input,
+      segments,
+      input.tags ?? '',
+      input.reference ?? '',
+      input.billable ?? 1,
+      input.private_note ?? '',
+      input.project_id ?? null
+    )
+  })
+  return ok(tx())
+}
+
+/** Start a running timer (stops any running entry first). Mirrors `entries:start`. */
+export function startTimer(db: Db, input: CreateEntryInput): IpcResult<Entry> {
+  const clientRow = db.prepare(`SELECT id FROM clients WHERE id = ?`).get(input.client_id) as
+    | { id: number }
+    | undefined
+  if (!clientRow) return fail('Kunde existiert nicht')
+  const tx = db.transaction((): Entry => {
+    db.prepare(`UPDATE entries SET stopped_at = ? WHERE stopped_at IS NULL`).run(
+      new Date().toISOString()
+    )
+    const info = db
+      .prepare(
+        `INSERT INTO entries (client_id, description, started_at, heartbeat_at, project_id)
+         VALUES (?, ?, ?, ?, ?)`
+      )
+      .run(
+        input.client_id,
+        input.description,
+        input.started_at,
+        input.started_at,
+        input.project_id ?? null
+      )
+    return db.prepare(`SELECT * FROM entries WHERE id = ?`).get(info.lastInsertRowid) as Entry
+  })
+  return ok(tx())
+}
+
+/** Stop a specific entry by id (stamps now). Mirrors `entries:stop`. */
+export function stopEntry(db: Db, id: number): IpcResult<Entry> {
+  const now = new Date().toISOString()
+  db.prepare(`UPDATE entries SET stopped_at = ?, heartbeat_at = ? WHERE id = ?`).run(now, now, id)
+  const row = db.prepare(`SELECT * FROM entries WHERE id = ?`).get(id) as Entry | undefined
+  if (!row) return fail('Eintrag existiert nicht')
+  return ok(row)
+}
+
+/** Stop the currently running timer, if any. Returns null when nothing runs. */
+export function stopRunningTimer(db: Db): IpcResult<Entry | null> {
+  const running = db
+    .prepare(
+      `SELECT id FROM entries WHERE stopped_at IS NULL AND deleted_at IS NULL
+       ORDER BY started_at DESC LIMIT 1`
+    )
+    .get() as { id: number } | undefined
+  if (!running) return ok(null)
+  const res = stopEntry(db, running.id)
+  return res.ok ? ok(res.data) : res
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -18,6 +18,13 @@ import trayRunningIcon from '../../resources/tray-running.png?asset'
 import trayStoppedIcon from '../../resources/tray-stopped.png?asset'
 import { getDb, recoverZombieEntries, MigrationError } from './db'
 import { registerIpcHandlers } from './ipc'
+import {
+  startMcpBridge,
+  stopMcpBridge,
+  generateWriteToken,
+  clearWriteToken,
+  type BridgeDeps
+} from './mcpBridge'
 import { initAutoUpdater } from './updater'
 import { applyMiniEnabled, destroyMini, pushMiniState, toggleMini } from './miniWindow'
 import {
@@ -344,6 +351,29 @@ function createWindow(): void {
   }
 }
 
+/** Dependencies handed to the MCP write bridge (all resolved lazily at call time). */
+function mcpBridgeDeps(): BridgeDeps {
+  return {
+    getDb,
+    refreshTray: () => {
+      refreshActiveClients()
+      tray?.setContextMenu(buildTrayMenu())
+    },
+    broadcast: (channel, payload) => {
+      for (const w of BrowserWindow.getAllWindows()) {
+        if (!w.isDestroyed()) w.webContents.send(channel, payload)
+      }
+    },
+    getMainWindow: () => mainWindow,
+    getSetting: (key) =>
+      (
+        getDb().prepare('SELECT value FROM settings WHERE key = ?').get(key) as
+          | { value: string }
+          | undefined
+      )?.value
+  }
+}
+
 app.whenReady().then(async () => {
   // Lock loser (v1.13.2): app.quit() above is async and ready can fire
   // before the quit lands. Bail out before touching the DB, hotkeys, tray,
@@ -387,11 +417,15 @@ app.whenReady().then(async () => {
           `INSERT INTO entries (client_id, description, started_at, stopped_at)
              VALUES (9999, 'smoke', ?, ?)`
         ).run(startIso, stopIso)
-        const payload = buildPdfPayload(db, {
-          clientId: 9999,
-          fromIso: today,
-          toIso: today
-        }, '')
+        const payload = buildPdfPayload(
+          db,
+          {
+            clientId: 9999,
+            fromIso: today,
+            toIso: today
+          },
+          ''
+        )
         const html = buildPdfHtml(payload)
         const buf = await renderPdfBuffer({ html })
         pdfBytes = buf.length
@@ -477,7 +511,16 @@ app.whenReady().then(async () => {
     setAutoStart: (enabled) => applyAutoStart(enabled),
     setIdleThreshold: (minutes) => setIdleThresholdMinutes(minutes),
     setMiniEnabled: (enabled) => applyMiniEnabled(enabled),
-    setMiniHotkey: (accelerator) => registerMiniHotkey(accelerator)
+    setMiniHotkey: (accelerator) => registerMiniHotkey(accelerator),
+    setMcpWriteEnabled: (enabled) => {
+      if (enabled) {
+        generateWriteToken()
+        startMcpBridge(mcpBridgeDeps())
+      } else {
+        stopMcpBridge()
+        clearWriteToken()
+      }
+    }
   })
   createWindow()
 
@@ -488,6 +531,14 @@ app.whenReady().then(async () => {
   refreshActiveClients()
   configureIdleWatcher({ getWindow: () => mainWindow })
   loadStartupSettings()
+
+  // v1.14 #127 — start the MCP write bridge only when opted in. A fresh token
+  // is minted per app run (rotation); the socket lives on the primary instance
+  // only (this code path is skipped for second-instance / smoke runs above).
+  if (mcpBridgeDeps().getSetting('mcp_write_enabled') === '1') {
+    generateWriteToken()
+    startMcpBridge(mcpBridgeDeps())
+  }
 
   tray = new Tray(trayStoppedIcon)
   updateTray(false, '', 0)
@@ -553,6 +604,7 @@ app.on('will-quit', () => {
   globalShortcut.unregisterAll()
   stopIdleWatcher()
   destroyMini()
+  stopMcpBridge()
 })
 
 app.on('window-all-closed', () => {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -4,11 +4,10 @@ import { dialog } from 'electron'
 import { writeFileSync, readFileSync, mkdirSync, readdirSync } from 'fs'
 import { dirname, join, normalize, resolve, sep } from 'path'
 import log from 'electron-log/main'
-import { randomUUID } from 'crypto'
 import { getDb, getDbPath } from './db'
 import { getBackupsDir, getDefaultBackupsDir, readBackupPathSetting } from './backup'
 import { createBackup, listBackups, restoreBackup as restoreBackupFile } from './backup'
-import { splitAtMidnight } from '../shared/midnightSplit'
+import { createManualEntry, updateManualEntry, startTimer, stopEntry } from './entryMutations'
 import { buildJsonExportPayload } from './jsonExport'
 import { buildPdfHtml, buildPdfPayload, type PdfRequest } from './pdf'
 import { renderPdfBuffer } from './pdfWindow'
@@ -37,11 +36,6 @@ import type {
   LicenseEntry
 } from '../shared/types'
 
-const MAX_DESCRIPTION_LEN = 500
-const MAX_REFERENCE_LEN = 200
-const MAX_NOTE_LEN = 1000
-const MAX_DURATION_SECONDS = 24 * 3600
-
 export interface IpcHooks {
   refreshTrayClients(): void
   setHotkey(accelerator: string): boolean
@@ -49,6 +43,7 @@ export interface IpcHooks {
   setIdleThreshold(minutes: number): void
   setMiniEnabled(enabled: boolean): void
   setMiniHotkey(accelerator: string): boolean
+  setMcpWriteEnabled(enabled: boolean): void
 }
 
 function ok<T>(data: T): IpcResult<T> {
@@ -111,7 +106,9 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
         )
         .run(
-          input.name.trim(), input.color, rate,
+          input.name.trim(),
+          input.color,
+          rate,
           input.billing_address_line1?.trim() ?? null,
           input.billing_address_line2?.trim() ?? null,
           input.billing_address_line3?.trim() ?? null,
@@ -141,7 +138,10 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
            vat_id = ?, contact_person = ?, contact_email = ?
          WHERE id = ?`
       ).run(
-        input.name.trim(), input.color, input.active, rate,
+        input.name.trim(),
+        input.color,
+        input.active,
+        rate,
         input.billing_address_line1?.trim() ?? null,
         input.billing_address_line2?.trim() ?? null,
         input.billing_address_line3?.trim() ?? null,
@@ -172,20 +172,7 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
   // ── Entries ───────────────────────────────────────────────────
   ipcMain.handle('entries:start', (_e, input: CreateEntryInput): IpcResult<Entry> => {
     try {
-      // Stop any currently running entry first
-      db.prepare(`UPDATE entries SET stopped_at = ? WHERE stopped_at IS NULL`).run(
-        new Date().toISOString()
-      )
-      const info = db
-        .prepare(
-          `INSERT INTO entries (client_id, description, started_at, heartbeat_at, project_id)
-           VALUES (?, ?, ?, ?, ?)`
-        )
-        .run(input.client_id, input.description, input.started_at, input.started_at, input.project_id ?? null)
-      const row = db
-        .prepare(`SELECT * FROM entries WHERE id = ?`)
-        .get(info.lastInsertRowid) as Entry
-      return ok(row)
+      return startTimer(db, input)
     } catch (e) {
       return fail(e)
     }
@@ -193,14 +180,7 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
 
   ipcMain.handle('entries:stop', (_e, id: number): IpcResult<Entry> => {
     try {
-      const now = new Date().toISOString()
-      db.prepare(`UPDATE entries SET stopped_at = ?, heartbeat_at = ? WHERE id = ?`).run(
-        now,
-        now,
-        id
-      )
-      const row = db.prepare(`SELECT * FROM entries WHERE id = ?`).get(id) as Entry
-      return ok(row)
+      return stopEntry(db, id)
     } catch (e) {
       return fail(e)
     }
@@ -265,11 +245,7 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
    */
   ipcMain.handle('entries:create', (_e, input: CreateManualEntryInput): IpcResult<Entry> => {
     try {
-      const err = validateManualEntry(db, input)
-      if (err) return fail(err)
-      const segments = splitAtMidnight(new Date(input.started_at), new Date(input.stopped_at))
-      const insertedRow = insertEntrySegments(db, input, segments, input.tags ?? '', input.reference ?? '', input.billable ?? 1, input.private_note ?? '', input.project_id ?? null)
-      return ok(insertedRow)
+      return createManualEntry(db, input)
     } catch (e) {
       return fail(e)
     }
@@ -277,29 +253,7 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
 
   ipcMain.handle('entries:update', (_e, input: UpdateEntryInput): IpcResult<Entry> => {
     try {
-      // Reuse the same validation contract as create. We exclude both the
-      // current row (`input.id`) and any sibling sharing its link_id so the
-      // overlap check doesn't fire against the about-to-be-deleted halves.
-      const existing = db.prepare(`SELECT link_id FROM entries WHERE id = ?`).get(input.id) as
-        | { link_id: string | null }
-        | undefined
-      const existingLinkId = existing?.link_id ?? undefined
-      const err = validateManualEntry(db, input, input.id, existingLinkId ?? undefined)
-      if (err) return fail(err)
-      const segments = splitAtMidnight(new Date(input.started_at), new Date(input.stopped_at))
-      const tx = db.transaction((): Entry => {
-        // Drop the original row + any linked sibling, then re-insert. This
-        // keeps the cross-midnight bookkeeping in one place rather than
-        // distinguishing "edit one half" vs "edit a single-day row".
-        if (existingLinkId) {
-          db.prepare(`DELETE FROM entries WHERE link_id = ?`).run(existingLinkId)
-        } else {
-          db.prepare(`DELETE FROM entries WHERE id = ?`).run(input.id)
-        }
-        return insertEntrySegments(db, input, segments, input.tags ?? '', input.reference ?? '', input.billable ?? 1, input.private_note ?? '', input.project_id ?? null)
-      })
-      const row = tx()
-      return ok(row)
+      return updateManualEntry(db, input)
     } catch (e) {
       return fail(e)
     }
@@ -365,9 +319,7 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
           freq.set(tag, (freq.get(tag) ?? 0) + 1)
         }
       }
-      const sorted = [...freq.entries()]
-        .sort((a, b) => b[1] - a[1])
-        .map(([tag]) => tag)
+      const sorted = [...freq.entries()].sort((a, b) => b[1] - a[1]).map(([tag]) => tag)
       return ok(sorted)
     } catch (e) {
       return fail(e)
@@ -452,15 +404,13 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
     try {
       const err = validateProject(input, db)
       if (err) return fail(err)
-      const current = db
-        .prepare('SELECT client_id FROM projects WHERE id = ?')
-        .get(input.id) as { client_id: number | null } | undefined
+      const current = db.prepare('SELECT client_id FROM projects WHERE id = ?').get(input.id) as
+        | { client_id: number | null }
+        | undefined
       if (!current) return fail('Projekt nicht gefunden')
       if (current.client_id !== input.client_id) {
         const countRow = db
-          .prepare(
-            `SELECT COUNT(*) AS n FROM entries WHERE project_id = ? AND deleted_at IS NULL`
-          )
+          .prepare(`SELECT COUNT(*) AS n FROM entries WHERE project_id = ? AND deleted_at IS NULL`)
           .get(input.id) as { n: number }
         if (countRow.n > 0) {
           return fail(
@@ -514,9 +464,7 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
     try {
       const tx = db.transaction(() => {
         const countRow = db
-          .prepare(
-            `SELECT COUNT(*) AS n FROM entries WHERE project_id = ? AND deleted_at IS NULL`
-          )
+          .prepare(`SELECT COUNT(*) AS n FROM entries WHERE project_id = ? AND deleted_at IS NULL`)
           .get(id) as { n: number }
         if (countRow.n > 0) throw new Error('Projekt hat noch aktive Einträge')
         db.prepare('DELETE FROM projects WHERE id = ?').run(id)
@@ -690,6 +638,8 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
       } else if (key === 'mini_hotkey') {
         const okHotkey = hooks.setMiniHotkey(value)
         if (!okHotkey) return fail(`Hotkey "${value}" konnte nicht registriert werden`)
+      } else if (key === 'mcp_write_enabled') {
+        hooks.setMcpWriteEnabled(value === '1')
       }
       return ok(undefined)
     } catch (e) {
@@ -702,9 +652,9 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
   // Used exclusively by preload to read theme_mode before first paint.
   ipcMain.on('settings:getSync', (event, key: string) => {
     try {
-      const row = db
-        .prepare(`SELECT value FROM settings WHERE key = ?`)
-        .get(key) as { value: string } | undefined
+      const row = db.prepare(`SELECT value FROM settings WHERE key = ?`).get(key) as
+        | { value: string }
+        | undefined
       event.returnValue = row?.value ?? null
     } catch {
       event.returnValue = null
@@ -745,10 +695,7 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
         const configuredPath = getBackupPathSetting()
         const configuredDir = configuredPath ? resolve(configuredPath) : defaultDir
         const resolved = resolve(filePath)
-        if (
-          !resolved.startsWith(defaultDir + sep) &&
-          !resolved.startsWith(configuredDir + sep)
-        ) {
+        if (!resolved.startsWith(defaultDir + sep) && !resolved.startsWith(configuredDir + sep)) {
           return fail('Ungültiger Backup-Pfad')
         }
         const dbPath = getDbPath()
@@ -979,19 +926,22 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
 
   // PDF open dialog: opens a native file picker and returns the selected path.
   // Safer than relying on file.path in the renderer (not available with contextIsolation).
-  ipcMain.handle('pdf:open-pdf-dialog', async (): Promise<IpcResult<{ filePath: string } | null>> => {
-    try {
-      const result = await dialog.showOpenDialog({
-        title: 'PDF auswählen',
-        filters: [{ name: 'PDF', extensions: ['pdf'] }],
-        properties: ['openFile']
-      })
-      if (result.canceled || !result.filePaths[0]) return ok(null)
-      return ok({ filePath: result.filePaths[0] })
-    } catch (e) {
-      return fail(e)
+  ipcMain.handle(
+    'pdf:open-pdf-dialog',
+    async (): Promise<IpcResult<{ filePath: string } | null>> => {
+      try {
+        const result = await dialog.showOpenDialog({
+          title: 'PDF auswählen',
+          filters: [{ name: 'PDF', extensions: ['pdf'] }],
+          properties: ['openFile']
+        })
+        if (result.canceled || !result.filePaths[0]) return ok(null)
+        return ok({ filePath: result.filePaths[0] })
+      } catch (e) {
+        return fail(e)
+      }
     }
-  })
+  )
 
   // Logo picker — copies user-chosen image into userData/pdf-logo.<ext>
   // and persists the path into settings.pdf_logo_path.
@@ -1081,141 +1031,10 @@ function validateProject(
     if (!Number.isFinite(rate) || rate < 0) return 'Stundensatz darf nicht negativ sein'
   }
   if (db && input.client_id !== null && input.client_id !== undefined) {
-    const clientRow = db
-      .prepare('SELECT id FROM clients WHERE id = ?')
-      .get(input.client_id) as { id: number } | undefined
+    const clientRow = db.prepare('SELECT id FROM clients WHERE id = ?').get(input.client_id) as
+      | { id: number }
+      | undefined
     if (!clientRow) return 'Kunde existiert nicht'
   }
   return null
-}
-
-/**
- * Server-side validation contract for manual entry create/update (E3).
- * Returns an error string if invalid, `null` if valid. Single point of
- * truth: UI may pre-validate but must not be the only line of defence
- * (e.g. against malicious renderer code or future scripted clients).
- *
- * Rules:
- *  - started_at <= now (no future entries)
- *  - stopped_at > started_at
- *  - client_id exists
- *  - description.length <= 500
- *  - duration <= 24h
- *  - no overlap with existing non-deleted entry of the same client
- *    (excluding the entry itself when updating; for cross-midnight splits
- *    the caller passes `excludeLinkId` so the second half doesn't claim
- *    its sibling overlaps)
- *
- * Cross-midnight is allowed since v1.3 PR B — entries that cross local
- * midnight are auto-split into linked halves by the create/update IPC
- * before insertion (see `splitAtMidnight`).
- */
-function validateManualEntry(
-  db: ReturnType<typeof getDb>,
-  input: {
-    client_id: number
-    description: string
-    started_at: string
-    stopped_at: string
-    reference?: string
-    private_note?: string
-  },
-  excludeId?: number,
-  excludeLinkId?: string
-): string | null {
-  const start = new Date(input.started_at)
-  const stop = new Date(input.stopped_at)
-  if (Number.isNaN(start.getTime())) return 'Startzeit ist ungültig'
-  if (Number.isNaN(stop.getTime())) return 'Endzeit ist ungültig'
-  const now = Date.now()
-  if (start.getTime() > now) return 'Startzeit darf nicht in der Zukunft liegen'
-  if (stop.getTime() <= start.getTime()) return 'Endzeit muss nach der Startzeit liegen'
-  const durationSec = (stop.getTime() - start.getTime()) / 1000
-  if (durationSec > MAX_DURATION_SECONDS) return 'Dauer überschreitet 24 Stunden'
-  if ((input.description ?? '').length > MAX_DESCRIPTION_LEN) {
-    return `Beschreibung überschreitet ${MAX_DESCRIPTION_LEN} Zeichen`
-  }
-  if ((input.reference ?? '').length > MAX_REFERENCE_LEN) {
-    return `Referenz überschreitet ${MAX_REFERENCE_LEN} Zeichen`
-  }
-  if ((input.private_note ?? '').length > MAX_NOTE_LEN) {
-    return `Notiz überschreitet ${MAX_NOTE_LEN} Zeichen`
-  }
-  const clientRow = db.prepare(`SELECT id FROM clients WHERE id = ?`).get(input.client_id) as
-    | { id: number }
-    | undefined
-  if (!clientRow) return 'Kunde existiert nicht'
-  // Overlap: any non-deleted entry of the same client whose time range
-  // intersects [start, stop). Two intervals overlap iff
-  //   existing.started_at < stop AND COALESCE(existing.stopped_at, now) > start
-  const params: Array<string | number> = [input.client_id, input.stopped_at, input.started_at]
-  let overlapSql = `SELECT id FROM entries
-                     WHERE client_id = ? AND deleted_at IS NULL
-                       AND started_at < ?
-                       AND COALESCE(stopped_at, datetime('now')) > ?`
-  if (excludeId !== undefined) {
-    overlapSql += ` AND id != ?`
-    params.push(excludeId)
-  }
-  if (excludeLinkId !== undefined) {
-    overlapSql += ` AND (link_id IS NULL OR link_id != ?)`
-    params.push(excludeLinkId)
-  }
-  const overlap = db.prepare(overlapSql).get(...params) as { id: number } | undefined
-  if (overlap) return 'Eintrag überlappt mit einem bestehenden Eintrag desselben Kunden'
-  return null
-}
-
-/**
- * Insert one or more time segments produced by `splitAtMidnight`. Single
- * segment → plain insert (link_id stays NULL). Multiple segments → all
- * rows share a fresh UUID `link_id` so the UI / delete flow can find
- * siblings later. Returns the FIRST inserted row (the one whose start
- * matches the user's input.started_at), so the renderer can reveal the
- * correct day in the calendar.
- *
- * Caller must have already run `validateManualEntry` against the full
- * (un-split) range. Runs inside a single transaction so a failed insert
- * leaves no half-state behind.
- */
-function insertEntrySegments(
-  db: ReturnType<typeof getDb>,
-  input: { client_id: number; description: string },
-  segments: Array<{ start: Date; stop: Date }>,
-  tags = '',
-  reference = '',
-  billable = 1,
-  private_note = '',
-  project_id: number | null = null
-): Entry {
-  const linkId = segments.length > 1 ? randomUUID() : null
-  const description = input.description.trim()
-  const insertStmt = db.prepare(
-    `INSERT INTO entries (client_id, description, started_at, stopped_at, heartbeat_at, rounded_min, link_id, project_id, tags, reference, billable, private_note)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-  )
-  const tx = db.transaction((): Entry => {
-    let firstId = 0
-    for (const seg of segments) {
-      const startedAt = seg.start.toISOString()
-      const stoppedAt = seg.stop.toISOString()
-      const info = insertStmt.run(
-        input.client_id,
-        description,
-        startedAt,
-        stoppedAt,
-        stoppedAt,
-        Math.round((seg.stop.getTime() - seg.start.getTime()) / 60000),
-        linkId,
-        project_id,
-        tags,
-        reference,
-        billable,
-        private_note
-      )
-      if (firstId === 0) firstId = Number(info.lastInsertRowid)
-    }
-    return db.prepare(`SELECT * FROM entries WHERE id = ?`).get(firstId) as Entry
-  })
-  return tx()
 }

--- a/src/main/mcpAudit.ts
+++ b/src/main/mcpAudit.ts
@@ -1,0 +1,34 @@
+/**
+ * Append-only audit log for MCP write-mode mutations.
+ *
+ * Uses a dedicated electron-log scope so entries land next to the app logs
+ * (%AppData%/TimeTrack/logs on Windows) as `mcp-writes.log`, with the same
+ * size-based rotation electron-log already provides. Never records the token
+ * or `private_note` content.
+ */
+import log from 'electron-log/main'
+
+const mcpLog = log.create({ logId: 'mcp' })
+mcpLog.transports.file.fileName = 'mcp-writes.log'
+// Console transport would duplicate into the main log; keep it file-only.
+mcpLog.transports.console.level = false
+
+export interface McpAuditEntry {
+  op: string
+  /** Resulting/affected entry id, if any. */
+  id?: number | null
+  client_id?: number | null
+  started_at?: string | null
+  stopped_at?: string | null
+  /** True when the request carried a non-empty private note (content omitted). */
+  hasPrivateNote?: boolean
+}
+
+/** Append one committed mutation to the audit log. */
+export function auditWrite(entry: McpAuditEntry): void {
+  try {
+    mcpLog.info('write', JSON.stringify(entry))
+  } catch {
+    // Auditing must never break a mutation.
+  }
+}

--- a/src/main/mcpBridge.ts
+++ b/src/main/mcpBridge.ts
@@ -1,0 +1,228 @@
+/**
+ * MCP write bridge (Electron side).
+ *
+ * Hosts a local IPC endpoint (named pipe on Windows, unix socket elsewhere)
+ * that the standalone MCP server connects to for WRITE operations. Every
+ * request is authenticated by a token and runs through the guarded
+ * `handleRequest` core, which executes mutations via the shared entry-mutation
+ * functions against the live main-process DB handle. Reads never touch this —
+ * they go directly against the read-only SQLite connection in the MCP process.
+ *
+ * Lifecycle: started in `whenReady` (and on the write-enable toggle) only on
+ * the primary instance; torn down on `will-quit` / disable. See index.ts.
+ */
+import net from 'net'
+import { existsSync, unlinkSync, readFileSync, writeFileSync, chmodSync } from 'fs'
+import { randomBytes } from 'crypto'
+import { app, dialog, type BrowserWindow } from 'electron'
+import log from 'electron-log/main'
+import type Database from 'better-sqlite3'
+import { createBackup } from './backup'
+import { auditWrite } from './mcpAudit'
+import { handleRequest, type BridgeCtx, type BridgeRequest } from './mcpBridgeCore'
+import { socketPathForDir, tokenPathForDir } from '../mcp/socketPath'
+
+export interface BridgeDeps {
+  getDb: () => Database.Database
+  refreshTray: () => void
+  broadcast: (channel: string, payload?: unknown) => void
+  getMainWindow: () => BrowserWindow | null
+  getSetting: (key: string) => string | undefined
+}
+
+let server: net.Server | null = null
+let deps: BridgeDeps | null = null
+let sessionApproved = false
+let backupDone = false
+
+function tokenPath(): string {
+  return tokenPathForDir(app.getPath('userData'))
+}
+function sockPath(): string {
+  return socketPathForDir(app.getPath('userData'))
+}
+
+/** Generate + persist a fresh write token (mode 0600). Returns it. */
+export function generateWriteToken(): string {
+  const token = randomBytes(32).toString('hex')
+  writeFileSync(tokenPath(), token, { mode: 0o600 })
+  try {
+    chmodSync(tokenPath(), 0o600)
+  } catch {
+    // chmod is a no-op / unsupported on Windows — the token still isn't shared.
+  }
+  return token
+}
+
+/** Ensure a token exists (used on startup when write mode is already on). */
+export function ensureWriteToken(): void {
+  if (!existsSync(tokenPath())) generateWriteToken()
+}
+
+/** Delete the token file (on disable). */
+export function clearWriteToken(): void {
+  try {
+    if (existsSync(tokenPath())) unlinkSync(tokenPath())
+  } catch {
+    // ignore
+  }
+}
+
+function readToken(): string | null {
+  try {
+    return existsSync(tokenPath()) ? readFileSync(tokenPath(), 'utf8').trim() : null
+  } catch {
+    return null
+  }
+}
+
+function confirmMode(): 'per-write' | 'session' | 'silent' {
+  const v = deps?.getSetting('mcp_write_confirm_mode')
+  return v === 'silent' || v === 'session' ? v : 'per-write'
+}
+
+/** Native confirm honouring per-write / session / silent + "remember". */
+async function confirm(summary: string): Promise<boolean> {
+  const mode = confirmMode()
+  if (mode === 'silent') return true
+  if (mode === 'session' && sessionApproved) return true
+
+  const win = deps?.getMainWindow() ?? null
+  if (win) {
+    if (!win.isVisible()) win.show()
+    win.focus()
+  }
+  const opts: Electron.MessageBoxOptions = {
+    type: 'question',
+    buttons: ['Ablehnen', 'Erlauben'],
+    defaultId: 1,
+    cancelId: 0,
+    noLink: true,
+    title: 'TimeTrack — MCP-Schreibzugriff',
+    message: 'Claude möchte eine Änderung in TimeTrack vornehmen:',
+    detail: summary,
+    checkboxLabel: 'Für diese Session merken (nicht mehr fragen)',
+    checkboxChecked: false
+  }
+  const res = win ? await dialog.showMessageBox(win, opts) : await dialog.showMessageBox(opts)
+  const approved = res.response === 1
+  if (approved && (mode === 'session' || res.checkboxChecked)) sessionApproved = true
+  return approved
+}
+
+async function ensureBackup(): Promise<void> {
+  if (backupDone) return
+  backupDone = true // set first so concurrent requests don't double-snapshot
+  try {
+    await createBackup(deps!.getDb(), 'mcp')
+  } catch (e) {
+    log.warn('[mcp-bridge] pre-write backup failed', e)
+  }
+}
+
+function buildCtx(): BridgeCtx {
+  return {
+    db: deps!.getDb(),
+    token: readToken(),
+    isWriteEnabled: () => deps!.getSetting('mcp_write_enabled') === '1',
+    confirm,
+    ensureBackup,
+    audit: auditWrite,
+    onChange: () => {
+      deps!.broadcast('data:changed')
+      deps!.refreshTray()
+    }
+  }
+}
+
+function onConnection(conn: net.Socket): void {
+  let buf = ''
+  // Serialise requests on a connection so modal confirm dialogs don't stack.
+  let chain: Promise<void> = Promise.resolve()
+
+  conn.on('data', (chunk) => {
+    buf += chunk.toString('utf8')
+    let idx: number
+    while ((idx = buf.indexOf('\n')) >= 0) {
+      const line = buf.slice(0, idx).trim()
+      buf = buf.slice(idx + 1)
+      if (!line) continue
+      chain = chain.then(() => processLine(line, conn))
+    }
+  })
+  conn.on('error', () => {
+    /* client went away — nothing to do */
+  })
+}
+
+async function processLine(line: string, conn: net.Socket): Promise<void> {
+  let req: BridgeRequest
+  try {
+    req = JSON.parse(line)
+  } catch {
+    writeLine(conn, { ok: false, error: 'Ungültiges JSON', code: 'invalid' })
+    return
+  }
+  try {
+    const res = await handleRequest(buildCtx(), req)
+    writeLine(conn, res)
+  } catch (e) {
+    log.error('[mcp-bridge] request failed', e)
+    writeLine(conn, { ok: false, error: String(e), code: 'invalid' })
+  }
+}
+
+function writeLine(conn: net.Socket, obj: unknown): void {
+  try {
+    conn.write(JSON.stringify(obj) + '\n')
+  } catch {
+    // socket closed mid-flight
+  }
+}
+
+/** Start the bridge. Idempotent. Call only on the primary instance. */
+export function startMcpBridge(d: BridgeDeps): void {
+  if (server) return
+  deps = d
+  sessionApproved = false
+  backupDone = false
+  ensureWriteToken()
+
+  const p = sockPath()
+  if (process.platform !== 'win32' && existsSync(p)) {
+    try {
+      unlinkSync(p)
+    } catch {
+      // stale socket removal best-effort
+    }
+  }
+  const srv = net.createServer(onConnection)
+  srv.on('error', (e) => {
+    log.error('[mcp-bridge] server error', e)
+    server = null
+  })
+  srv.listen(p, () => log.info('[mcp-bridge] write bridge listening on', p))
+  server = srv
+}
+
+/** Stop the bridge and clean up the socket file. Idempotent. */
+export function stopMcpBridge(): void {
+  if (server) {
+    try {
+      server.close()
+    } catch {
+      // ignore
+    }
+    server = null
+  }
+  if (process.platform !== 'win32') {
+    const p = sockPath()
+    if (existsSync(p)) {
+      try {
+        unlinkSync(p)
+      } catch {
+        // ignore
+      }
+    }
+  }
+}

--- a/src/main/mcpBridge.ts
+++ b/src/main/mcpBridge.ts
@@ -14,9 +14,11 @@
 import net from 'net'
 import { existsSync, unlinkSync, readFileSync, writeFileSync, chmodSync } from 'fs'
 import { randomBytes } from 'crypto'
-import { app, dialog, type BrowserWindow } from 'electron'
+import { dirname } from 'path'
+import { dialog, type BrowserWindow } from 'electron'
 import log from 'electron-log/main'
 import type Database from 'better-sqlite3'
+import { getDbPath } from './db'
 import { createBackup } from './backup'
 import { auditWrite } from './mcpAudit'
 import { handleRequest, type BridgeCtx, type BridgeRequest } from './mcpBridgeCore'
@@ -35,11 +37,18 @@ let deps: BridgeDeps | null = null
 let sessionApproved = false
 let backupDone = false
 
+// Anchor token + socket on the DIRECTORY OF THE DB the app actually uses
+// (getDbPath() === <userData>/timetrack.sqlite). The MCP side derives the same
+// paths from dirname(resolveDbPath()), so both agree as long as the MCP server
+// points at the app's real DB (see socketPath.ts / README).
+function endpointDir(): string {
+  return dirname(getDbPath())
+}
 function tokenPath(): string {
-  return tokenPathForDir(app.getPath('userData'))
+  return tokenPathForDir(endpointDir())
 }
 function sockPath(): string {
-  return socketPathForDir(app.getPath('userData'))
+  return socketPathForDir(endpointDir())
 }
 
 /** Generate + persist a fresh write token (mode 0600). Returns it. */
@@ -85,7 +94,9 @@ function confirmMode(): 'per-write' | 'session' | 'silent' {
 async function confirm(summary: string): Promise<boolean> {
   const mode = confirmMode()
   if (mode === 'silent') return true
-  if (mode === 'session' && sessionApproved) return true
+  // Once approved-for-session — either via 'session' mode or the "remember"
+  // checkbox in 'per-write' mode — skip the dialog for the rest of the run.
+  if (sessionApproved) return true
 
   const win = deps?.getMainWindow() ?? null
   if (win) {

--- a/src/main/mcpBridgeCore.test.ts
+++ b/src/main/mcpBridgeCore.test.ts
@@ -195,6 +195,31 @@ describe('handleRequest', () => {
     expect(row.started_at).toBe('2026-06-10T09:00:00.000Z') // untouched
   })
 
+  it('update_entry_fields refuses a running entry even if stopped_at is supplied', async () => {
+    const { ctx } = makeCtx(db)
+    await handleRequest(ctx, {
+      v: 1,
+      token: 'secret',
+      op: 'start_timer',
+      args: { client_id: 1, description: 'run', started_at: '2026-06-10T09:00:00.000Z' }
+    })
+    const id = (
+      db.prepare(`SELECT id FROM entries WHERE stopped_at IS NULL`).get() as { id: number }
+    ).id
+    const res = await handleRequest(ctx, {
+      v: 1,
+      token: 'secret',
+      op: 'update_entry_fields',
+      args: { id, stopped_at: '2026-06-10T10:00:00.000Z', description: 'x' }
+    })
+    expect(res).toMatchObject({ ok: false, code: 'invalid' })
+    // Still running — untouched.
+    const row = db.prepare(`SELECT stopped_at FROM entries WHERE id = ?`).get(id) as {
+      stopped_at: string | null
+    }
+    expect(row.stopped_at).toBeNull()
+  })
+
   it('start_timer then stop_running_timer', async () => {
     const { ctx } = makeCtx(db)
     const start = await handleRequest(ctx, {

--- a/src/main/mcpBridgeCore.test.ts
+++ b/src/main/mcpBridgeCore.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Tests for the guarded MCP write-bridge core. In-memory migrated DB; stubs
+ * for confirm/backup/audit/onChange. Skips when better-sqlite3 can't load.
+ */
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import type Database from 'better-sqlite3'
+import { migrations } from './migrations'
+import { handleRequest, type BridgeCtx, type BridgeRequest } from './mcpBridgeCore'
+
+type DatabaseCtor = new (path: string) => Database.Database
+let DatabaseImpl: DatabaseCtor | null = null
+
+beforeAll(async () => {
+  try {
+    const mod = await import('better-sqlite3')
+    const Ctor = mod.default as unknown as DatabaseCtor
+    const probe = new Ctor(':memory:')
+    probe.close()
+    DatabaseImpl = Ctor
+  } catch {
+    DatabaseImpl = null
+  }
+})
+
+function seed(db: Database.Database): void {
+  db.pragma('foreign_keys = ON')
+  db.exec(
+    `CREATE TABLE schema_version (version INTEGER PRIMARY KEY, name TEXT NOT NULL, applied_at TEXT NOT NULL DEFAULT (datetime('now')))`
+  )
+  for (const m of migrations) {
+    db.transaction(() => {
+      db.exec(m.up)
+      db.prepare('INSERT INTO schema_version (version, name) VALUES (?, ?)').run(m.version, m.name)
+    })()
+  }
+  db.prepare(
+    `INSERT INTO clients (id, name, color, active, rate_cent) VALUES (1,'Acme','#111',1,0)`
+  ).run()
+}
+
+interface Spies {
+  confirmCalls: number
+  backupCalls: number
+  auditCalls: number
+  changeCalls: number
+}
+
+function makeCtx(
+  db: Database.Database,
+  o: Partial<{
+    token: string | null
+    incomingWriteEnabled: boolean
+    approve: boolean
+  }> = {}
+): { ctx: BridgeCtx; spies: Spies } {
+  const spies: Spies = { confirmCalls: 0, backupCalls: 0, auditCalls: 0, changeCalls: 0 }
+  const ctx: BridgeCtx = {
+    db,
+    token: o.token === undefined ? 'secret' : o.token,
+    isWriteEnabled: () => o.incomingWriteEnabled !== false,
+    confirm: async () => {
+      spies.confirmCalls++
+      return o.approve !== false
+    },
+    ensureBackup: async () => {
+      spies.backupCalls++
+    },
+    audit: () => {
+      spies.auditCalls++
+    },
+    onChange: () => {
+      spies.changeCalls++
+    }
+  }
+  return { ctx, spies }
+}
+
+const CREATE: BridgeRequest = {
+  v: 1,
+  token: 'secret',
+  op: 'create_manual_entry',
+  args: {
+    client_id: 1,
+    description: 'Feature',
+    started_at: '2026-06-10T09:00:00.000Z',
+    stopped_at: '2026-06-10T10:00:00.000Z'
+  }
+}
+
+function countEntries(db: Database.Database): number {
+  return (db.prepare(`SELECT COUNT(*) AS n FROM entries`).get() as { n: number }).n
+}
+
+describe('handleRequest', () => {
+  let db: Database.Database
+  beforeEach((ctx) => {
+    if (!DatabaseImpl) {
+      ctx.skip()
+      return
+    }
+    db = new DatabaseImpl(':memory:')
+    seed(db)
+  })
+
+  it('rejects a bad token', async () => {
+    const { ctx } = makeCtx(db)
+    const res = await handleRequest(ctx, { ...CREATE, token: 'wrong' })
+    expect(res).toMatchObject({ ok: false, code: 'bad_token' })
+    expect(countEntries(db)).toBe(0)
+  })
+
+  it('rejects when write is disabled', async () => {
+    const { ctx } = makeCtx(db, { incomingWriteEnabled: false })
+    const res = await handleRequest(ctx, CREATE)
+    expect(res).toMatchObject({ ok: false, code: 'write_disabled' })
+  })
+
+  it('rejects an op outside the allowlist', async () => {
+    const { ctx } = makeCtx(db)
+    const res = await handleRequest(ctx, {
+      v: 1,
+      token: 'secret',
+      op: 'delete_client',
+      args: { id: 1 }
+    })
+    expect(res).toMatchObject({ ok: false, code: 'not_allowed' })
+  })
+
+  it('rejects a malformed request', async () => {
+    const { ctx } = makeCtx(db)
+    const res = await handleRequest(ctx, {
+      token: 'secret',
+      op: 'create_manual_entry'
+    } as BridgeRequest)
+    expect(res).toMatchObject({ ok: false, code: 'invalid' })
+  })
+
+  it('preview does not mutate, confirm, back up, or audit', async () => {
+    const { ctx, spies } = makeCtx(db)
+    const res = await handleRequest(ctx, { ...CREATE, preview: true })
+    expect(res.ok).toBe(true)
+    if (res.ok) expect(res.data).toMatchObject({ preview: true, action: 'create_manual_entry' })
+    expect(countEntries(db)).toBe(0)
+    expect(spies).toMatchObject({ confirmCalls: 0, backupCalls: 0, auditCalls: 0, changeCalls: 0 })
+  })
+
+  it('commits a create: confirm + backup + change + audit fire once', async () => {
+    const { ctx, spies } = makeCtx(db)
+    const res = await handleRequest(ctx, CREATE)
+    expect(res.ok).toBe(true)
+    expect(countEntries(db)).toBe(1)
+    expect(spies).toEqual({ confirmCalls: 1, backupCalls: 1, auditCalls: 1, changeCalls: 1 })
+  })
+
+  it('declined confirm blocks the mutation', async () => {
+    const { ctx, spies } = makeCtx(db, { approve: false })
+    const res = await handleRequest(ctx, CREATE)
+    expect(res).toMatchObject({ ok: false, code: 'confirm_declined' })
+    expect(countEntries(db)).toBe(0)
+    expect(spies).toMatchObject({ backupCalls: 0, auditCalls: 0, changeCalls: 0 })
+  })
+
+  it('surfaces a validation error as invalid without mutating', async () => {
+    const { ctx } = makeCtx(db)
+    const res = await handleRequest(ctx, {
+      ...CREATE,
+      args: { ...CREATE.args, client_id: 999 }
+    })
+    expect(res).toMatchObject({ ok: false, code: 'invalid' })
+    expect(countEntries(db)).toBe(0)
+  })
+
+  it('update_entry_fields patches only provided fields', async () => {
+    const { ctx } = makeCtx(db)
+    await handleRequest(ctx, CREATE)
+    const id = (db.prepare(`SELECT id FROM entries LIMIT 1`).get() as { id: number }).id
+    const res = await handleRequest(ctx, {
+      v: 1,
+      token: 'secret',
+      op: 'update_entry_fields',
+      args: { id, description: 'Renamed', tags: ',x,' }
+    })
+    expect(res.ok).toBe(true)
+    // update deletes + reinserts, yielding a new row id — read it back from the result.
+    const newId = res.ok ? (res.data as { id: number }).id : id
+    const row = db
+      .prepare(`SELECT description, tags, started_at FROM entries WHERE id = ?`)
+      .get(newId) as {
+      description: string
+      tags: string
+      started_at: string
+    }
+    expect(row.description).toBe('Renamed')
+    expect(row.tags).toBe(',x,')
+    expect(row.started_at).toBe('2026-06-10T09:00:00.000Z') // untouched
+  })
+
+  it('start_timer then stop_running_timer', async () => {
+    const { ctx } = makeCtx(db)
+    const start = await handleRequest(ctx, {
+      v: 1,
+      token: 'secret',
+      op: 'start_timer',
+      args: { client_id: 1, description: 'run', started_at: '2026-06-10T09:00:00.000Z' }
+    })
+    expect(start.ok).toBe(true)
+    expect(
+      (
+        db.prepare(`SELECT COUNT(*) AS n FROM entries WHERE stopped_at IS NULL`).get() as {
+          n: number
+        }
+      ).n
+    ).toBe(1)
+    const stop = await handleRequest(ctx, { v: 1, token: 'secret', op: 'stop_running_timer' })
+    expect(stop.ok).toBe(true)
+    expect(
+      (
+        db.prepare(`SELECT COUNT(*) AS n FROM entries WHERE stopped_at IS NULL`).get() as {
+          n: number
+        }
+      ).n
+    ).toBe(0)
+  })
+})

--- a/src/main/mcpBridgeCore.ts
+++ b/src/main/mcpBridgeCore.ts
@@ -1,0 +1,292 @@
+/**
+ * Electron-free core of the MCP write bridge.
+ *
+ * `handleRequest` is the single guarded entry point that both the socket
+ * server (mcpBridge.ts) and the unit tests drive. It contains no `net`, no
+ * `electron`, and no I/O beyond the injected DB + callbacks — so the whole
+ * guard chain (token, opt-in, allowlist, preview, confirm, backup, audit) is
+ * testable with stubs.
+ */
+import type Database from 'better-sqlite3'
+import {
+  createManualEntry,
+  updateManualEntry,
+  startTimer,
+  stopRunningTimer,
+  validateManualEntry
+} from './entryMutations'
+import type {
+  Entry,
+  CreateManualEntryInput,
+  UpdateEntryInput,
+  CreateEntryInput
+} from '../shared/types'
+import type { McpAuditEntry } from './mcpAudit'
+
+type Db = Database.Database
+
+export const WRITE_OPS = [
+  'create_manual_entry',
+  'update_entry_fields',
+  'stop_running_timer',
+  'start_timer'
+] as const
+export type WriteOp = (typeof WRITE_OPS)[number]
+
+export interface BridgeRequest {
+  v?: number
+  token?: string
+  op?: string
+  args?: Record<string, unknown>
+  preview?: boolean
+}
+
+export type BridgeResponse =
+  | { ok: true; data: unknown }
+  | { ok: false; error: string; code: BridgeErrorCode }
+
+export type BridgeErrorCode =
+  | 'invalid'
+  | 'bad_token'
+  | 'write_disabled'
+  | 'not_allowed'
+  | 'confirm_declined'
+
+export interface BridgeCtx {
+  db: Db
+  /** Expected token; null/empty ⇒ treat as write-disabled. */
+  token: string | null
+  /** Re-checked per request from the settings table. */
+  isWriteEnabled: () => boolean
+  /** Ask the user; encapsulates per-write/session/silent. Resolves to approval. */
+  confirm: (summary: string) => Promise<boolean>
+  /** Make the one-per-session pre-write backup (idempotent). */
+  ensureBackup: () => Promise<void>
+  audit: (entry: McpAuditEntry) => void
+  /** Broadcast + tray refresh after a committed change. */
+  onChange: () => void
+}
+
+function err(code: BridgeErrorCode, error: string): BridgeResponse {
+  return { ok: false, error, code }
+}
+
+// ── arg coercion ───────────────────────────────────────────────────────────
+
+function asString(v: unknown, fallback = ''): string {
+  return typeof v === 'string' ? v : fallback
+}
+function asBillable(v: unknown, fallback: number): number {
+  if (typeof v === 'boolean') return v ? 1 : 0
+  if (typeof v === 'number') return v === 0 ? 0 : 1
+  return fallback
+}
+function asProjectId(v: unknown, fallback: number | null): number | null {
+  if (v === null) return null
+  if (typeof v === 'number') return v
+  return fallback
+}
+function durationMin(started_at: string, stopped_at: string): number {
+  return Math.round((Date.parse(stopped_at) - Date.parse(started_at)) / 60000)
+}
+
+// ── op planning ──────────────────────────────────────────────────────────
+
+interface Plan {
+  summary: string
+  preview: Record<string, unknown>
+  run: () => { ok: true; data: Entry | null } | { ok: false; error: string }
+  audit: (result: Entry | null) => McpAuditEntry
+}
+
+/** Build an executable plan for an op, or return an error string. */
+function planOp(db: Db, op: WriteOp, args: Record<string, unknown>): Plan | { error: string } {
+  switch (op) {
+    case 'create_manual_entry': {
+      const input: CreateManualEntryInput = {
+        client_id: Number(args.client_id),
+        description: asString(args.description),
+        started_at: asString(args.started_at),
+        stopped_at: asString(args.stopped_at),
+        tags: asString(args.tags),
+        reference: asString(args.reference),
+        billable: asBillable(args.billable, 1),
+        private_note: asString(args.private_note),
+        project_id: asProjectId(args.project_id, null)
+      }
+      const vErr = validateManualEntry(db, input)
+      if (vErr) return { error: vErr }
+      return {
+        summary: `Eintrag nachtragen — Kunde ${input.client_id}, ${input.started_at} → ${input.stopped_at} (${durationMin(input.started_at, input.stopped_at)} min): "${input.description}"`,
+        preview: {
+          action: 'create_manual_entry',
+          client_id: input.client_id,
+          started_at: input.started_at,
+          stopped_at: input.stopped_at,
+          duration_min: durationMin(input.started_at, input.stopped_at),
+          project_id: input.project_id
+        },
+        run: () => createManualEntry(db, input),
+        audit: (r) => ({
+          op,
+          id: r?.id ?? null,
+          client_id: input.client_id,
+          started_at: input.started_at,
+          stopped_at: input.stopped_at,
+          hasPrivateNote: (input.private_note ?? '') !== ''
+        })
+      }
+    }
+    case 'update_entry_fields': {
+      const id = Number(args.id)
+      const existing = db
+        .prepare(`SELECT * FROM entries WHERE id = ? AND deleted_at IS NULL`)
+        .get(id) as Entry | undefined
+      if (!existing) return { error: 'Eintrag existiert nicht' }
+      if (existing.stopped_at === null && args.stopped_at === undefined) {
+        return {
+          error: 'Laufende Einträge können nicht über update_entry_fields bearbeitet werden'
+        }
+      }
+      const input: UpdateEntryInput = {
+        id,
+        client_id: args.client_id === undefined ? existing.client_id : Number(args.client_id),
+        description:
+          args.description === undefined ? existing.description : asString(args.description),
+        started_at: args.started_at === undefined ? existing.started_at : asString(args.started_at),
+        stopped_at:
+          args.stopped_at === undefined ? (existing.stopped_at ?? '') : asString(args.stopped_at),
+        tags: args.tags === undefined ? existing.tags : asString(args.tags),
+        reference: args.reference === undefined ? existing.reference : asString(args.reference),
+        billable:
+          args.billable === undefined
+            ? existing.billable
+            : asBillable(args.billable, existing.billable),
+        private_note:
+          args.private_note === undefined ? existing.private_note : asString(args.private_note),
+        project_id:
+          'project_id' in args
+            ? asProjectId(args.project_id, existing.project_id ?? null)
+            : (existing.project_id ?? null)
+      }
+      const vErr = validateManualEntry(db, input, id, existing.link_id ?? undefined)
+      if (vErr) return { error: vErr }
+      return {
+        summary: `Eintrag #${id} ändern — ${input.started_at} → ${input.stopped_at}: "${input.description}"`,
+        preview: {
+          action: 'update_entry_fields',
+          id,
+          before: {
+            description: existing.description,
+            started_at: existing.started_at,
+            stopped_at: existing.stopped_at,
+            tags: existing.tags,
+            reference: existing.reference,
+            billable: existing.billable,
+            project_id: existing.project_id ?? null
+          },
+          after: {
+            description: input.description,
+            started_at: input.started_at,
+            stopped_at: input.stopped_at,
+            tags: input.tags,
+            reference: input.reference,
+            billable: input.billable,
+            project_id: input.project_id
+          }
+        },
+        run: () => updateManualEntry(db, input),
+        audit: (r) => ({
+          op,
+          id: r?.id ?? id,
+          client_id: input.client_id,
+          started_at: input.started_at,
+          stopped_at: input.stopped_at,
+          hasPrivateNote: (input.private_note ?? '') !== ''
+        })
+      }
+    }
+    case 'start_timer': {
+      const input: CreateEntryInput = {
+        client_id: Number(args.client_id),
+        description: asString(args.description),
+        started_at: asString(args.started_at) || new Date().toISOString(),
+        project_id: asProjectId(args.project_id, null)
+      }
+      const client = db.prepare(`SELECT id FROM clients WHERE id = ?`).get(input.client_id) as
+        | { id: number }
+        | undefined
+      if (!client) return { error: 'Kunde existiert nicht' }
+      return {
+        summary: `Timer starten — Kunde ${input.client_id}: "${input.description}"`,
+        preview: {
+          action: 'start_timer',
+          client_id: input.client_id,
+          started_at: input.started_at,
+          project_id: input.project_id
+        },
+        run: () => startTimer(db, input),
+        audit: (r) => ({
+          op,
+          id: r?.id ?? null,
+          client_id: input.client_id,
+          started_at: input.started_at
+        })
+      }
+    }
+    case 'stop_running_timer': {
+      const running = db
+        .prepare(
+          `SELECT id, client_id FROM entries WHERE stopped_at IS NULL AND deleted_at IS NULL
+           ORDER BY started_at DESC LIMIT 1`
+        )
+        .get() as { id: number; client_id: number } | undefined
+      return {
+        summary: running
+          ? `Laufenden Timer stoppen (Eintrag #${running.id})`
+          : 'Laufenden Timer stoppen (keiner aktiv)',
+        preview: { action: 'stop_running_timer', running: running ?? null },
+        run: () => stopRunningTimer(db),
+        audit: (r) => ({ op, id: r?.id ?? null, client_id: r?.client_id ?? null })
+      }
+    }
+  }
+}
+
+/**
+ * Guarded request handler. Order: shape → token → opt-in → allowlist → plan →
+ * (preview short-circuits here) → confirm → backup → execute → broadcast + audit.
+ */
+export async function handleRequest(ctx: BridgeCtx, req: BridgeRequest): Promise<BridgeResponse> {
+  if (!req || req.v !== 1 || typeof req.op !== 'string') {
+    return err('invalid', 'Ungültige Anfrage')
+  }
+  if (!ctx.token || req.token !== ctx.token) {
+    return err('bad_token', 'Ungültiges oder fehlendes Token')
+  }
+  if (!ctx.isWriteEnabled()) {
+    return err('write_disabled', 'Schreibzugriff ist deaktiviert (Einstellungen → Integrationen)')
+  }
+  if (!(WRITE_OPS as readonly string[]).includes(req.op)) {
+    return err('not_allowed', `Operation nicht erlaubt: ${req.op}`)
+  }
+
+  const plan = planOp(ctx.db, req.op as WriteOp, req.args ?? {})
+  if ('error' in plan) return err('invalid', plan.error)
+
+  if (req.preview) {
+    return { ok: true, data: { preview: true, ...plan.preview } }
+  }
+
+  const approved = await ctx.confirm(plan.summary)
+  if (!approved) return err('confirm_declined', 'Änderung wurde in TimeTrack abgelehnt')
+
+  await ctx.ensureBackup()
+
+  const result = plan.run()
+  if (!result.ok) return err('invalid', result.error)
+
+  ctx.onChange()
+  ctx.audit(plan.audit(result.data))
+  return { ok: true, data: result.data }
+}

--- a/src/main/mcpBridgeCore.ts
+++ b/src/main/mcpBridgeCore.ts
@@ -143,9 +143,12 @@ function planOp(db: Db, op: WriteOp, args: Record<string, unknown>): Plan | { er
         .prepare(`SELECT * FROM entries WHERE id = ? AND deleted_at IS NULL`)
         .get(id) as Entry | undefined
       if (!existing) return { error: 'Eintrag existiert nicht' }
-      if (existing.stopped_at === null && args.stopped_at === undefined) {
+      // Running timers are excluded from update_entry_fields entirely (matches
+      // the tool description). Stop the timer via stop_running_timer first.
+      if (existing.stopped_at === null) {
         return {
-          error: 'Laufende Einträge können nicht über update_entry_fields bearbeitet werden'
+          error:
+            'Laufende Einträge können nicht über update_entry_fields bearbeitet werden — erst stop_running_timer nutzen'
         }
       }
       const input: UpdateEntryInput = {

--- a/src/main/migrations/019-v114-mcp-write-confirm.ts
+++ b/src/main/migrations/019-v114-mcp-write-confirm.ts
@@ -1,0 +1,21 @@
+import type { Migration } from './index'
+
+/**
+ * v1.14 #127 — MCP write-mode confirmation setting.
+ *
+ * Seeds `mcp_write_confirm_mode`, which controls how a write coming from the
+ * MCP bridge is confirmed in the app:
+ *   'per-write' (default) → native confirm dialog on every mutation
+ *   'session'             → confirm once per app run, then silent
+ *   'silent'              → no dialog (opt-in + preview + audit log only)
+ *
+ * `INSERT OR IGNORE` keeps it idempotent and never overwrites a user choice.
+ */
+export const migration019: Migration = {
+  version: 19,
+  name: 'v1.14-mcp-write-confirm',
+  up: `
+    INSERT OR IGNORE INTO settings (key, value) VALUES
+      ('mcp_write_confirm_mode', 'per-write');
+  `
+}

--- a/src/main/migrations/index.ts
+++ b/src/main/migrations/index.ts
@@ -16,6 +16,7 @@ import { migration015 } from './015-v12-project-contact-person'
 import { migration016 } from './016-v112-tags'
 import { migration017 } from './017-v113-tag-whitespace'
 import { migration018 } from './018-v114-mcp-integration'
+import { migration019 } from './019-v114-mcp-write-confirm'
 
 export interface Migration {
   /** Monotonically increasing integer. Never reused, never reordered. */
@@ -48,5 +49,6 @@ export const migrations: Migration[] = [
   migration015,
   migration016,
   migration017,
-  migration018
+  migration018,
+  migration019
 ].sort((a, b) => a.version - b.version)

--- a/src/main/migrations/migrations.test.ts
+++ b/src/main/migrations/migrations.test.ts
@@ -120,6 +120,7 @@ describe('migration SQL execution', () => {
       // Migration 018 — MCP integration flags (v1.14 #128)
       { key: 'mcp_expose_private_notes', value: '0' },
       { key: 'mcp_expose_rates', value: '0' },
+      { key: 'mcp_write_confirm_mode', value: 'per-write' },
       { key: 'mcp_write_enabled', value: '0' },
       // Migration 006 — Mini-Widget (v1.4)
       { key: 'mini_enabled', value: '0' },

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,18 +1,16 @@
 /**
- * TimeTrack MCP server — read-only (MVP).
+ * TimeTrack MCP server — over stdio.
  *
- * Exposes the local TimeTrack SQLite database to any MCP client (Claude Code,
- * …) over stdio. This server can ONLY read: the DB is opened read-only and no
- * write tools exist. The guarded write path is a separate, opt-in feature —
- * see the "MCP-Write-Mode" issue.
+ * READS open the local SQLite DB directly in read-only mode. WRITES never touch
+ * the DB from here — they forward over a local socket to the running TimeTrack
+ * app, which executes them through its own validated logic behind opt-in,
+ * token, confirmation, backup and audit guards (v1.14 #127).
  *
- * Tools:
- *   list_clients        — clients (active by default)
- *   list_projects       — projects, optionally filtered by client
- *   list_entries        — entries by month or date range, with filters + totals
- *   get_running_timer   — the currently running entry, if any
- *   get_dashboard       — today/week totals, recent entries, top clients (30d)
- *   get_analytics       — monthly hours (+ revenue when rates are exposed)
+ * Read tools:
+ *   list_clients · list_projects · list_entries · get_running_timer
+ *   get_dashboard · get_analytics
+ * Write tools (require write mode enabled in the app; each supports preview):
+ *   create_manual_entry · update_entry_fields · start_timer · stop_running_timer
  *
  * Privacy: rates and internal notes are hidden by default. Enable per-request
  * either in the app (Einstellungen → Integrationen) or via env override:
@@ -34,6 +32,7 @@ import {
   readStoredPrivacy,
   type SqliteDb
 } from './queries'
+import { sendWrite } from './writeClient'
 
 /**
  * Open the DB fresh per call and close it afterwards. TimeTrack uses WAL, so a
@@ -71,10 +70,12 @@ export function buildServer(): McpServer {
     { name: 'timetrack', version: '0.1.0' },
     {
       instructions:
-        'Read-only Zugriff auf die lokale TimeTrack-Zeiterfassung. Nutze list_entries ' +
-        'und get_analytics für Auswertungen (z. B. Stunden pro Kunde/Projekt), ' +
-        'get_dashboard für den aktuellen Tag/Woche. Stundensätze und interne Notizen ' +
-        'sind standardmäßig ausgeblendet.'
+        'Zugriff auf die lokale TimeTrack-Zeiterfassung. Lesen: list_entries/get_analytics ' +
+        'für Auswertungen (Stunden pro Kunde/Projekt), get_dashboard für Tag/Woche. ' +
+        'Schreiben (create_manual_entry, update_entry_fields, start_timer, stop_running_timer) ' +
+        'erfordert aktivierten Schreibzugriff in der App und kann eine Bestätigung auslösen — ' +
+        'rufe Write-Tools bevorzugt zuerst mit preview:true auf. Stundensätze und interne ' +
+        'Notizen sind standardmäßig ausgeblendet.'
     }
   )
 
@@ -235,6 +236,137 @@ export function buildServer(): McpServer {
         return errorResult(e)
       }
     }
+  )
+
+  // ── Write tools (v1.14 #127) ────────────────────────────────────────────
+  // These forward to the running TimeTrack app over a local socket; they do
+  // NOT touch the DB directly. They require the write bridge to be enabled in
+  // the app (Einstellungen → Integrationen) and may trigger an in-app
+  // confirmation. Every tool supports `preview: true` to see the planned
+  // change without committing.
+  const WRITE_HINT =
+    'Erfordert aktivierten Schreibzugriff (Einstellungen → Integrationen); je nach Einstellung ' +
+    'erscheint eine Bestätigung in TimeTrack. preview:true zeigt die geplante Änderung ohne Commit.'
+
+  async function runWrite(
+    op: string,
+    args: Record<string, unknown>,
+    preview: boolean | undefined
+  ): Promise<ReturnType<typeof jsonResult>> {
+    const r = await sendWrite(op, args, preview === true)
+    return r.ok ? jsonResult(r.data ?? { ok: true }) : errorResult(r.error ?? 'Unbekannter Fehler')
+  }
+
+  server.registerTool(
+    'create_manual_entry',
+    {
+      title: 'Eintrag nachtragen',
+      description: `Legt einen abgeschlossenen Zeiteintrag an (Start + Ende). ${WRITE_HINT}`,
+      inputSchema: {
+        client_id: z.number().int().describe('Kunden-ID'),
+        description: z.string().describe('Tätigkeitsbeschreibung'),
+        started_at: z.string().describe('Startzeit als ISO-Zeitstempel'),
+        stopped_at: z.string().describe('Endzeit als ISO-Zeitstempel'),
+        tags: z.string().optional().describe("Serialisierte Tags, z. B. ',bug,ux,'"),
+        reference: z.string().optional().describe('Ticket/Referenz'),
+        billable: z.boolean().optional().describe('Abrechenbar (Default true)'),
+        private_note: z.string().optional().describe('Interne Notiz (nie exportiert)'),
+        project_id: z.number().int().nullable().optional().describe('Projekt-ID oder null'),
+        preview: z.boolean().optional().describe('Nur Vorschau, kein Commit')
+      }
+    },
+    async (a) =>
+      runWrite(
+        'create_manual_entry',
+        {
+          client_id: a.client_id,
+          description: a.description,
+          started_at: a.started_at,
+          stopped_at: a.stopped_at,
+          tags: a.tags,
+          reference: a.reference,
+          billable: a.billable,
+          private_note: a.private_note,
+          project_id: a.project_id
+        },
+        a.preview
+      )
+  )
+
+  server.registerTool(
+    'update_entry_fields',
+    {
+      title: 'Eintrag bearbeiten',
+      description: `Ändert Felder eines bestehenden Eintrags (nur angegebene Felder). Laufende Timer sind ausgenommen. ${WRITE_HINT}`,
+      inputSchema: {
+        id: z.number().int().describe('ID des Eintrags'),
+        client_id: z.number().int().optional().describe('Neuer Kunde'),
+        description: z.string().optional().describe('Neue Beschreibung'),
+        started_at: z.string().optional().describe('Neue Startzeit (ISO)'),
+        stopped_at: z.string().optional().describe('Neue Endzeit (ISO)'),
+        tags: z.string().optional().describe("Neue Tags, z. B. ',bug,'"),
+        reference: z.string().optional().describe('Neue Referenz'),
+        billable: z.boolean().optional().describe('Abrechenbar'),
+        private_note: z.string().optional().describe('Interne Notiz'),
+        project_id: z.number().int().nullable().optional().describe('Projekt-ID oder null'),
+        preview: z.boolean().optional().describe('Nur Vorschau, kein Commit')
+      }
+    },
+    async (a) =>
+      runWrite(
+        'update_entry_fields',
+        {
+          id: a.id,
+          client_id: a.client_id,
+          description: a.description,
+          started_at: a.started_at,
+          stopped_at: a.stopped_at,
+          tags: a.tags,
+          reference: a.reference,
+          billable: a.billable,
+          private_note: a.private_note,
+          project_id: a.project_id
+        },
+        a.preview
+      )
+  )
+
+  server.registerTool(
+    'start_timer',
+    {
+      title: 'Timer starten',
+      description: `Startet einen laufenden Timer für einen Kunden (stoppt einen ggf. laufenden). ${WRITE_HINT}`,
+      inputSchema: {
+        client_id: z.number().int().describe('Kunden-ID'),
+        description: z.string().optional().describe('Beschreibung'),
+        started_at: z.string().optional().describe('Startzeit (ISO); Default jetzt'),
+        project_id: z.number().int().nullable().optional().describe('Projekt-ID oder null'),
+        preview: z.boolean().optional().describe('Nur Vorschau, kein Commit')
+      }
+    },
+    async (a) =>
+      runWrite(
+        'start_timer',
+        {
+          client_id: a.client_id,
+          description: a.description,
+          started_at: a.started_at,
+          project_id: a.project_id
+        },
+        a.preview
+      )
+  )
+
+  server.registerTool(
+    'stop_running_timer',
+    {
+      title: 'Laufenden Timer stoppen',
+      description: `Stoppt den aktuell laufenden Timer (falls einer läuft). ${WRITE_HINT}`,
+      inputSchema: {
+        preview: z.boolean().optional().describe('Nur Vorschau, kein Commit')
+      }
+    },
+    async (a) => runWrite('stop_running_timer', {}, a.preview)
   )
 
   return server

--- a/src/mcp/socketPath.ts
+++ b/src/mcp/socketPath.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared resolvers for the MCP write-bridge endpoint and token file.
+ *
+ * Both processes must agree on these locations:
+ *  - the Electron main process (mcpBridge.ts) — hosts the socket, writes the token
+ *  - the standalone MCP server (writeClient.ts) — connects, reads the token
+ *
+ * Everything is anchored on the TimeTrack userData directory, derived from the
+ * DB path (which honours TIMETRACK_DB_PATH) so a custom profile keeps socket,
+ * token and DB together. Electron-free — safe to import from either side.
+ *
+ *   Windows : named pipe  \\.\pipe\timetrack-mcp
+ *   *nix    : unix socket  <userData>/mcp.sock
+ *   token   :              <userData>/mcp-write.token   (mode 0600)
+ */
+import { dirname, join } from 'path'
+import { resolveDbPath } from './dbPath'
+
+export const TOKEN_FILENAME = 'mcp-write.token'
+export const SOCK_FILENAME = 'mcp.sock'
+export const WIN_PIPE = '\\\\.\\pipe\\timetrack-mcp'
+
+/** Socket path (or named pipe) for a given userData directory. */
+export function socketPathForDir(
+  dir: string,
+  platform: NodeJS.Platform = process.platform
+): string {
+  return platform === 'win32' ? WIN_PIPE : join(dir, SOCK_FILENAME)
+}
+
+/** Token file path for a given userData directory. */
+export function tokenPathForDir(dir: string): string {
+  return join(dir, TOKEN_FILENAME)
+}
+
+/** userData directory, inferred from the resolved DB path. */
+export function userDataDir(): string {
+  return dirname(resolveDbPath())
+}
+
+/** MCP-side socket/pipe resolver (Electron-free). */
+export function resolveSocketPath(platform: NodeJS.Platform = process.platform): string {
+  return socketPathForDir(userDataDir(), platform)
+}
+
+/** MCP-side token-file resolver (Electron-free). */
+export function resolveTokenPath(): string {
+  return tokenPathForDir(userDataDir())
+}

--- a/src/mcp/writeClient.ts
+++ b/src/mcp/writeClient.ts
@@ -80,5 +80,9 @@ export function sendWrite(
       }
     })
     conn.on('error', () => finish({ ok: false, error: UNAVAILABLE, code: 'unavailable' }))
+    // If the app closes the connection without a newline-terminated response
+    // (e.g. it crashed mid-request), resolve now instead of hanging until the
+    // deadline. No-op once a response has already been delivered.
+    conn.on('close', () => finish({ ok: false, error: UNAVAILABLE, code: 'unavailable' }))
   })
 }

--- a/src/mcp/writeClient.ts
+++ b/src/mcp/writeClient.ts
@@ -1,0 +1,84 @@
+/**
+ * Client for the TimeTrack write bridge (MCP-server side).
+ *
+ * Connects to the local socket / named pipe hosted by the running Electron
+ * app, authenticates with the token file, sends one line-delimited JSON
+ * request and resolves the single JSON response. The MCP process never writes
+ * to the DB itself — all mutations go through the app's validated handlers.
+ */
+import net from 'net'
+import { existsSync, readFileSync } from 'fs'
+import { resolveSocketPath, resolveTokenPath } from './socketPath'
+
+export interface WriteResult {
+  ok: boolean
+  data?: unknown
+  error?: string
+  code?: string
+}
+
+const UNAVAILABLE =
+  'TimeTrack läuft nicht oder der Schreibzugriff ist deaktiviert (Einstellungen → Integrationen).'
+
+// Generous ceiling: a "per-write" confirmation waits on the user in the app.
+const RESPONSE_DEADLINE_MS = 5 * 60 * 1000
+
+export function sendWrite(
+  op: string,
+  args: Record<string, unknown>,
+  preview: boolean
+): Promise<WriteResult> {
+  return new Promise((resolve) => {
+    const tokenFile = resolveTokenPath()
+    if (!existsSync(tokenFile)) {
+      resolve({ ok: false, error: UNAVAILABLE, code: 'unavailable' })
+      return
+    }
+    let token: string
+    try {
+      token = readFileSync(tokenFile, 'utf8').trim()
+    } catch {
+      resolve({ ok: false, error: UNAVAILABLE, code: 'unavailable' })
+      return
+    }
+
+    let buf = ''
+    let done = false
+    const conn = net.createConnection(resolveSocketPath())
+    const timer = setTimeout(() => {
+      finish({
+        ok: false,
+        error: 'Zeitüberschreitung bei der Verbindung zu TimeTrack.',
+        code: 'timeout'
+      })
+    }, RESPONSE_DEADLINE_MS)
+
+    function finish(r: WriteResult): void {
+      if (done) return
+      done = true
+      clearTimeout(timer)
+      try {
+        conn.destroy()
+      } catch {
+        // ignore
+      }
+      resolve(r)
+    }
+
+    conn.on('connect', () => {
+      conn.write(JSON.stringify({ v: 1, token, op, args, preview }) + '\n')
+    })
+    conn.on('data', (chunk) => {
+      buf += chunk.toString('utf8')
+      const idx = buf.indexOf('\n')
+      if (idx >= 0) {
+        try {
+          finish(JSON.parse(buf.slice(0, idx)) as WriteResult)
+        } catch {
+          finish({ ok: false, error: 'Ungültige Antwort von TimeTrack.' })
+        }
+      }
+    })
+    conn.on('error', () => finish({ ok: false, error: UNAVAILABLE, code: 'unavailable' }))
+  })
+}

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -868,9 +868,40 @@ export default function SettingsView(): React.JSX.Element {
             </Section>
 
             <Section title={t('settings.mcp.writeTitle')}>
-              <Row label={t('settings.mcp.writeEnable')} hint={t('settings.mcp.writeSoon')}>
-                <Toggle checked={false} disabled onChange={() => {}} />
+              <Row label={t('settings.mcp.writeEnable')} hint={t('settings.mcp.writeEnableHint')}>
+                <Toggle
+                  checked={settings.mcp_write_enabled === '1'}
+                  onChange={(v) => void update('mcp_write_enabled', v ? '1' : '0')}
+                />
               </Row>
+              {settings.mcp_write_enabled === '1' && (
+                <>
+                  <Row
+                    label={t('settings.mcp.confirmMode')}
+                    hint={t('settings.mcp.confirmModeHint')}
+                  >
+                    <select
+                      aria-label={t('settings.mcp.confirmMode')}
+                      value={settings.mcp_write_confirm_mode ?? 'per-write'}
+                      onChange={(e) => void update('mcp_write_confirm_mode', e.target.value)}
+                      className={inputClass}
+                    >
+                      <option value="per-write">{t('settings.mcp.confirmPerWrite')}</option>
+                      <option value="session">{t('settings.mcp.confirmSession')}</option>
+                      <option value="silent">{t('settings.mcp.confirmSilent')}</option>
+                    </select>
+                  </Row>
+                  <Row label={t('settings.mcp.auditLog')} hint={t('settings.mcp.auditLogHint')}>
+                    <button
+                      type="button"
+                      onClick={() => window.api.shell.openPath(paths.logs)}
+                      className={btnSecondaryClass}
+                    >
+                      {t('settings.mcp.openAuditLog')}
+                    </button>
+                  </Row>
+                </>
+              )}
             </Section>
           </>
         )}

--- a/src/shared/locales/de.ts
+++ b/src/shared/locales/de.ts
@@ -552,8 +552,17 @@ export const de = {
     'Standardmäßig aus. Betrifft das interne Notizfeld (private_note), das nie exportiert wird.',
   'settings.mcp.writeTitle': 'Schreibzugriff',
   'settings.mcp.writeEnable': 'Schreibzugriff erlauben',
-  'settings.mcp.writeSoon':
-    'Kommt später als eigenes, abgesichertes Feature (Allowlist, Vorschau, Pre-Write-Backup).',
+  'settings.mcp.writeEnableHint':
+    'Erlaubt Claude, über den MCP Einträge anzulegen/zu ändern und Timer zu starten/stoppen — abgesichert durch Bestätigung, Pre-Write-Backup und Audit-Log. Nur bei laufender App.',
+  'settings.mcp.confirmMode': 'Bestätigung',
+  'settings.mcp.confirmModeHint': 'Wie eine Schreibaktion in der App bestätigt wird.',
+  'settings.mcp.confirmPerWrite': 'Bei jeder Änderung nachfragen',
+  'settings.mcp.confirmSession': 'Einmal pro Sitzung',
+  'settings.mcp.confirmSilent': 'Nicht nachfragen',
+  'settings.mcp.auditLog': 'Audit-Log',
+  'settings.mcp.auditLogHint':
+    'Jede ausgeführte Schreibaktion wird in mcp-writes.log protokolliert.',
+  'settings.mcp.openAuditLog': 'Log-Ordner öffnen',
   'settings.theme.title': 'Erscheinungsbild',
   'settings.theme.light': 'Hell',
   'settings.theme.dark': 'Dunkel',

--- a/src/shared/locales/en.ts
+++ b/src/shared/locales/en.ts
@@ -545,8 +545,16 @@ export const en: Record<TranslationKey, string> = {
     'Off by default. Affects the internal note field (private_note), which is never exported.',
   'settings.mcp.writeTitle': 'Write access',
   'settings.mcp.writeEnable': 'Allow write access',
-  'settings.mcp.writeSoon':
-    'Coming later as a separate, guarded feature (allowlist, preview, pre-write backup).',
+  'settings.mcp.writeEnableHint':
+    'Lets Claude create/edit entries and start/stop timers via MCP — guarded by confirmation, a pre-write backup and an audit log. Only while the app is running.',
+  'settings.mcp.confirmMode': 'Confirmation',
+  'settings.mcp.confirmModeHint': 'How a write action is confirmed in the app.',
+  'settings.mcp.confirmPerWrite': 'Ask on every change',
+  'settings.mcp.confirmSession': 'Once per session',
+  'settings.mcp.confirmSilent': "Don't ask",
+  'settings.mcp.auditLog': 'Audit log',
+  'settings.mcp.auditLogHint': 'Every executed write action is logged to mcp-writes.log.',
+  'settings.mcp.openAuditLog': 'Open log folder',
   'settings.theme.title': 'Appearance',
   'settings.theme.light': 'Light',
   'settings.theme.dark': 'Dark',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -194,6 +194,9 @@ export interface Settings {
   mcp_expose_rates?: string
   mcp_expose_private_notes?: string
   mcp_write_enabled?: string
+  // v1.14 #127 — MCP write-mode confirmation (seeded by migration 019):
+  // 'per-write' (default) | 'session' | 'silent'.
+  mcp_write_confirm_mode?: string
 }
 
 export interface CreateClientInput {
@@ -286,7 +289,7 @@ export interface MonthQuery {
 
 export type IpcResult<T> = { ok: true; data: T } | { ok: false; error: string }
 
-export type BackupReason = 'daily' | 'manual' | 'pre-migration'
+export type BackupReason = 'daily' | 'manual' | 'pre-migration' | 'mcp'
 
 export interface BackupInfo {
   filename: string


### PR DESCRIPTION
Ergänzt den read-only MCP-Server um einen **abgesicherten, opt-in Schreibpfad** (#127) und hebt die App auf **v1.14.0**, damit die gesamte MCP-Funktionalität ausgeliefert wird.

## Kernprinzip

Der MCP-Server schreibt **nie** direkt in die SQLite-DB (WAL-Konflikt + Electron-ABI). Schreib-Tools senden über einen lokalen **Named Pipe / Unix-Socket** an die **laufende App**, die die Änderung durch ihre **eigene validierte Logik** ausführt (Overlap-Prüfung, Cross-Midnight-Split, Transaktionen).

```
Claude Code ──stdio──> MCP-Server ──socket(+Token)──> TimeTrack (laufend)
   Lesen: direkt read-only auf DB          │  Token → Opt-in → Allowlist →
                                           │  Preview → Confirm → Backup(1×) →
                                           └─ entryMutations → Broadcast + Audit
```

## Umfang (Kern + Timer starten)

Tools (je mit `preview: true`): `create_manual_entry`, `update_entry_fields`, `start_timer`, `stop_running_timer`.

## Sicherheits-Guards

- **Opt-in**, default aus (`mcp_write_enabled`).
- **Token**: Zufallstoken bei Aktivierung (`<userData>/mcp-write.token`, `0600`), **Rotation je App-Start**; jede Anfrage muss es tragen.
- **Allowlist** — alles andere hart abgelehnt.
- **Preview** — geplante Änderung ohne Commit.
- **Bestätigung** wählbar per Dropdown: bei jeder Änderung (Default) / einmal pro Sitzung / nie — als native `dialog.showMessageBox` mit „für Session merken".
- **Pre-Write-Backup** einmal je Sitzung (`backup-mcp-*`).
- **Audit-Log** `mcp-writes.log` (append-only; Token & interne Notizen werden nie protokolliert).
- App zu / Schreiben aus → klare Fehlermeldung, kein Fallback.

## Architektur / Refactor

- **`entryMutations.ts`** — create/update/stop/start + Validierung aus den `entries:*`-Handlern extrahiert (Electron-frei, wiederverwendbar); Handler sind jetzt Thin-Shims. Von IPC **und** Bridge genutzt.
- **`mcpBridgeCore.ts`** — Electron-freie, getestete Guard-Kette. **`mcpBridge.ts`** — net-Server, Confirm-Dialog, Token, Socket-Lifecycle (in `index.ts` bei `whenReady`/`will-quit` + Settings-Hook verdrahtet, nur Primary-Instanz).
- **`socketPath.ts` / `writeClient.ts`** — Endpoint-/Token-Resolver + Socket-Client auf MCP-Seite.
- **Migration 019** — seedet `mcp_write_confirm_mode`.

## UI

**Einstellungen → Integrationen**: funktionaler Schreibzugriff-Toggle, Bestätigungs-Modus-Dropdown, „Audit-Log öffnen" (DE/EN).

## Tests & Qualität

- **entryMutations**: create/update/stop/start inkl. Cross-Midnight-Split, Overlap, Timer-Wechsel.
- **Bridge-Guardkette**: bad_token, write_disabled, not_allowed, Preview mutiert nicht, Confirm-Ablehnung, Commit + Backup + Audit + Broadcast einmalig.
- **Echter Socket-Round-Trip-Smoke** (writeClient ↔ Bridge-Kern): Preview → Commit → falsches Token abgelehnt, verifiziert.
- Ganze Suite **513 grün**, Typecheck (node + web + mcp) sauber, `pnpm build:mcp` ok.

## Release v1.14.0

`package.json` → 1.14.0; `CHANGELOG.md` `[Unreleased]` → `[1.14.0]` (bündelt read-only + Integrationen + Write-Mode); README-Abschnitt „MCP-Integration" um Write-Tools + Sicherheitsmodell erweitert. **Der auslösende Tag-Push `v1.14.0` erfolgt bewusst erst nach Merge auf `main` und auf explizites Go** (er startet Build + öffentliches Release + Auto-Update-Verteilung).

## Native-ABI-Hinweis

Der MCP-Server läuft unter Node; `better-sqlite3` ist auf Electron-ABI gebaut → für den Betrieb `npm rebuild better-sqlite3 --build-from-source` (in README dokumentiert). Der Schreibpfad selbst umgeht das, weil er über die laufende App geht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VF3ef5EN9w6f17akah1VFh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VF3ef5EN9w6f17akah1VFh)_