### PR TITLE
docs(#142): disable-Kommentare wahrheitsgemäß begründen statt „Folge-PR"

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -42,7 +42,7 @@ function App(): React.JSX.Element {
   // Track the color of the currently running entry's project for the nav pill.
   useEffect(() => {
     if (runningEntry?.project_id == null) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: dauerhaft — Teilfix möglich (bedingtes Rendern), der asynchrone Zweig bleibt Effect
       setRunningProjectColor(undefined)
       return
     }
@@ -55,7 +55,7 @@ function App(): React.JSX.Element {
 
   // Check onboarding flag — show wizard only for fresh installs.
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: dauerhaft — zweiter Schreiber finishOnboarding(); Ableitung würde den Wizard nach Abschluss erneut öffnen
     if (onboardingCompleted === '0') setShowOnboarding(true)
     void useUiPrefsStore.getState().load()
   }, [onboardingCompleted])
@@ -223,7 +223,7 @@ function RunningPill({
     return () => clearInterval(id)
   }, [startedAt])
 
-  // eslint-disable-next-line react-hooks/purity -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
+  // eslint-disable-next-line react-hooks/purity -- #142: dauerhaft — tickende Uhr muss bei jedem Render „jetzt" lesen; das ist bereits die Ableitung
   const seconds = Math.max(0, Math.floor((Date.now() - new Date(startedAt).getTime()) / 1000))
   const h = Math.floor(seconds / 3600)
   const m = Math.floor((seconds % 3600) / 60)

--- a/src/renderer/src/components/AboutDialog.tsx
+++ b/src/renderer/src/components/AboutDialog.tsx
@@ -39,7 +39,7 @@ export function AboutDialog({ open, onClose, version }: Props): React.JSX.Elemen
 
   useEffect(() => {
     if (!open || licenses.length > 0) return
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: dauerhaft — asynchroner IPC-Abruf der Lizenzliste
     setLoading(true)
     void window.api.app.getLicenses().then((res) => {
       if (res.ok) setLicenses(res.data)

--- a/src/renderer/src/components/Dialog.tsx
+++ b/src/renderer/src/components/Dialog.tsx
@@ -32,7 +32,7 @@ export function Dialog({
   // every time the parent re-renders (which would re-focus the close button
   // on every tick — e.g. Today's running-timer pill ticks once per second).
   const onCloseRef = useRef(onClose)
-  // eslint-disable-next-line react-hooks/refs -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
+  // eslint-disable-next-line react-hooks/refs -- #142: zurückgestellt bis zur Compiler-Entscheidung — Basis für sechs Modals, keine Testabdeckung
   onCloseRef.current = onClose
 
   useEffect(() => {

--- a/src/renderer/src/components/EntryEditForm.tsx
+++ b/src/renderer/src/components/EntryEditForm.tsx
@@ -69,7 +69,7 @@ export function EntryEditForm({
   // Load projects when client changes; reset project if client changes
   useEffect(() => {
     if (!clientId) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: dauerhaft — Teilfix möglich, der asynchrone Zweig bleibt Effect
       setProjects([])
       setProjectId(null)
       return

--- a/src/renderer/src/components/ExportModal.tsx
+++ b/src/renderer/src/components/ExportModal.tsx
@@ -142,12 +142,12 @@ export function ExportModal(props: Props): React.JSX.Element {
 
   // Sync prefill props if they change after mount (e.g. CalendarView quick-filters).
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: dauerhaft — unerreichbar: CalendarView remountet per key; Prop hat zudem keinen Aufrufer
     if (prefilledClientId != null) setClientId(prefilledClientId)
   }, [prefilledClientId])
   useEffect(() => {
     if (prefilledRange) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: dauerhaft — unerreichbar: CalendarView remountet per key statt neu zu rendern
       setFromIso(prefilledRange.fromIso)
       setToIso(prefilledRange.toIso)
     }
@@ -155,14 +155,14 @@ export function ExportModal(props: Props): React.JSX.Element {
 
   // v1.13 #118: grouping by project is meaningless with a single project filter.
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: dauerhaft — Ableitung würde Dropdown-Anzeige und tatsächlichen Export auseinanderlaufen lassen
     if (projectId != null && groupBy === 'project') setGroupBy('none')
   }, [projectId, groupBy])
 
   // Load active projects when a client is selected; reset project filter on change.
   useEffect(() => {
     if (clientId == null) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: dauerhaft — Teilfix möglich, der asynchrone Zweig bleibt Effect
       setProjects([])
       setProjectId(null)
       return

--- a/src/renderer/src/components/PdfMergeModal.tsx
+++ b/src/renderer/src/components/PdfMergeModal.tsx
@@ -82,7 +82,7 @@ export function PdfMergeModal({ open, onClose }: Props): React.JSX.Element {
   // Pre-fill from localStorage on open. Any failure = treat path as gone.
   useEffect(() => {
     if (!open) return
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: dauerhaft — Reset plus asynchroner localStorage-/Seitenzahl-Pfad, Aufrufer übergibt kein key
     setStatusMsg(null)
     setStatusKind('info')
     setBusy(false)

--- a/src/renderer/src/components/QuickNoteModal.tsx
+++ b/src/renderer/src/components/QuickNoteModal.tsx
@@ -15,7 +15,7 @@ export function QuickNoteModal({ entry, onDone }: Props): React.JSX.Element {
   const [text, setText] = useState('')
   const [remaining, setRemaining] = useState(TIMEOUT_S)
   const inputRef = useRef<HTMLInputElement>(null)
-  // eslint-disable-next-line react-hooks/purity -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
+  // eslint-disable-next-line react-hooks/purity -- #142: dauerhaft — useRef-Initialwert, Umbau ohne beobachtbaren Effekt
   const deadlineRef = useRef(Date.now() + TIMEOUT_S * 1000)
   const bumpVersion = useEntriesStore((s) => s.bumpVersion)
 

--- a/src/renderer/src/components/StartTimerModal.tsx
+++ b/src/renderer/src/components/StartTimerModal.tsx
@@ -31,7 +31,7 @@ export function StartTimerModal({ open, onClose }: StartTimerModalProps): React.
   // Load projects when client selection changes
   useEffect(() => {
     if (!selectedClientId) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: dauerhaft — Teilfix möglich, der asynchrone Zweig bleibt Effect
       setProjects([])
       setSelectedProjectId(null)
       return

--- a/src/renderer/src/components/TagInput.tsx
+++ b/src/renderer/src/components/TagInput.tsx
@@ -69,7 +69,7 @@ export function TagInput({
 
   // Load master registry on mount
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: dauerhaft — asynchroner Abruf beim Mount
     void reloadKnown()
   }, [reloadKnown])
 

--- a/src/renderer/src/contexts/I18nContext.tsx
+++ b/src/renderer/src/contexts/I18nContext.tsx
@@ -36,7 +36,7 @@ export function I18nProvider({ children }: { children: React.ReactNode }): React
 
   // Sync locale once settings are loaded.
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: dauerhaft — wie ThemeContext
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: dauerhaft — ruft rohes window.api.settings.set, und settings:set sendet kein Push-Update — lokaler State ist die einzige Stelle, die von der Änderung erfährt (wie ThemeContext)
     if (language === 'en') setLocaleState('en')
   }, [language])
 

--- a/src/renderer/src/contexts/I18nContext.tsx
+++ b/src/renderer/src/contexts/I18nContext.tsx
@@ -36,7 +36,7 @@ export function I18nProvider({ children }: { children: React.ReactNode }): React
 
   // Sync locale once settings are loaded.
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: dauerhaft — wie ThemeContext
     if (language === 'en') setLocaleState('en')
   }, [language])
 

--- a/src/renderer/src/contexts/RoundingContext.tsx
+++ b/src/renderer/src/contexts/RoundingContext.tsx
@@ -30,7 +30,7 @@ export function RoundingProvider({ children }: { children: React.ReactNode }): R
   // Sync from the settings store once loaded (and whenever it changes).
   useEffect(() => {
     const v = parseInt(pdfRoundMinutes ?? '0', 10)
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: zurückgestellt bis zur Compiler-Entscheidung — saubere Ableitung möglich, aber ohne Test nicht abgesichert
     setRoundMinutesState(Number.isFinite(v) && v > 0 ? v : 0)
   }, [pdfRoundMinutes])
 

--- a/src/renderer/src/contexts/ThemeContext.tsx
+++ b/src/renderer/src/contexts/ThemeContext.tsx
@@ -20,7 +20,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }): Reac
 
   // Sync theme mode once settings are loaded.
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: dauerhaft — ruft rohes window.api.settings.set, und settings:set sendet kein Push-Update — lokaler State ist die einzige Stelle, die von der Änderung erfährt
     if (themeMode) setMode((themeMode as ThemeMode) ?? 'system')
   }, [themeMode])
 

--- a/src/renderer/src/hooks/useTimer.ts
+++ b/src/renderer/src/hooks/useTimer.ts
@@ -319,11 +319,11 @@ export function useTimer(): UseTimerResult {
   }, [dismissIdle])
 
   // Keep refs current so listeners always call the latest fn
-  // eslint-disable-next-line react-hooks/immutability -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
+  // eslint-disable-next-line react-hooks/immutability -- #142: zurückgestellt bis zur Compiler-Entscheidung — daran hängen die globalen Hotkeys, keine Testabdeckung
   globalToggleRef.current = runningEntry ? stop : start
-  // eslint-disable-next-line react-hooks/immutability -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
+  // eslint-disable-next-line react-hooks/immutability -- #142: zurückgestellt bis zur Compiler-Entscheidung — daran hängen die globalen Hotkeys, keine Testabdeckung
   globalQuickStartRef.current = startWithClient
-  // eslint-disable-next-line react-hooks/immutability -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
+  // eslint-disable-next-line react-hooks/immutability -- #142: zurückgestellt bis zur Compiler-Entscheidung — daran hängen die globalen Hotkeys, keine Testabdeckung
   globalStopRef.current = stop
 
   return {

--- a/src/renderer/src/views/AuswertungView.tsx
+++ b/src/renderer/src/views/AuswertungView.tsx
@@ -149,7 +149,7 @@ export default function AuswertungView(): React.JSX.Element {
   }, [])
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: dauerhaft — asynchroner Datenabruf pro Monatsnavigation
     void load(year, month)
   }, [year, month, load])
 

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -103,7 +103,7 @@ export default function SettingsView(): React.JSX.Element {
   }
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: dauerhaft — fünf asynchrone Quellen beim Mount
     loadAll()
   }, [])
 

--- a/src/renderer/src/views/TagManagementView.tsx
+++ b/src/renderer/src/views/TagManagementView.tsx
@@ -51,7 +51,7 @@ export default function TagManagementView(): React.JSX.Element {
   }, [])
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- #142: dauerhaft — Laden beim Mount, kein dedizierter Store für Tags
     void reload()
   }, [reload])
 


### PR DESCRIPTION
## Worum es geht

Reiner Dokumentations-PR zu #142, Schritt 1. Die 26 `eslint-disable-next-line`-Kommentare
aus der React-Compiler-Lint-Einführung tragen alle denselben Platzhaltertext:

```
-- #142: React-Compiler-Regel, Aufarbeitung im Folge-PR
```

„Aufarbeitung im Folge-PR" liest sich als offene Schuld. Für die meisten Stellen ist das
falsch — sie bleiben bewusst so. Dieser PR ersetzt ausschließlich den Beschreibungstext hinter
`--` durch eine wahrheitsgemäße Begründung. **Kein Zeichen Programmlogik ändert sich**, der
Regelname vor `--` bleibt unangetastet, der Code darunter ebenfalls.

## Was sich ändert

Die 26 Fundstellen sind in drei Klassen aufgeteilt (Faktenbasis: Issue-Body #142 und
`#issuecomment-5084731342`):

- **Gruppe A — dauerhaft (18 Stellen).** Neuer Text: `-- #142: dauerhaft — <Grund>`.
  Strukturell unvermeidbare oder bewusst so belassene Ausnahmen: Datenabruf beim Mount ohne
  dedizierten Store, praktisch unerreichbare Codepfade, „saubere" Ableitungen, die die UI
  auseinanderlaufen ließen.
- **Gruppe B — zurückgestellt (5 Stellen).** Neuer Text:
  `-- #142: zurückgestellt bis zur Compiler-Entscheidung — <Grund>`. Keine Dauerausnahmen,
  aber ohne Testabdeckung nicht gefahrlos umbaubar: `useTimer.ts` (3×, globale Hotkeys),
  `Dialog.tsx` (Basis für sechs Modals), `RoundingContext.tsx`.
- **Gruppe C — unverändert (3 Stellen).** `CalendarView.tsx` (2×) und `TagInput.tsx:87`
  werden in Schritt 2 tatsächlich repariert; ihr Kommentar bleibt wortwörtlich stehen.

18 + 5 + 3 = 26. Die Zählung geht auf.

## Verifikation

- `pnpm lint` → **0 Fehler, 11 Warnungen** (unverändert; die 11 `exhaustive-deps`-Warnungen
  bestehen bereits vor diesem PR). Das ist der eigentliche Test: Bricht das Kommentarformat,
  feuert die Regel wieder und der Lauf wird rot.
- `pnpm typecheck` → **0 Fehler**.
- `pnpm test` → **596 passed, 0 skipped**.
- `git diff` enthält ausschließlich Kommentarzeilen.

## Kein Closes

Dieses Issue bleibt nach dem Merge **offen** — Schritt 2 (Gruppe C tatsächlich reparieren)
fehlt noch. Deshalb bewusst **kein** `Closes #142`.
