### PR TITLE
v1.14.1 fix: MCP-Server findet die Datenbank wieder (userData-Verzeichnis)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to TimeTrack are documented here.
 
 ## [Unreleased]
 
+## [1.14.1] — 2026-07-25
+
+### Fixed
+
+- **MCP-Server findet die Datenbank wieder** — Der Server suchte die Zeiterfassung in `%APPDATA%\TimeTrack\` (macOS `~/Library/Application Support/TimeTrack/`, Linux `~/.config/TimeTrack/`), die App legt sie aber in `time-tracking` ab: Electron leitet dieses Verzeichnis aus `package.json` → `name` ab, der `productName` aus dem Installer benennt nur die installierte App. Der gesuchte Ordner existierte damit auf **keiner** Installation — alle Lese-Tools scheiterten mit „Datenbank nicht gefunden", solange man `TIMETRACK_DB_PATH` nicht von Hand setzte. Der Schreibzugriff war genauso betroffen: Token und Socket werden neben der Datenbank gesucht, also antworteten die Schreib-Tools mit „TimeTrack läuft nicht", obwohl die App lief. Wer den Fehler mit einer Kopie der Datenbank im alten Ordner umgangen hat, liest ab jetzt wieder die echte — die Kopie kann weg.
+
+### Changed
+
+- **Dokumentierte Datenpfade korrigiert** — README, PRIVACY.md und CONTRIBUTING.md nannten `%AppData%\TimeTrack\` als Ablageort; tatsächlich ist es `%AppData%\time-tracking\` (macOS `~/Library/Application Support/time-tracking/`). PRIVACY.md nannte zusätzlich einen Dateinamen, den es nie gab (`timetrack.db` statt `timetrack.sqlite`).
+
 ## [1.14.0] — 2026-07-24
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,8 +35,8 @@ pnpm lint           # ESLint
 pnpm build          # Production-Build (electron-builder, ohne Publish)
 ```
 
-App-Daten landen lokal in `%AppData%\TimeTrack\` (Windows) bzw.
-`~/Library/Application Support/TimeTrack/` (macOS). Diese kannst du beim
+App-Daten landen lokal in `%AppData%\time-tracking\` (Windows) bzw.
+`~/Library/Application Support/time-tracking/` (macOS). Diese kannst du beim
 Entwickeln gefahrlos sichern oder löschen.
 
 ## Pull-Request-Workflow

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -7,9 +7,9 @@ Es gibt keine Cloud-Synchronisation, keine Konten und keinen eigenen Server.
 
 | Typ | Pfad (Windows) | Pfad (macOS) |
 | --- | -------------- | ------------ |
-| Datenbank | `%AppData%\TimeTrack\timetrack.db` | `~/Library/Application Support/TimeTrack/timetrack.db` |
-| Einstellungen | `%AppData%\TimeTrack\timetrack.db` | (selbe DB) |
-| Log-Dateien | `%AppData%\TimeTrack\logs\` | `~/Library/Logs/TimeTrack/` |
+| Datenbank | `%AppData%\time-tracking\timetrack.sqlite` | `~/Library/Application Support/time-tracking/timetrack.sqlite` |
+| Einstellungen | `%AppData%\time-tracking\timetrack.sqlite` | (selbe DB) |
+| Log-Dateien | `%AppData%\time-tracking\logs\` | `~/Library/Logs/time-tracking/` |
 | PDF-Exporte | Frei wählbarer Speicherort | Frei wählbarer Speicherort |
 
 Du kannst die Datenbank jederzeit sichern oder löschen. Ein Backup-Export

--- a/README.md
+++ b/README.md
@@ -113,9 +113,11 @@ pnpm mcp         # startet den stdio-Server
 }
 ```
 
