### PR TITLE
chore(#142/#143): mechanische Lint-Fehler beheben + ESLint als CI-Gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,12 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
+      # #143: ESLint als CI-Gate. --max-warnings bewusst offen gelassen, solange
+      # die verbleibenden Warnungen react-hooks-Hinweise sind; Fehler lassen den
+      # Job ohnehin scheitern.
+      - name: Lint
+        run: pnpm lint
+
       - name: Rebuild native modules for Node (test runtime)
         run: pnpm rebuild better-sqlite3
 

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ templates/*.png
 
 # Claude Code local settings (personal, machine-specific)
 .claude/settings.local.json
+
+# Worktree-Kopien paralleler Agenten (nicht einchecken; der Rest von .claude/
+# bleibt bewusst trackbar).
+.claude/worktrees/

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,7 +6,10 @@ import eslintPluginReactHooks from 'eslint-plugin-react-hooks'
 import eslintPluginReactRefresh from 'eslint-plugin-react-refresh'
 
 export default defineConfig(
-  { ignores: ['**/node_modules', '**/dist', '**/out', 'scripts/**'] },
+  // '.claude/' enthält u. a. die worktree-Kopien paralleler Agenten
+  // (.claude/worktrees/…). Ohne diesen Filter lintet ESLint jede Kopie mit und
+  // vervielfacht die Fehlerzahlen — daher das gesamte Verzeichnis ignorieren.
+  { ignores: ['**/node_modules', '**/dist', '**/out', 'scripts/**', '.claude/'] },
   tseslint.configs.recommended,
   eslintPluginReact.configs.flat.recommended,
   eslintPluginReact.configs.flat['jsx-runtime'],

--- a/src/main/backup.test.ts
+++ b/src/main/backup.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { mkdtempSync, rmSync, writeFileSync, existsSync, statSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync, existsSync, statSync, readFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 
@@ -139,10 +139,10 @@ describe('restoreBackup', () => {
     expect(existsSync(safetyBackupPath)).toBe(true)
     expect(safetyBackupPath).toContain('backup-pre-restore-')
     // Current DB now holds backup contents
-    const current = require('fs').readFileSync(currentDb, 'utf-8')
+    const current = readFileSync(currentDb, 'utf-8')
     expect(current).toBe('BACKUP')
     // Safety copy holds the prior contents
-    const safety = require('fs').readFileSync(safetyBackupPath, 'utf-8')
+    const safety = readFileSync(safetyBackupPath, 'utf-8')
     expect(safety).toBe('CURRENT')
     // Safety is listed (mtime-based, not classified as daily)
     const list = listBackups()

--- a/src/main/pdfMergeHandlers.test.ts
+++ b/src/main/pdfMergeHandlers.test.ts
@@ -3,6 +3,7 @@ import { resolve } from 'path'
 import { PDFDocument } from 'pdf-lib'
 import { mergeExportHandler, mergeOnlyHandler, pdfInfoHandler } from './pdfMergeHandlers'
 import type { FsDeps, DialogDeps, MergeExportPdfDeps } from './pdfMergeHandlers'
+import type { PdfPayload } from './pdf'
 import type { IpcResult } from '../shared/types'
 import type Database from 'better-sqlite3'
 
@@ -59,7 +60,8 @@ function mockFs(files: Record<string, Buffer | 'EBUSY' | 'EPERM'>): FsDeps {
 }
 
 const noDialog: DialogDeps = {
-  showSaveDialog: async () => ({ canceled: true, filePath: undefined }) as any
+  // Electron liefert bei Abbruch einen leeren `filePath` (nicht undefined).
+  showSaveDialog: async () => ({ canceled: true, filePath: '' })
 }
 
 // ── mergeOnlyHandler tests ────────────────────────────────────────────────────
@@ -199,7 +201,7 @@ describe('mergeOnlyHandler', () => {
       }
     }
     const mockDialog: DialogDeps = {
-      showSaveDialog: async () => ({ canceled: false, filePath: 'C:/fallback_merged.pdf' }) as any
+      showSaveDialog: async () => ({ canceled: false, filePath: 'C:/fallback_merged.pdf' })
     }
     const res = await mergeOnlyHandler(
       { stundennachweisPath: 'C:/sn.pdf', invoicePath: 'C:/inv.pdf' },
@@ -409,7 +411,10 @@ function mockDb(): Database.Database {
 function mockPdfDeps(snBuffer: Buffer, mergedBuffer: Buffer): MergeExportPdfDeps {
   return {
     readLogoAsDataUrl: () => '',
-    buildPdfPayload: () => ({}) as any,
+    // Throwaway payload: buildPdfHtml is mocked to ignore it, so the value is
+    // never read — cast a bare object to the real type rather than build a full
+    // PdfPayload just to satisfy the stub.
+    buildPdfPayload: () => ({}) as unknown as PdfPayload,
     buildPdfHtml: () => '<html/>',
     renderPdfBuffer: async () => snBuffer,
     mergePdfs: async () => mergedBuffer
@@ -567,7 +572,7 @@ describe('mergeExportHandler — successful merge', () => {
       existsSync: (p) => p === resolve('C:/invoices/rechnung.pdf'),
       statSync: () => ({ size: pdf1.length }),
       readFileSync: () => pdf1,
-      writeFileSync: (_p, _d) => {
+      writeFileSync: () => {
         if (firstWrite) {
           firstWrite = false
           throw Object.assign(new Error('EPERM'), { code: 'EPERM' })
@@ -575,7 +580,7 @@ describe('mergeExportHandler — successful merge', () => {
       }
     }
     const dialogDeps: DialogDeps = {
-      showSaveDialog: async () => ({ canceled: false, filePath: fallbackPath }) as any
+      showSaveDialog: async () => ({ canceled: false, filePath: fallbackPath })
     }
     const res = await mergeExportHandler(
       mockDb(),

--- a/src/main/pdfMergeHandlers.ts
+++ b/src/main/pdfMergeHandlers.ts
@@ -18,6 +18,16 @@ import type { IpcResult, Settings } from '../shared/types'
 
 const MAX_PDF_BYTES = 50 * 1024 * 1024 // 50 MB
 
+/**
+ * Node fs-Fehler tragen einen `code` (z. B. 'EBUSY', 'EPERM', 'EACCES'). Ein
+ * `catch`-Wert ist in TS `unknown`; dieser Guard grenzt auf die tatsächliche
+ * Node-Fehlerform ein, statt den Wert blind zu casten — so bleibt der
+ * `code`-Zugriff typsicher.
+ */
+function isErrnoException(e: unknown): e is NodeJS.ErrnoException {
+  return e instanceof Error && 'code' in e
+}
+
 // ── Injectable deps (real implementations are the defaults) ──────────────────
 // Injecting deps makes the core logic testable without an Electron runtime.
 
@@ -95,8 +105,8 @@ export async function mergeOnlyHandler(
     for (let i = 0; i < resolvedSnPaths.length; i++) {
       try {
         snBuffers.push(fsDeps.readFileSync(resolvedSnPaths[i]))
-      } catch (e: any) {
-        if (e.code === 'EBUSY' || e.code === 'EPERM') {
+      } catch (e) {
+        if (isErrnoException(e) && (e.code === 'EBUSY' || e.code === 'EPERM')) {
           const label = snPaths.length === 1 ? 'Stundennachweis' : `Stundennachweis ${i + 1}`
           return {
             ok: false,
@@ -110,8 +120,8 @@ export async function mergeOnlyHandler(
     let invBuffer: Buffer
     try {
       invBuffer = fsDeps.readFileSync(resolvedInv)
-    } catch (e: any) {
-      if (e.code === 'EBUSY' || e.code === 'EPERM') {
+    } catch (e) {
+      if (isErrnoException(e) && (e.code === 'EBUSY' || e.code === 'EPERM')) {
         return {
           ok: false,
           error: `Rechnung ist durch ein anderes Programm gesperrt: ${parse(resolvedInv).base}`
@@ -145,9 +155,9 @@ export async function mergeOnlyHandler(
     try {
       fsDeps.writeFileSync(outputPath, merged)
       return { ok: true, data: { path: outputPath } }
-    } catch (writeErr: any) {
+    } catch (writeErr) {
       // Target directory is read-only — fall back to a user-chosen path.
-      if (writeErr.code === 'EPERM' || writeErr.code === 'EACCES') {
+      if (isErrnoException(writeErr) && (writeErr.code === 'EPERM' || writeErr.code === 'EACCES')) {
         const fallback = await dialogDeps.showSaveDialog({
           title: 'Zusammengeführte PDF speichern',
           defaultPath: `${name}_inkl_Stundennachweis.pdf`,
@@ -188,8 +198,8 @@ export async function pdfInfoHandler(
     let buf: Buffer
     try {
       buf = fsDeps.readFileSync(resolved)
-    } catch (e: any) {
-      if (e.code === 'EBUSY' || e.code === 'EPERM') {
+    } catch (e) {
+      if (isErrnoException(e) && (e.code === 'EBUSY' || e.code === 'EPERM')) {
         return {
           ok: false,
           error: `Datei ist durch ein anderes Programm gesperrt: ${parse(resolved).base}`
@@ -255,8 +265,8 @@ export async function mergeExportHandler(
     let invoiceBuffer: Buffer
     try {
       invoiceBuffer = fsDeps.readFileSync(resolvedInvoice)
-    } catch (e: any) {
-      if (e.code === 'EBUSY' || e.code === 'EPERM') {
+    } catch (e) {
+      if (isErrnoException(e) && (e.code === 'EBUSY' || e.code === 'EPERM')) {
         return {
           ok: false,
           error: `Datei ist durch ein anderes Programm gesperrt: ${parse(resolvedInvoice).base}`
@@ -294,9 +304,9 @@ export async function mergeExportHandler(
     try {
       fsDeps.writeFileSync(outputPath, merged)
       return { ok: true, data: { path: outputPath } }
-    } catch (writeErr: any) {
+    } catch (writeErr) {
       // Target directory is read-only — fall back to a user-chosen path.
-      if (writeErr.code === 'EPERM' || writeErr.code === 'EACCES') {
+      if (isErrnoException(writeErr) && (writeErr.code === 'EPERM' || writeErr.code === 'EACCES')) {
         const fallback = await dialogDeps.showSaveDialog({
           title: 'Zusammengeführte PDF speichern',
           defaultPath: `${name}_inkl_Stundennachweis.pdf`,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -68,7 +68,7 @@ const api = {
     end: (): void => ipcRenderer.send('hotkey:endCapture')
   },
   onHotkeyToggle: (callback: () => void): (() => void) => {
-    const handler = () => callback()
+    const handler = (): void => callback()
     ipcRenderer.on('timer:hotkey-toggle', handler)
     return () => ipcRenderer.removeListener('timer:hotkey-toggle', handler)
   },

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -42,6 +42,7 @@ function App(): React.JSX.Element {
   // Track the color of the currently running entry's project for the nav pill.
   useEffect(() => {
     if (runningEntry?.project_id == null) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
       setRunningProjectColor(undefined)
       return
     }
@@ -54,6 +55,7 @@ function App(): React.JSX.Element {
 
   // Check onboarding flag — show wizard only for fresh installs.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
     if (onboardingCompleted === '0') setShowOnboarding(true)
     void useUiPrefsStore.getState().load()
   }, [onboardingCompleted])
@@ -221,6 +223,7 @@ function RunningPill({
     return () => clearInterval(id)
   }, [startedAt])
 
+  // eslint-disable-next-line react-hooks/purity -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
   const seconds = Math.max(0, Math.floor((Date.now() - new Date(startedAt).getTime()) / 1000))
   const h = Math.floor(seconds / 3600)
   const m = Math.floor((seconds % 3600) / 60)

--- a/src/renderer/src/components/AboutDialog.tsx
+++ b/src/renderer/src/components/AboutDialog.tsx
@@ -39,6 +39,7 @@ export function AboutDialog({ open, onClose, version }: Props): React.JSX.Elemen
 
   useEffect(() => {
     if (!open || licenses.length > 0) return
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
     setLoading(true)
     void window.api.app.getLicenses().then((res) => {
       if (res.ok) setLicenses(res.data)

--- a/src/renderer/src/components/Dialog.tsx
+++ b/src/renderer/src/components/Dialog.tsx
@@ -32,6 +32,7 @@ export function Dialog({
   // every time the parent re-renders (which would re-focus the close button
   // on every tick — e.g. Today's running-timer pill ticks once per second).
   const onCloseRef = useRef(onClose)
+  // eslint-disable-next-line react-hooks/refs -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
   onCloseRef.current = onClose
 
   useEffect(() => {

--- a/src/renderer/src/components/EntryEditForm.tsx
+++ b/src/renderer/src/components/EntryEditForm.tsx
@@ -69,6 +69,7 @@ export function EntryEditForm({
   // Load projects when client changes; reset project if client changes
   useEffect(() => {
     if (!clientId) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
       setProjects([])
       setProjectId(null)
       return

--- a/src/renderer/src/components/ExportModal.tsx
+++ b/src/renderer/src/components/ExportModal.tsx
@@ -142,10 +142,12 @@ export function ExportModal(props: Props): React.JSX.Element {
 
   // Sync prefill props if they change after mount (e.g. CalendarView quick-filters).
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
     if (prefilledClientId != null) setClientId(prefilledClientId)
   }, [prefilledClientId])
   useEffect(() => {
     if (prefilledRange) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
       setFromIso(prefilledRange.fromIso)
       setToIso(prefilledRange.toIso)
     }
@@ -153,12 +155,14 @@ export function ExportModal(props: Props): React.JSX.Element {
 
   // v1.13 #118: grouping by project is meaningless with a single project filter.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
     if (projectId != null && groupBy === 'project') setGroupBy('none')
   }, [projectId, groupBy])
 
   // Load active projects when a client is selected; reset project filter on change.
   useEffect(() => {
     if (clientId == null) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
       setProjects([])
       setProjectId(null)
       return

--- a/src/renderer/src/components/IdleModal.tsx
+++ b/src/renderer/src/components/IdleModal.tsx
@@ -10,7 +10,13 @@ interface Props {
   onMarkPause: () => void
 }
 
-export function IdleModal({ idleSince, idleSeconds, onKeep, onStopAtIdle, onMarkPause }: Props) {
+export function IdleModal({
+  idleSince,
+  idleSeconds,
+  onKeep,
+  onStopAtIdle,
+  onMarkPause
+}: Props): React.JSX.Element {
   const t = useT()
   useEffect(() => {
     const handler = (e: KeyboardEvent): void => {

--- a/src/renderer/src/components/PdfMergeModal.tsx
+++ b/src/renderer/src/components/PdfMergeModal.tsx
@@ -82,6 +82,7 @@ export function PdfMergeModal({ open, onClose }: Props): React.JSX.Element {
   // Pre-fill from localStorage on open. Any failure = treat path as gone.
   useEffect(() => {
     if (!open) return
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
     setStatusMsg(null)
     setStatusKind('info')
     setBusy(false)

--- a/src/renderer/src/components/QuickNoteModal.tsx
+++ b/src/renderer/src/components/QuickNoteModal.tsx
@@ -10,7 +10,7 @@ interface Props {
   onDone: () => void
 }
 
-export function QuickNoteModal({ entry, onDone }: Props) {
+export function QuickNoteModal({ entry, onDone }: Props): React.JSX.Element {
   const t = useT()
   const [text, setText] = useState('')
   const [remaining, setRemaining] = useState(TIMEOUT_S)

--- a/src/renderer/src/components/QuickNoteModal.tsx
+++ b/src/renderer/src/components/QuickNoteModal.tsx
@@ -15,6 +15,7 @@ export function QuickNoteModal({ entry, onDone }: Props): React.JSX.Element {
   const [text, setText] = useState('')
   const [remaining, setRemaining] = useState(TIMEOUT_S)
   const inputRef = useRef<HTMLInputElement>(null)
+  // eslint-disable-next-line react-hooks/purity -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
   const deadlineRef = useRef(Date.now() + TIMEOUT_S * 1000)
   const bumpVersion = useEntriesStore((s) => s.bumpVersion)
 

--- a/src/renderer/src/components/StartTimerModal.tsx
+++ b/src/renderer/src/components/StartTimerModal.tsx
@@ -31,6 +31,7 @@ export function StartTimerModal({ open, onClose }: StartTimerModalProps): React.
   // Load projects when client selection changes
   useEffect(() => {
     if (!selectedClientId) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
       setProjects([])
       setSelectedProjectId(null)
       return

--- a/src/renderer/src/components/TagInput.tsx
+++ b/src/renderer/src/components/TagInput.tsx
@@ -69,6 +69,7 @@ export function TagInput({
 
   // Load master registry on mount
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
     void reloadKnown()
   }, [reloadKnown])
 
@@ -83,6 +84,7 @@ export function TagInput({
     }
     // Append "create" sentinel if typed text is non-empty and not an exact match
     if (q && !allKnown.includes(q) && !tags.includes(q)) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
       setSuggestions([...matches, CREATE_SENTINEL])
     } else {
       setSuggestions(matches)

--- a/src/renderer/src/components/pdfMergeUtils.ts
+++ b/src/renderer/src/components/pdfMergeUtils.ts
@@ -7,7 +7,7 @@
  */
 export function detectFilePurpose(filename: string): 'sn' | 'invoice' | null {
   if (!filename) return null
-  if (/stundennachweis|nachweis|sn[_\-]/i.test(filename)) return 'sn'
-  if (/rechnung|invoice|inv[_\-]/i.test(filename)) return 'invoice'
+  if (/stundennachweis|nachweis|sn[_-]/i.test(filename)) return 'sn'
+  if (/rechnung|invoice|inv[_-]/i.test(filename)) return 'invoice'
   return null
 }

--- a/src/renderer/src/contexts/I18nContext.tsx
+++ b/src/renderer/src/contexts/I18nContext.tsx
@@ -55,6 +55,7 @@ export function I18nProvider({ children }: { children: React.ReactNode }): React
  * Returns the `t()` translation function bound to the current locale.
  * Must be called within an `I18nProvider`.
  */
+// eslint-disable-next-line react-refresh/only-export-components -- Provider und Hooks liegen bewusst im selben Modul; ein Fast-Refresh-Split würde nur die ~26 Importpfade streuen, ohne Laufzeitnutzen.
 export function useT(): TFunction {
   const ctx = useContext(I18nContext)
   if (!ctx) throw new Error('useT must be used within an I18nProvider')
@@ -65,6 +66,7 @@ export function useT(): TFunction {
  * Returns the current locale and a setter that persists the change.
  * Must be called within an `I18nProvider`.
  */
+// eslint-disable-next-line react-refresh/only-export-components -- siehe useT: Provider + Hooks bewusst im selben Modul.
 export function useLocale(): { locale: Locale; setLocale: (l: Locale) => Promise<void> } {
   const ctx = useContext(I18nContext)
   if (!ctx) throw new Error('useLocale must be used within an I18nProvider')

--- a/src/renderer/src/contexts/I18nContext.tsx
+++ b/src/renderer/src/contexts/I18nContext.tsx
@@ -36,6 +36,7 @@ export function I18nProvider({ children }: { children: React.ReactNode }): React
 
   // Sync locale once settings are loaded.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
     if (language === 'en') setLocaleState('en')
   }, [language])
 

--- a/src/renderer/src/contexts/RoundingContext.tsx
+++ b/src/renderer/src/contexts/RoundingContext.tsx
@@ -46,6 +46,7 @@ export function RoundingProvider({ children }: { children: React.ReactNode }): R
 }
 
 /** Returns `{ roundMinutes, setRoundMinutes }`. Must be inside RoundingProvider. */
+// eslint-disable-next-line react-refresh/only-export-components -- Provider + Hook bewusst im selben Modul; Fast-Refresh-Split ohne Laufzeitnutzen.
 export function useRounding(): RoundingCtx {
   return useContext(RoundingContext)
 }

--- a/src/renderer/src/contexts/RoundingContext.tsx
+++ b/src/renderer/src/contexts/RoundingContext.tsx
@@ -30,6 +30,7 @@ export function RoundingProvider({ children }: { children: React.ReactNode }): R
   // Sync from the settings store once loaded (and whenever it changes).
   useEffect(() => {
     const v = parseInt(pdfRoundMinutes ?? '0', 10)
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
     setRoundMinutesState(Number.isFinite(v) && v > 0 ? v : 0)
   }, [pdfRoundMinutes])
 

--- a/src/renderer/src/contexts/ThemeContext.tsx
+++ b/src/renderer/src/contexts/ThemeContext.tsx
@@ -53,6 +53,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }): Reac
   )
 }
 
+// eslint-disable-next-line react-refresh/only-export-components -- Provider + Hook bewusst im selben Modul; Fast-Refresh-Split ohne Laufzeitnutzen.
 export function useTheme(): ThemeContextValue {
   return useContext(ThemeContext)
 }

--- a/src/renderer/src/contexts/ThemeContext.tsx
+++ b/src/renderer/src/contexts/ThemeContext.tsx
@@ -20,6 +20,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }): Reac
 
   // Sync theme mode once settings are loaded.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
     if (themeMode) setMode((themeMode as ThemeMode) ?? 'system')
   }, [themeMode])
 

--- a/src/renderer/src/hooks/useTimer.ts
+++ b/src/renderer/src/hooks/useTimer.ts
@@ -1,7 +1,35 @@
 import { useEffect, useRef, useCallback } from 'react'
+import type { Client, Entry } from '../../../shared/types'
 import { useTimerStore } from '../store/timerStore'
 import { useClientsStore } from '../store/clientsStore'
 import { formatDuration as _formatDuration } from '../../../shared/duration'
+
+/**
+ * Shape returned by {@link useTimer}. Named explicitly (rather than inferred)
+ * so the public hook contract is stated in one place and satisfies
+ * `explicit-function-return-type`. Field types mirror `timerStore`.
+ */
+export interface UseTimerResult {
+  clients: Client[]
+  runningEntry: Entry | null
+  selectedClientId: number | null
+  selectedProjectId: number | null
+  description: string
+  elapsedSeconds: number
+  isLoading: boolean
+  idleEvent: { idleSince: string; idleSeconds: number } | null
+  quickNoteEntry: Entry | null
+  setSelectedClientId: (id: number | null) => void
+  setSelectedProjectId: (id: number | null) => void
+  setDescription: (desc: string) => void
+  setQuickNoteEntry: (entry: Entry | null) => void
+  start: () => Promise<void>
+  stop: () => Promise<void>
+  startWithClient: (clientId: number, projectId?: number | null) => Promise<void>
+  idleKeep: () => void
+  idleStopAtIdle: () => Promise<void>
+  idleMarkPause: () => Promise<void>
+}
 
 /**
  * Fetch today's total seconds from main and push it to the tray together with
@@ -46,7 +74,7 @@ function installGlobalListenersOnce(
 
 let initRan = false
 
-export function useTimer() {
+export function useTimer(): UseTimerResult {
   const {
     clients,
     runningEntry,
@@ -87,7 +115,7 @@ export function useTimer() {
   useEffect(() => {
     if (initRan) return
     initRan = true
-    async function init() {
+    async function init(): Promise<void> {
       const [clientsRes, runningRes] = await Promise.all([
         window.api.clients.getAll(),
         window.api.entries.getRunning()

--- a/src/renderer/src/hooks/useTimer.ts
+++ b/src/renderer/src/hooks/useTimer.ts
@@ -319,8 +319,11 @@ export function useTimer(): UseTimerResult {
   }, [dismissIdle])
 
   // Keep refs current so listeners always call the latest fn
+  // eslint-disable-next-line react-hooks/immutability -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
   globalToggleRef.current = runningEntry ? stop : start
+  // eslint-disable-next-line react-hooks/immutability -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
   globalQuickStartRef.current = startWithClient
+  // eslint-disable-next-line react-hooks/immutability -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
   globalStopRef.current = stop
 
   return {

--- a/src/renderer/src/views/AuswertungView.tsx
+++ b/src/renderer/src/views/AuswertungView.tsx
@@ -149,6 +149,7 @@ export default function AuswertungView(): React.JSX.Element {
   }, [])
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
     void load(year, month)
   }, [year, month, load])
 

--- a/src/renderer/src/views/CalendarView.tsx
+++ b/src/renderer/src/views/CalendarView.tsx
@@ -99,6 +99,7 @@ export default function CalendarView(): React.JSX.Element {
 
   const onPrev = useCallback(() => setCursor((d) => addMonths(d, -1)), [])
   const onNext = useCallback(() => setCursor((d) => addMonths(d, 1)), [])
+  // eslint-disable-next-line react-hooks/preserve-manual-memoization -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
   const onToday = useCallback(() => {
     const today = new Date()
     setCursor(startOfMonth(today))
@@ -110,6 +111,7 @@ export default function CalendarView(): React.JSX.Element {
   const [pdfRange, setPdfRange] = useState<{ fromIso: string; toIso: string } | null>(null)
   const [mergeOpen, setMergeOpen] = useState(false)
 
+  // eslint-disable-next-line react-hooks/preserve-manual-memoization -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
   const onQuickRange = useCallback((kind: QuickRangeKind) => {
     const range = getQuickRange(kind, new Date())
     setPdfRange({ fromIso: localDateKey(range.from), toIso: localDateKey(range.to) })

--- a/src/renderer/src/views/ClientsView.tsx
+++ b/src/renderer/src/views/ClientsView.tsx
@@ -45,7 +45,7 @@ function shiftColor(hex: string, lightnessShift = 18): string {
     }
   }
   const newL = Math.min(0.85, Math.max(0, l + lightnessShift / 100))
-  function hue2rgb(p: number, q: number, t: number) {
+  function hue2rgb(p: number, q: number, t: number): number {
     if (t < 0) t += 1
     if (t > 1) t -= 1
     if (t < 1 / 6) return p + (q - p) * 6 * t
@@ -63,7 +63,7 @@ function shiftColor(hex: string, lightnessShift = 18): string {
     ng = hue2rgb(p, q, h)
     nb = hue2rgb(p, q, h - 1 / 3)
   }
-  const toHex = (x: number) =>
+  const toHex = (x: number): string =>
     Math.round(x * 255)
       .toString(16)
       .padStart(2, '0')
@@ -107,7 +107,7 @@ const COLOR_NAMES_KEYS: Record<string, TranslationKey> = {
   '#84cc16': 'clients.color.lime'
 }
 
-export default function ClientsView() {
+export default function ClientsView(): React.JSX.Element {
   const t = useT()
   const [clients, setClients] = useState<Client[]>([])
   const [isLoading, setIsLoading] = useState(true)
@@ -132,7 +132,7 @@ export default function ClientsView() {
     loadClients()
   }, [])
 
-  async function loadClients() {
+  async function loadClients(): Promise<void> {
     setIsLoading(true)
     const res = await window.api.clients.getAll()
     if (res.ok) setClients(res.data)
@@ -146,7 +146,7 @@ export default function ClientsView() {
     }
   }, [])
 
-  async function toggleClientExpanded(clientId: number) {
+  async function toggleClientExpanded(clientId: number): Promise<void> {
     setExpandedClientIds((prev) => {
       const next = new Set(prev)
       if (next.has(clientId)) {
@@ -159,21 +159,21 @@ export default function ClientsView() {
     })
   }
 
-  function openNew() {
+  function openNew(): void {
     setEditingClient(null)
     setShowForm(true)
   }
 
-  function openEdit(client: Client) {
+  function openEdit(client: Client): void {
     setEditingClient(client)
     setShowForm(true)
   }
 
-  async function handleDelete(client: Client) {
+  async function handleDelete(client: Client): Promise<void> {
     setPendingDeleteClient(client)
   }
 
-  async function doDeleteClient() {
+  async function doDeleteClient(): Promise<void> {
     if (!pendingDeleteClient) return
     await window.api.clients.delete(pendingDeleteClient.id)
     setPendingDeleteClient(null)
@@ -181,7 +181,7 @@ export default function ClientsView() {
     bumpClientsVersion()
   }
 
-  async function handleToggleActive(client: Client) {
+  async function handleToggleActive(client: Client): Promise<void> {
     await window.api.clients.update({ ...client, active: client.active ? 0 : 1 })
     await loadClients()
     bumpClientsVersion()
@@ -198,7 +198,7 @@ export default function ClientsView() {
     vat_id: string | null
     contact_person: string | null
     contact_email: string | null
-  }) {
+  }): Promise<void> {
     if (editingClient) {
       const input: UpdateClientInput = { ...editingClient, ...data }
       await window.api.clients.update(input)
@@ -212,13 +212,13 @@ export default function ClientsView() {
     setEditingClient(null)
   }
 
-  function openNewProject(clientId: number) {
+  function openNewProject(clientId: number): void {
     setEditingProject(null)
     setProjectFormClientId(clientId)
     setShowProjectForm(true)
   }
 
-  function openEditProject(project: Project) {
+  function openEditProject(project: Project): void {
     setEditingProject(project)
     setProjectFormClientId(project.client_id)
     setShowProjectForm(true)
@@ -234,7 +234,7 @@ export default function ClientsView() {
     budget_minutes: number | null
     status: 'active' | 'paused' | 'archived'
     contact_person: string | null
-  }) {
+  }): Promise<void> {
     if (!projectFormClientId && projectFormClientId !== 0) return
     if (editingProject) {
       const input: UpdateProjectInput = {
@@ -254,17 +254,17 @@ export default function ClientsView() {
     setProjectFormClientId(null)
   }
 
-  async function handleProjectArchive(project: Project) {
+  async function handleProjectArchive(project: Project): Promise<void> {
     await window.api.projects.archive(project.id)
     if (project.client_id !== null) await loadProjectsForClient(project.client_id)
     bumpProjectsVersion()
   }
 
-  async function handleProjectDelete(project: ProjectWithCount) {
+  async function handleProjectDelete(project: ProjectWithCount): Promise<void> {
     setPendingDeleteProject(project)
   }
 
-  async function doDeleteProject() {
+  async function doDeleteProject(): Promise<void> {
     if (!pendingDeleteProject) return
     const res = await window.api.projects.delete(pendingDeleteProject.id)
     const clientId = pendingDeleteProject.client_id
@@ -449,7 +449,7 @@ function ClientList({
   onArchiveProject: (p: Project) => void
   onDeleteProject: (p: ProjectWithCount) => void
   dimmed?: boolean
-}) {
+}): React.JSX.Element {
   return (
     <ul className="flex flex-col gap-2">
       {clients.map((c) => (
@@ -499,7 +499,7 @@ function ClientItem({
   onArchiveProject: (p: Project) => void
   onDeleteProject: (p: ProjectWithCount) => void
   dimmed?: boolean
-}) {
+}): React.JSX.Element {
   const t = useT()
   const activeProjects =
     projects?.filter((p) => p.status === 'active' || (!p.status && p.active)) ?? []
@@ -684,7 +684,7 @@ function ProjectItem({
   onEdit: (p: Project) => void
   onArchive: (p: Project) => void
   onDelete: (p: ProjectWithCount) => void
-}) {
+}): React.JSX.Element {
   const t = useT()
   const { locale } = useLocale()
   const showProjectNumber = useUiPrefsStore((s) => s.showProjectNumber)
@@ -826,7 +826,7 @@ function ArchivedProjectsSection({
   onEdit: (p: Project) => void
   onArchive: (p: Project) => void
   onDelete: (p: ProjectWithCount) => void
-}) {
+}): React.JSX.Element {
   const t = useT()
   const [expanded, setExpanded] = useState(false)
 
@@ -888,7 +888,7 @@ function ClientFormModal({
     contact_email: string | null
   }) => Promise<void>
   onClose: () => void
-}) {
+}): React.JSX.Element {
   const t = useT()
   const [name, setName] = useState(client?.name ?? '')
   const [color, setColor] = useState(client?.color ?? COLORS[0])
@@ -919,7 +919,7 @@ function ClientFormModal({
     return v.trim() === '' ? null : v.trim()
   }
 
-  async function handleSubmit(e: React.FormEvent) {
+  async function handleSubmit(e: React.FormEvent): Promise<void> {
     e.preventDefault()
     const trimmed = name.trim()
     if (!trimmed) {
@@ -1252,7 +1252,7 @@ function ProjectFormModal({
     contact_person: string | null
   }) => Promise<void>
   onClose: () => void
-}) {
+}): React.JSX.Element {
   const t = useT()
   const [name, setName] = useState(project?.name ?? '')
   const [color, setColor] = useState(() =>
@@ -1285,7 +1285,7 @@ function ProjectFormModal({
     return v.trim() === '' ? null : v.trim()
   }
 
-  async function handleSubmit(e: React.FormEvent) {
+  async function handleSubmit(e: React.FormEvent): Promise<void> {
     e.preventDefault()
     const trimmed = name.trim()
     if (!trimmed) {

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -103,6 +103,7 @@ export default function SettingsView(): React.JSX.Element {
   }
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
     loadAll()
   }, [])
 

--- a/src/renderer/src/views/TagManagementView.tsx
+++ b/src/renderer/src/views/TagManagementView.tsx
@@ -51,6 +51,7 @@ export default function TagManagementView(): React.JSX.Element {
   }, [])
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
     void reload()
   }, [reload])
 


### PR DESCRIPTION
Schließt #143, erledigt #142 zur Hälfte.

## #142 Teil 1 — die mechanischen Fehler

Behebt 50 der 76 ESLint-Fehler:

| Anzahl | Regel |
| --- | --- |
| 30 | `@typescript-eslint/explicit-function-return-type` |
| 10 | `@typescript-eslint/no-explicit-any` |
| 4 | `react-refresh/only-export-components` |
| 2 | `@typescript-eslint/no-require-imports` |
| 2 | `@typescript-eslint/no-unused-vars` |
| 2 | `no-useless-escape` |

- **Rückgabetypen** handgesetzt — die Regel hat keinen Autofixer, `--fix` ändert nichts. `useTimer()` bekommt ein benanntes `UseTimerResult`-Interface statt eines inline inferierten Riesentyps.
- **`no-explicit-any`** in `pdfMergeHandlers.ts`: ein `NodeJS.ErrnoException`-Type-Guard grenzt die `catch`-Zugriffe auf `.code` ein. Echter Typ, nicht `unknown` mit Cast an derselben Stelle — die Regel ist erfüllt, nicht stillgelegt.
- **`react-refresh`**: Provider und Hooks liegen in denselben Modulen (I18n/Rounding/Theme). Ein Datei-Split hätte ~26 Importpfade angefasst; stattdessen ein begründeter Disable je Stelle.

**Nicht enthalten:** die 26 React-Compiler-Regeln (`set-state-in-effect` ×18, `immutability` ×3, `preserve-manual-memoization` ×2, `purity` ×2, `refs` ×1). Das ist Arbeit am Renderverhalten, kein Suchen-und-Ersetzen. #142 bleibt offen.

## #143 — ESLint als CI-Gate

Neuer `Lint`-Step im `test`-Job nach dem Typecheck.

Damit das Gate grün starten kann, ohne die ausgeklammerten 26 Fehler vorwegzunehmen, brauchte es eine Ausnahme. Die naheliegende Variante — die fünf Regeln global auf `warn` — wurde **verworfen**: ein global herabgestufter `set-state-in-effect` lässt auch jeden *neuen* Verstoß irgendwo im Code als Warnung durch. Das ist genau das Szenario, vor dem #143 selbst warnt („ein Gate, das sofort rot ist, wird binnen einer Woche mit `continue-on-error` entschärft und ist dann schlimmer als keines") — nur eine Stufe subtiler.

Stattdessen bleiben alle Regeln global auf `error`, und die 26 Fundstellen bekommen je ein `eslint-disable-next-line` mit `#142`-Verweis. Der Unterschied:

- Ein neuer Verstoß an anderer Stelle lässt CI weiterhin **scheitern**.
- Die Ausnahmen sind namentlich und greppbar (`rg "#142: React-Compiler"`), können also nicht still wachsen. Der Folge-PR arbeitet eine Liste ab, statt eine Regel scharf zu schalten und zu sehen, was passiert.

`--max-warnings` bleibt offen — die verbleibenden 11 Warnungen sind rein `react-hooks/exhaustive-deps`, womit die Bedingung aus dem Issue weiter trägt.

## Nebenbei (Hygiene)

- `.gitignore`: `.claude/worktrees/` — die Worktrees paralleler Agenten waren untracked *und* ungeignored; ein `git add -A` hätte sie eingecheckt.
- `eslint.config.mjs`: `.claude/` in die `ignores` — sonst lintet ESLint die Worktree-Kopien mit und vervierfacht jede Fehlerzahl.

## Verifikation

| | vorher | nachher |
| --- | --- | --- |
| Fehler | 76 | **0** |
| Warnungen | 11 | **11** (rein `exhaustive-deps`) |

- `pnpm typecheck`: sauber (node, web, mcp)
- `npx prettier --check .`: sauber
- Tests: **595 passed, 1 skipped**

Zum Testlauf: `better-sqlite3` wurde vorher gegen die Node-ABI gebaut. Ohne das überspringen sich die DB-gestützten Tests stumm und ein lokales „grün" bedeutet 334 statt 595 gelaufener Tests — siehe #151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
