### PR TITLE
v1.14.2 docs: TODOS-Notizen aus dem Ship-Review

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -39,6 +39,12 @@ Deferred items from plan reviews. Items here have explicit decisions — they ar
 
 - **DB-Cleanup: tote Rounding-Settings** — `rounding_mode` und `rounding_minutes` wurden aus UI + Types entfernt (v1.11, 2026-04-30), stehen aber noch als Rows in der `settings`-Tabelle (gesät von Migration 001). Migration 014 ergänzt `DELETE FROM settings WHERE key IN ('rounding_mode', 'rounding_minutes')` als Cleanup-Statement.
 
+### Kleinkram (aus /ship-Review v1.14.2, 2026-07-25)
+
+- **Redundante `@electron/rebuild`-devDependency** — electron-builder warnt bei jedem Paketbuild: „@electron/rebuild already used by electron-builder, please consider to remove excess dependency from devDependencies". Der Release-Workflow ruft `electron-rebuild` allerdings direkt auf (`pnpm exec electron-rebuild -f -w better-sqlite3`), vor dem Entfernen also prüfen, ob der Aufruf über electron-builder mitkommt.
+
+- **RunAsNode-Fuse-Abhängigkeit dokumentieren** — Seit v1.14.2 startet der MCP-Server über `ELECTRON_RUN_AS_NODE=1`. Diese Electron-Fuse lässt sich zur Härtung abschalten; das Projekt setzt derzeit keine Fuses, also funktioniert es. Würde man Fuses jemals aktivieren, muss `runAsNode` an bleiben, sonst bricht die MCP-Integration wortlos. Steht bisher nur im PR-Body von #140, also faktisch unauffindbar — gehört als Kommentar an `electron-builder.yml` oder in `src/main/mcpLaunch.ts`.
+
 ### v1.12 Issues (aktiv geplant)
 
 ~~- **#105 — Projektspezifischer Ansprechpartner**~~ → Abgeschlossen (v1.12.0, 2026-05-04)


### PR DESCRIPTION
## Summary

Zwei Kleinigkeiten aus dem `/ship`-Review von v1.14.2, die kein Issue rechtfertigen, aber auch nicht verloren gehen sollen. Reine Doku, kein Code.

- **Redundante `@electron/rebuild`-devDependency** — electron-builder warnt bei jedem Paketbuild. Mit dem Hinweis versehen, dass der Release-Workflow `electron-rebuild` direkt aufruft, das Entfernen also nicht blind passieren darf.
- **RunAsNode-Fuse** — v1.14.2 startet den MCP-Server über `ELECTRON_RUN_AS_NODE=1`. Würde man Electron-Fuses zur Härtung aktivieren, muss `runAsNode` an bleiben, sonst bricht die Integration wortlos. Stand bisher nur im PR-Body von #140.

Die substanziellen Findings aus derselben Session liegen als #141–#145.

## Test plan

- [x] Nur `TODOS.md` geändert, kein Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)