-Der DB-Pfad wird plattformübergreifend aufgelöst (Windows `%APPDATA%\TimeTrack\`,
-macOS `~/Library/Application Support/TimeTrack/`, Linux `~/.config/TimeTrack/`) und lässt
-sich per `TIMETRACK_DB_PATH` überschreiben.
+Der DB-Pfad wird plattformübergreifend aufgelöst (Windows `%APPDATA%\time-tracking\`,
+macOS `~/Library/Application Support/time-tracking/`, Linux `~/.config/time-tracking/`) und
+lässt sich per `TIMETRACK_DB_PATH` überschreiben. Das Verzeichnis heißt `time-tracking`
+(package.json → `name`), nicht `TimeTrack` — der `productName` aus `electron-builder.yml`
+benennt nur die installierte App, nicht `app.getPath('userData')`.
 
 **Datenschutz:** Stundensätze/Umsätze und interne Notizen (`private_note`) sind **standardmäßig
 ausgeblendet**. Einschalten wahlweise in der App unter **Einstellungen → Integrationen** (die

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "time-tracking",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "Schlanker Desktop-Zeiterfasser für Windows — Toggl-Track-Style, lokal, ohne Cloud.",
   "main": "./out/main/index.js",
   "author": "skoedr",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -37,8 +37,9 @@ import {
 import type { Client } from '../shared/types'
 
 // ── Logging (v1.5 PR A) ─────────────────────────────────────────
-// electron-log writes to %AppData%\TimeTrack\logs\main.log on Windows
-// (~/Library/Logs/TimeTrack on macOS, ~/.config/TimeTrack/logs on Linux).
+// electron-log writes to %AppData%\time-tracking\logs\main.log on Windows
+// (~/Library/Logs/time-tracking on macOS, ~/.config/time-tracking/logs on
+// Linux) — the directory is app.getName(), i.e. package.json → name.
 // `spyRendererConsole: true` mirrors renderer console.* into the same
 // file via IPC — no separate channel needed. `Object.assign(console, …)`
 // routes main-process console.* through the logger too, so existing

--- a/src/main/mcpAudit.ts
+++ b/src/main/mcpAudit.ts
@@ -2,7 +2,7 @@
  * Append-only audit log for MCP write-mode mutations.
  *
  * Uses a dedicated electron-log scope so entries land next to the app logs
- * (%AppData%/TimeTrack/logs on Windows) as `mcp-writes.log`, with the same
+ * (%AppData%/time-tracking/logs on Windows) as `mcp-writes.log`, with the same
  * size-based rotation electron-log already provides. Never records the token
  * or `private_note` content.
  */

--- a/src/mcp/dbPath.test.ts
+++ b/src/mcp/dbPath.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for the Electron-free userData/DB path resolver.
+ *
+ * The regression these guard: the resolver used to hardcode `TimeTrack` (the
+ * electron-builder `productName`), while Electron derives userData from
+ * `app.getName()` → `package.json` → `name` = `time-tracking`. The MCP server
+ * therefore looked for the DB — and, via socketPath.ts, for the write token —
+ * in a directory that never existed on any install.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { readFileSync } from 'fs'
+import { join, dirname } from 'path'
+import { appDataDir, resolveDbPath } from './dbPath'
+import {
+  resolveSocketPath,
+  resolveTokenPath,
+  SOCK_FILENAME,
+  TOKEN_FILENAME,
+  WIN_PIPE
+} from './socketPath'
+
+const HOME = join('/home', 'robin')
+
+describe('appDataDir', () => {
+  it('uses %APPDATA% on Windows', () => {
+    expect(appDataDir('win32', { APPDATA: 'C:\\Users\\r\\AppData\\Roaming' }, HOME)).toBe(
+      'C:\\Users\\r\\AppData\\Roaming'
+    )
+  })
+
+  it('falls back to <home>/AppData/Roaming when %APPDATA% is unset', () => {
+    expect(appDataDir('win32', {}, HOME)).toBe(join(HOME, 'AppData', 'Roaming'))
+  })
+
+  it('uses Application Support on macOS', () => {
+    expect(appDataDir('darwin', {}, HOME)).toBe(join(HOME, 'Library', 'Application Support'))
+  })
+
+  it('respects XDG_CONFIG_HOME on Linux, else ~/.config', () => {
+    expect(appDataDir('linux', { XDG_CONFIG_HOME: '/xdg' }, HOME)).toBe('/xdg')
+    expect(appDataDir('linux', {}, HOME)).toBe(join(HOME, '.config'))
+  })
+})
+
+describe('resolveDbPath', () => {
+  it('points at the app-name directory, not the productName one', () => {
+    const win = resolveDbPath('win32', { APPDATA: 'C:\\Roaming' }, HOME)
+    expect(win).toBe(join('C:\\Roaming', 'time-tracking', 'timetrack.sqlite'))
+    expect(win).not.toMatch(/TimeTrack/)
+  })
+
+  it('uses the same directory name on macOS and Linux', () => {
+    expect(resolveDbPath('darwin', {}, HOME)).toBe(
+      join(HOME, 'Library', 'Application Support', 'time-tracking', 'timetrack.sqlite')
+    )
+    expect(resolveDbPath('linux', {}, HOME)).toBe(
+      join(HOME, '.config', 'time-tracking', 'timetrack.sqlite')
+    )
+  })
+
+  it('matches package.json → name, which is what app.getName() returns', () => {
+    const pkg = JSON.parse(readFileSync(new URL('../../package.json', import.meta.url), 'utf8'))
+    // If `productName` is ever added to package.json, Electron prefers it and
+    // this resolver must follow — the assertion below fails loudly if so.
+    expect(pkg.productName).toBeUndefined()
+    expect(resolveDbPath('linux', {}, HOME)).toBe(
+      join(HOME, '.config', pkg.name, 'timetrack.sqlite')
+    )
+  })
+
+  it('honours TIMETRACK_DB_PATH, trimmed', () => {
+    expect(resolveDbPath('win32', { TIMETRACK_DB_PATH: '  D:\\custom\\tt.sqlite  ' }, HOME)).toBe(
+      'D:\\custom\\tt.sqlite'
+    )
+  })
+
+  it('ignores a blank TIMETRACK_DB_PATH', () => {
+    expect(resolveDbPath('linux', { TIMETRACK_DB_PATH: '   ' }, HOME)).toBe(
+      join(HOME, '.config', 'time-tracking', 'timetrack.sqlite')
+    )
+  })
+})
+
+describe('token and socket paths (derived from the DB path)', () => {
+  const original = process.env.TIMETRACK_DB_PATH
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.TIMETRACK_DB_PATH
+    else process.env.TIMETRACK_DB_PATH = original
+  })
+
+  it('token lands next to the DB when TIMETRACK_DB_PATH is set', () => {
+    const db = join('D:', 'profile', 'timetrack.sqlite')
+    process.env.TIMETRACK_DB_PATH = db
+    expect(resolveTokenPath()).toBe(join(dirname(db), TOKEN_FILENAME))
+  })
+
+  it('token lands in the app-name directory by default', () => {
+    delete process.env.TIMETRACK_DB_PATH
+    expect(dirname(resolveTokenPath())).toMatch(/time-tracking$/)
+  })
+
+  // The socket was broken by the same wrong directory on posix. On Windows the
+  // endpoint is a fixed named pipe, so only the posix branch depends on the fix.
+  it('socket lands next to the DB on posix', () => {
+    const db = join('D:', 'profile', 'timetrack.sqlite')
+    process.env.TIMETRACK_DB_PATH = db
+    expect(resolveSocketPath('linux')).toBe(join(dirname(db), SOCK_FILENAME))
+  })
+
+  it('socket lands in the app-name directory by default on posix', () => {
+    delete process.env.TIMETRACK_DB_PATH
+    expect(dirname(resolveSocketPath('linux'))).toMatch(/time-tracking$/)
+  })
+
+  it('socket is the fixed named pipe on Windows', () => {
+    delete process.env.TIMETRACK_DB_PATH
+    expect(resolveSocketPath('win32')).toBe(WIN_PIPE)
+  })
+})

--- a/src/mcp/dbPath.ts
+++ b/src/mcp/dbPath.ts
@@ -2,13 +2,18 @@
  * Cross-platform resolver for the TimeTrack SQLite database path.
  *
  * The Electron app stores its DB at `app.getPath('userData')/timetrack.sqlite`,
- * where `userData` is `<appData>/TimeTrack` (productName = "TimeTrack", see
- * electron-builder.yml). This module reproduces that location WITHOUT importing
- * Electron, so the standalone MCP server can find the same file.
+ * where `userData` is `<appData>/<app.getName()>`. This module reproduces that
+ * location WITHOUT importing Electron, so the standalone MCP server can find
+ * the same file.
  *
- *   Windows : %APPDATA%\TimeTrack\timetrack.sqlite
- *   macOS   : ~/Library/Application Support/TimeTrack/timetrack.sqlite
- *   Linux   : ~/.config/TimeTrack/timetrack.sqlite   (or $XDG_CONFIG_HOME)
+ *   Windows : %APPDATA%\time-tracking\timetrack.sqlite
+ *   macOS   : ~/Library/Application Support/time-tracking/timetrack.sqlite
+ *   Linux   : ~/.config/time-tracking/timetrack.sqlite   (or $XDG_CONFIG_HOME)
+ *
+ * NOTE the directory is `time-tracking`, not `TimeTrack`: `app.getName()` reads
+ * `package.json` → `name`, and we set no `productName` there. The `productName:
+ * TimeTrack` in electron-builder.yml names the installed *product* (exe, Start
+ * menu, install dir) and does NOT influence `getPath('userData')`.
  *
  * Override with the `TIMETRACK_DB_PATH` env var (absolute path to the .sqlite
  * file) — useful for tests, portable installs, or a non-default profile.
@@ -16,7 +21,8 @@
 import { homedir } from 'os'
 import { join } from 'path'
 
-const APP_DIR = 'TimeTrack'
+/** Must match `package.json` → `name`, which is what `app.getName()` returns. */
+const APP_DIR = 'time-tracking'
 const DB_FILE = 'timetrack.sqlite'
 
 /** Roaming app-data directory, matching Electron's `getPath('appData')`. */


### PR DESCRIPTION
## Summary

Der mitgelieferte MCP-Server konnte die Zeiterfassungs-Datenbank auf **keiner** Installation finden.

**Der Bug**

`src/mcp/dbPath.ts` löste den Datenordner auf `<appData>/TimeTrack` auf — mit Verweis auf `productName: TimeTrack` aus `electron-builder.yml`. Electron leitet `app.getPath('userData')` aber aus `app.getName()` ab, und das liest `package.json` → `name` = `time-tracking`. Der `productName` aus der electron-builder-Konfiguration benennt nur die installierte App (exe, Startmenü, Installationsordner) und hat auf `userData` keinen Einfluss.

Ergebnis auf einer frischen 1.14.0-Installation:

```
%APPDATA%\time-tracking\timetrack.sqlite   ← existiert (App)
%APPDATA%\TimeTrack\                       ← existiert nicht (MCP-Server suchte hier)
```

Alle Lese-Tools scheiterten mit „Datenbank nicht gefunden", solange `TIMETRACK_DB_PATH` nicht von Hand gesetzt war.

**Blast Radius größer als nur Lesen**

`src/mcp/socketPath.ts:38` verankert `userDataDir()` auf `dirname(resolveDbPath())`. Damit lagen auch der Write-Token (`mcp-write.token`) und der posix-Socket am falschen Ort — die Schreib-Tools antworteten „TimeTrack läuft nicht oder der Schreibzugriff ist deaktiviert", obwohl die App lief und Schreiben eingeschaltet war. Der Windows-Named-Pipe ist fix benannt und war als einziges nicht betroffen.

**Was sich ändert** (`8d9cbfe`, `610f6f7`)

- `APP_DIR` → `'time-tracking'`, mit Kommentar warum es nicht der `productName` ist.
- Neue `src/mcp/dbPath.test.ts`: beide Resolver auf allen drei Plattformen, `%APPDATA%`- und `XDG`-Fallbacks, `TIMETRACK_DB_PATH`-Override inkl. Trim und Blank-Fall, Token- und Socket-Ableitung.
- Regressions-Guard: der Test schlägt fehl, sobald `package.json` ein `productName` bekäme — Electron würde es bevorzugen und `userData` erneut verschieben, diesmal unter den Füßen bestehender Nutzer.
- Doku: README, PRIVACY.md, CONTRIBUTING.md nannten durchgehend `%AppData%\TimeTrack\`. PRIVACY.md nannte zusätzlich einen Dateinamen, den es nie gab (`timetrack.db` statt `timetrack.sqlite`). Dazu die Header-Kommentare in `src/main/index.ts` und `src/main/mcpAudit.ts`.

**Verifiziert gegen die installierte App**, nicht nur gegen Tests: stdio-Handshake gegen den gebauten Server, `get_dashboard` und `list_clients` liefern echte Daten aus `%APPDATA%\time-tracking\timetrack.sqlite`.

**Nebeneffekt:** Wer den Bug mit einer Kopie der Datenbank im alten Ordner umgangen hat, liest ab jetzt wieder die echte. Die Kopie wird zur Karteileiche und kann weg.

## Test Coverage

```
CODE PATHS                                              TESTS
[~] src/mcp/dbPath.ts  (APP_DIR: 'TimeTrack' → 'time-tracking')
  ├── appDataDir()
  │   ├── [★★★ TESTED] win32 + %APPDATA% gesetzt
  │   ├── [★★★ TESTED] win32 + %APPDATA% fehlt (Fallback)
  │   ├── [★★★ TESTED] darwin
  │   └── [★★★ TESTED] linux XDG_CONFIG_HOME + ~/.config
  └── resolveDbPath()
      ├── [★★★ TESTED] Default-Verzeichnis (win/mac/linux)
      ├── [★★★ TESTED] Regression: Pfad enthält kein /TimeTrack/
      ├── [★★★ TESTED] Guard gegen package.json → productName
      ├── [★★★ TESTED] TIMETRACK_DB_PATH + Trim
      └── [★★★ TESTED] blanker Override wird ignoriert
[~] src/mcp/socketPath.ts (unverändert, aber downstream des Fixes)
      ├── [★★★ TESTED] Token folgt dem Override
      ├── [★★★ TESTED] Token im Default-Verzeichnis
      ├── [★★★ TESTED] Socket folgt dem Override (posix)
      ├── [★★★ TESTED] Socket im Default-Verzeichnis (posix)
      └── [★★★ TESTED] Windows: fixer Named Pipe
[~] src/main/index.ts, src/main/mcpAudit.ts   — Kommentar-only, kein Codepfad
[~] README/PRIVACY/CONTRIBUTING.md            — Doku, kein Codepfad

COVERAGE: 14/14 paths tested (100%)  |  QUALITY: ★★★:14  |  GAPS: 0
```

Tests: 28 → 29 Dateien (+1). Coverage-Gate: **PASS (100%)**.

## Pre-Landing Review

2 Findings, 0 kritisch, beide auto-fixed:

- `src/mcp/dbPath.test.ts` (confidence 8/10, testing) — `resolveSocketPath()` leitet auf posix `<userData>/mcp.sock` aus demselben Resolver ab und war vom selben Bug betroffen, hatte aber keinen Test. → Socket-Fälle ergänzt.
- `src/mcp/dbPath.test.ts` (confidence 7/10, testing) — `endsWith()` in `toBe(true)` gekapselt, Fehlermeldung zeigte den Pfad nicht. → auf `toMatch(/time-tracking$/)` umgestellt.

Specialists: testing + maintainability gelaufen. security / performance / data-migration / api-contract / design übersprungen (`SCOPE_*=false`). Red Team nicht aktiviert (165 Zeilen < 200, keine kritischen Findings). PR Quality Score: 9.0/10.

**Adversarial Review** (Claude): keine FIXABLE Findings. Ein INVESTIGATE-Punkt: die macOS-/Linux-Logpfade in PRIVACY.md sind aus derselben `app.getName()`-Regel abgeleitet, aber nur der Windows-Pfad ist auf dieser Maschine empirisch bestätigt (`%AppData%\time-tracking\logs\main.log` existiert). Codex war nicht installiert — Cross-Model-Abdeckung fehlt für diesen PR.

## Design Review

Keine Frontend-Dateien geändert — Design Review übersprungen.

## Eval Results

Keine prompt-bezogenen Dateien geändert — Evals übersprungen.

## Scope Drift

Scope Check: **CLEAN**. Intent: MCP-Server soll die DB der installierten App finden. Delivered: Resolver korrigiert + Regressionstests + die Doku-Stellen, die denselben falschen Pfad behaupteten. Über den Resolver hinaus ging nur die Korrektur des DB-Dateinamens in PRIVACY.md (`timetrack.db` → `timetrack.sqlite`) — dieselbe Tabellenzeile, gleiche Fehlerklasse.

## Plan Completion

Kein Plan-File für diesen Branch — Audit übersprungen.

## TODOS

Keine TODO-Einträge werden von diesem PR abgeschlossen. TODOS.md nutzt eine eigene, konsistente Konvention (Gruppen + durchgestrichene Resolved-Einträge) statt des P0–P4-Formats; bewusst nicht umgebaut.

## Test plan

- [x] Vitest: 528 Tests grün, 1 skipped (29 Dateien)
- [x] `npm run typecheck` grün (node + web + mcp)
- [x] `pnpm build:mcp` grün
- [x] stdio-Smoke-Test gegen die installierte 1.14.0-DB: `get_dashboard` + `list_clients` liefern echte Daten

🤖 Generated with [Claude Code](https://claude.com/claude-code)
