### PR TITLE
feat(#153): Exportieren wird ein eigener Reiter, der Kalender wieder nur Kalender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to TimeTrack are documented here.
 
+## [Unreleased]
+
+### Changed
+
+- **Exportieren ist jetzt ein eigener Reiter (#153)** — Das Export-Fenster war ausschließlich über die Zeitraum-Knöpfe in der **Kalender**-Ansicht erreichbar, das Zusammenführen von PDFs über einen weiteren Knopf daneben. In der Navigation stand nirgends „Export": Wer danach suchte, fand nichts, und ein automatisierter Durchlauf von v1.15.0 fand ebenfalls nichts. Mit dem iCal-Export (#135) wog das schwerer als vorher, weil dessen ganzer Zweck ein dauerhafter zweiter Kalender-Layer ist — man sucht danach unter „Export", nicht unter „Dieser Monat". Es gibt jetzt einen Reiter **Export** zwischen _Auswertung_ und _Einstellungen_, der beide Wege beherbergt: Stundennachweis/CSV/iCal oben, PDFs zusammenführen darunter. Die Knöpfe selbst sind unverändert — gleiche Beschriftungen, gleiche Zeiträume, „Letzter Monat" weiterhin farblich hervorgehoben, weil das der häufigste Rechnungs-Weg ist.
+
+  Bewusst **kein zweiter Einstiegspunkt neben dem alten**, was sowohl das Issue als auch der `TODOS`-Punkt zum PdfMergeModal wörtlich vorschlugen: Beide Fenster hingen an der Kalenderansicht, ohne kalenderspezifisch zu sein — die Zeitraum-Knöpfe haben nie den Kalender gefiltert, sie haben nur einen Zeitraum vorbelegt und ein Fenster geöffnet. Vier Einstiegspunkte über zwei Ansichten hätten die Oberfläche verdoppelt, ohne die Ursache anzufassen. Die Toolbar ist deshalb komplett umgezogen; der **Kalender ist wieder nur Kalender**. Wer den Export bisher aus dem Kalender heraus gestartet hat, klickt jetzt einen Reiter weiter links — aus der Standardansicht _Heute_ sind es unverändert zwei Klicks.
+
+  Der `TODOS`-Punkt „Merge modal Nav-Trigger" ist damit erledigt, das dort und in #153 angemahnte Design-Gespräch geführt.
+
+### Internal
+
+- **Charakterisierungstest für die Export-Einstiegspunkte (#153)** — `exportEntryPoints.test.tsx` sichert acht Verhaltensweisen ab (welcher Knopf welchen Zeitraum vorbelegt, welches Fenster aufgeht, dass ein zweites Öffnen den Zeitraum ersetzt) und wurde vor dem Umzug gegen den alten Code in `CalendarView` grün geschrieben; danach zeigt dieselbe Datei unverändert auf die neue `ExportView`. Das ist der Beleg, dass der Umzug nichts verloren hat, und nicht bloß eine Beschreibung des neuen Codes.
+
+  Bemerkenswert ist Fall 6. Der naheliegende Test — „ein zweites Öffnen zeigt den neuen Zeitraum" — bewacht die tragende Stelle **nicht**: Das Fenster wird per `key` bei jedem Öffnen neu aufgebaut, aber den Zeitraum bekommt es zusätzlich über einen Effekt, sodass dieser Fall auch mit gelöschtem `key` grün blieb (nachgemessen, nicht vermutet). Tragend ist der `key` für die gespeicherten Export-Einstellungen, die genau einmal pro Aufbau gelesen werden — ohne Neuaufbau bliebe der Stand vom ersten Mount stehen, und das ist beim App-Start der Stand _vor_ dem Laden der Einstellungen. Fall 6 prüft deshalb, dass ein zweites Öffnen die inzwischen geänderten Einstellungen liest; er fällt mit gelöschtem `key` um und ist damit der einzige Fall, der die Bedingung wirklich unterscheidet statt sie zu bestätigen.
+
+- **`localDateKey` liegt jetzt in `shared/dateRanges.ts`** — Die Funktion lag lokal in `CalendarView`, wurde für die Zeitraum-Übergabe aber in beiden Ansichten gebraucht. Sie ist verschoben statt kopiert und hat fünf eigene Tests bekommen (Nullen-Auffüllung, Mitternacht, Jahreswechsel) — sie darf nicht durch `toISOString()` ersetzt werden, das östlich von Greenwich vor dem UTC-Versatz den Vortag meldet.
+
 ## [1.15.1] — 2026-07-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to TimeTrack are documented here.
 
   Bewusst **kein zweiter Einstiegspunkt neben dem alten**, was sowohl das Issue als auch der `TODOS`-Punkt zum PdfMergeModal wörtlich vorschlugen: Beide Fenster hingen an der Kalenderansicht, ohne kalenderspezifisch zu sein — die Zeitraum-Knöpfe haben nie den Kalender gefiltert, sie haben nur einen Zeitraum vorbelegt und ein Fenster geöffnet. Vier Einstiegspunkte über zwei Ansichten hätten die Oberfläche verdoppelt, ohne die Ursache anzufassen. Die Toolbar ist deshalb komplett umgezogen; der **Kalender ist wieder nur Kalender**. Wer den Export bisher aus dem Kalender heraus gestartet hat, klickt jetzt einen Reiter weiter links — aus der Standardansicht _Heute_ sind es unverändert zwei Klicks.
 
+  Nebeneffekt, der auffiel und mitbehoben ist: Das Monatsgitter richtet sich jetzt an der Fensterbreite aus. Vorher bestimmte die Breite der Export-Toolbar, wie breit die Kalenderansicht wurde — ein Nebenprodukt, keine Entscheidung; ohne sie wäre das Gitter auf seine Eigenbreite geschrumpft.
+
   Der `TODOS`-Punkt „Merge modal Nav-Trigger" ist damit erledigt, das dort und in #153 angemahnte Design-Gespräch geführt.
 
 ### Internal

--- a/TODOS.md
+++ b/TODOS.md
@@ -24,7 +24,8 @@ Deferred items from plan reviews. Items here have explicit decisions — they ar
 
 ### Design-Gespräche ausstehend
 
-- **Merge modal Nav-Trigger** — PdfMergeModal ist nur via CalendarView erreichbar. Zweiter Einstiegspunkt in Sidebar oder ExportModal. Design-Gespräch ausstehend.
+~~- **Merge modal Nav-Trigger**~~ → Entschieden und umgesetzt in v1.16.0 ([#153](https://github.com/skoedr/time-tracking/issues/153)). Nicht als „zweiter Einstiegspunkt": beide Modals hingen an der Kalenderansicht, ohne kalenderspezifisch zu sein, also ist die ganze Toolbar in einen eigenen `Export`-Tab gezogen. Der Kalender ist jetzt nur noch Kalender.
+
 - **Competitive positioning** — README + App-Beschreibung auf LocalFirst / Datenschutz / Kein-Abo schärfen. Kein Code, nur Text. Gespräch ausstehend.
 
 ### v1.13.2 Follow-ups (aus /ship-Review 2026-07-17)
@@ -78,6 +79,6 @@ Deferred items from plan reviews. Items here have explicit decisions — they ar
 - ~~**Preview before merge**~~ — Included in v1.7 via `pdf:pdf-info` handler + page count row in `PdfMergeModal`. Removed from backlog.
 - ~~**Full i18n DE/EN pass**~~ — Shipped in v1.8.0. All views, components and mini-widget migrated.
 - ~~**Competitive positioning**~~ → Kein Issue, Gespräch ausstehend (siehe oben).
-- ~~**Merge modal: Nav sidebar trigger**~~ → Kein Issue, Design-Gespräch ausstehend (siehe oben).
+- ~~**Merge modal: Nav sidebar trigger**~~ → Erledigt in v1.16.0 über den eigenen `Export`-Reiter ([#153](https://github.com/skoedr/time-tracking/issues/153), siehe oben).
 - **Handler extraction: pdf:merge-export** → Verschoben in »Nächster Hotfix« (siehe oben).
 - **Type guard hygiene: `filePath` input in PDF handlers** (Low) — `pdfInfoHandler` und `mergeOnlyHandler` casten `r.filePath as string` ohne expliziten `typeof`-Check. Beide fallen sicher. → v1.9 candidate.

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -4,6 +4,7 @@ import CalendarView from './views/CalendarView'
 import ClientsView from './views/ClientsView'
 import SettingsView from './views/SettingsView'
 import AuswertungView from './views/AuswertungView'
+import ExportView from './views/ExportView'
 import { IdleModal } from './components/IdleModal'
 import { QuickNoteModal } from './components/QuickNoteModal'
 import { StartTimerModal } from './components/StartTimerModal'
@@ -16,7 +17,7 @@ import { useSettingsStore } from './store/settingsStore'
 import { useProjectsStore } from './store/projectsStore'
 import { useUiPrefsStore } from './store/uiPrefsStore'
 
-type View = 'today' | 'calendar' | 'clients' | 'analytics' | 'settings'
+type View = 'today' | 'calendar' | 'clients' | 'analytics' | 'export' | 'settings'
 
 function App(): React.JSX.Element {
   const t = useT()
@@ -109,18 +110,20 @@ function App(): React.JSX.Element {
           borderColor: 'var(--card-border)'
         }}
       >
-        {(['today', 'calendar', 'clients', 'analytics', 'settings'] as View[]).map((v) => (
-          <button
-            key={v}
-            onClick={() => setView(v)}
-            className={`px-4 py-1.5 rounded-full text-sm font-medium transition-colors
+        {(['today', 'calendar', 'clients', 'analytics', 'export', 'settings'] as View[]).map(
+          (v) => (
+            <button
+              key={v}
+              onClick={() => setView(v)}
+              className={`px-4 py-1.5 rounded-full text-sm font-medium transition-colors
               focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500
               ${view === v ? 'bg-indigo-600 text-white' : 'hover:bg-white/10'}`}
-            style={view !== v ? { color: 'var(--text2)' } : undefined}
-          >
-            {t(('nav.' + v) as `nav.${View}`)}
-          </button>
-        ))}
+              style={view !== v ? { color: 'var(--text2)' } : undefined}
+            >
+              {t(('nav.' + v) as `nav.${View}`)}
+            </button>
+          )
+        )}
 
         {/* Play button — only when no timer is running */}
         {!runningEntry && (
@@ -159,6 +162,7 @@ function App(): React.JSX.Element {
           {view === 'calendar' && <CalendarView />}
           {view === 'clients' && <ClientsView />}
           {view === 'analytics' && <AuswertungView />}
+          {view === 'export' && <ExportView />}
           {view === 'settings' && <SettingsView />}
         </div>
       </main>

--- a/src/renderer/src/views/CalendarView.tsx
+++ b/src/renderer/src/views/CalendarView.tsx
@@ -132,7 +132,13 @@ export default function CalendarView(): React.JSX.Element {
   const drawerEntries = selectedKey ? (byDay.get(selectedKey) ?? []) : []
 
   return (
-    <div className="mx-auto flex max-w-5xl flex-col gap-4">
+    // `w-full` is load-bearing, not decoration: this is a flex item in App's
+    // column layout, and `mx-auto` makes an item size to its content instead of
+    // stretching. Until #153 the export toolbar (five pills plus an `ml-auto`
+    // button) padded the content out to `max-w-5xl` by accident; with it gone
+    // the widest child is the grid, which shrink-wrapped to ~370px in an 886px
+    // pane. Every other view already carries `w-full` for this reason.
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-4">
       <div className="flex items-center gap-2">
         <button
           type="button"

--- a/src/renderer/src/views/CalendarView.tsx
+++ b/src/renderer/src/views/CalendarView.tsx
@@ -14,12 +14,10 @@ import {
 import type { Entry } from '../../../shared/types'
 import type { Client, Project } from '../../../shared/types'
 import { useProjectsStore } from '../store/projectsStore'
-import { getQuickRange, type QuickRangeKind } from '../../../shared/dateRanges'
+import { localDateKey } from '../../../shared/dateRanges'
 import { useEntriesStore } from '../store/entriesStore'
 import { useTimer } from '../hooks/useTimer'
 import { CalendarDrawer } from '../components/CalendarDrawer'
-import { ExportModal } from '../components/ExportModal'
-import { PdfMergeModal } from '../components/PdfMergeModal'
 import { useRounding } from '../contexts/RoundingContext'
 import { roundDuration } from '../../../shared/duration'
 
@@ -104,19 +102,6 @@ export default function CalendarView(): React.JSX.Element {
     setCursor(startOfMonth(today))
     setFocusDay(today)
   }, [setFocusDay])
-
-  // PDF export modal state — opened by the quick-filter pills with the
-  // selected range pre-filled (#21).
-  const [pdfRange, setPdfRange] = useState<{ fromIso: string; toIso: string } | null>(null)
-  const [mergeOpen, setMergeOpen] = useState(false)
-
-  const onQuickRange = useCallback(
-    (kind: QuickRangeKind) => {
-      const range = getQuickRange(kind, new Date())
-      setPdfRange({ fromIso: localDateKey(range.from), toIso: localDateKey(range.to) })
-    },
-    [setPdfRange]
-  )
 
   // Keyboard navigation on the grid.
   function handleKey(e: React.KeyboardEvent): void {
@@ -209,51 +194,6 @@ export default function CalendarView(): React.JSX.Element {
         )}
       </div>
 
-      {/* PDF quick-filter row (#21). Hero "Letzter Monat" gets the accent
-          colour to draw the eye on the most common rechnungs-flow. */}
-      <div className="flex flex-wrap items-center gap-2">
-        <button
-          type="button"
-          onClick={() => onQuickRange('lastMonth')}
-          className="rounded-full px-3 py-1.5 text-xs font-semibold text-white hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-indigo-300"
-          style={{ background: 'var(--accent)' }}
-          title={t('calendar.export.lastMonthTitle')}
-        >
-          {t('calendar.export.lastMonth')}
-        </button>
-        <span className="ml-1 text-xs uppercase tracking-wide" style={{ color: 'var(--text3)' }}>
-          {t('calendar.export.rangeLabel')}
-        </span>
-        {(['thisWeek', 'lastWeek', 'thisMonth'] as const).map((k) => (
-          <button
-            key={k}
-            type="button"
-            onClick={() => onQuickRange(k)}
-            className="rounded-full border px-3 py-1.5 text-xs font-medium backdrop-blur-xl hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-indigo-400"
-            style={{
-              background: 'var(--card-bg)',
-              borderColor: 'var(--card-border)',
-              color: 'var(--text)'
-            }}
-          >
-            {t(('calendar.range.' + k) as TranslationKey)}
-          </button>
-        ))}
-        <button
-          type="button"
-          onClick={() => setMergeOpen(true)}
-          className="ml-auto rounded-full border px-3 py-1.5 text-xs font-medium backdrop-blur-xl hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-indigo-400"
-          style={{
-            background: 'var(--card-bg)',
-            borderColor: 'var(--card-border)',
-            color: 'var(--text)'
-          }}
-          title={t('calendar.export.mergeTitle')}
-        >
-          {t('calendar.export.merge')}
-        </button>
-      </div>
-
       {/* Header row: KW + Mo–So */}
       <div
         className="grid grid-cols-[40px_repeat(7,minmax(0,1fr))] gap-px rounded-t-lg"
@@ -321,15 +261,6 @@ export default function CalendarView(): React.JSX.Element {
         clients={clients}
         onClose={() => setSelectedDay(null)}
       />
-
-      <ExportModal
-        key={pdfRange ? `${pdfRange.fromIso}-${pdfRange.toIso}` : 'closed'}
-        open={pdfRange !== null}
-        prefilledRange={pdfRange ?? undefined}
-        onClose={() => setPdfRange(null)}
-      />
-
-      <PdfMergeModal open={mergeOpen} onClose={() => setMergeOpen(false)} />
     </div>
   )
 }
@@ -503,13 +434,6 @@ function buildMonthWeeks(cursor: Date): WeekData[] {
     })
   }
   return weeks
-}
-
-function localDateKey(d: Date): string {
-  const y = d.getFullYear()
-  const m = String(d.getMonth() + 1).padStart(2, '0')
-  const day = String(d.getDate()).padStart(2, '0')
-  return `${y}-${m}-${day}`
 }
 
 function addDays(d: Date, n: number): Date {

--- a/src/renderer/src/views/ExportView.tsx
+++ b/src/renderer/src/views/ExportView.tsx
@@ -1,0 +1,140 @@
+import { useCallback, useState } from 'react'
+import { useT } from '../contexts/I18nContext'
+import type { TranslationKey } from '../../../shared/locales/de'
+import { ExportModal } from '../components/ExportModal'
+import { PdfMergeModal } from '../components/PdfMergeModal'
+import { getQuickRange, localDateKey, type QuickRangeKind } from '../../../shared/dateRanges'
+
+/**
+ * Export view (#153).
+ *
+ * Both export dialogs used to hang off `CalendarView`: the range pills opened
+ * `ExportModal`, a right-aligned button opened `PdfMergeModal`. Neither is a
+ * calendar function — the pills filtered nothing, they only prefilled a range
+ * and opened a modal — so the whole toolbar was a passenger in a view whose
+ * label gave no hint that exporting lived there. With the iCal export (#135)
+ * behind it that stopped being tolerable: the feature exists to be a permanent
+ * second calendar layer, and it was reachable only via a button labelled
+ * "Dieser Monat".
+ *
+ * This view is that entry point, and it takes the PdfMergeModal trigger with
+ * it (TODOS.md "Merge modal Nav-Trigger") — one decision instead of bolting a
+ * second entry point onto each modal separately.
+ *
+ * The triggers themselves are unchanged: same labels, same ranges, same hero
+ * treatment for the invoice path. `exportEntryPoints.test.tsx` was written
+ * against the CalendarView version and pins that.
+ */
+export default function ExportView(): React.JSX.Element {
+  const t = useT()
+
+  // Range hand-off to ExportModal. `null` = closed; a range = open with that
+  // range prefilled.
+  const [pdfRange, setPdfRange] = useState<{ fromIso: string; toIso: string } | null>(null)
+  const [mergeOpen, setMergeOpen] = useState(false)
+
+  const onQuickRange = useCallback((kind: QuickRangeKind) => {
+    const range = getQuickRange(kind, new Date())
+    setPdfRange({ fromIso: localDateKey(range.from), toIso: localDateKey(range.to) })
+  }, [])
+
+  return (
+    <div className="mx-auto flex w-full max-w-[920px] flex-col gap-4">
+      <h1 className="text-xl font-bold tracking-tight" style={{ color: 'var(--text)' }}>
+        {t('export.view.title')}
+      </h1>
+
+      <Card>
+        <CardHeading title={t('export.view.timesTitle')} hint={t('export.view.timesHint')} />
+
+        {/* Trigger row, moved verbatim from CalendarView. Hero "Letzter Monat"
+            keeps the accent colour — it is the most common rechnungs-flow. */}
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={() => onQuickRange('lastMonth')}
+            className="rounded-full px-3 py-1.5 text-xs font-semibold text-white hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-indigo-300"
+            style={{ background: 'var(--accent)' }}
+            title={t('export.view.lastMonthTitle')}
+          >
+            {t('export.view.lastMonth')}
+          </button>
+          <span className="ml-1 text-xs uppercase tracking-wide" style={{ color: 'var(--text3)' }}>
+            {t('export.view.rangeLabel')}
+          </span>
+          {(['thisWeek', 'lastWeek', 'thisMonth'] as const).map((k) => (
+            <button
+              key={k}
+              type="button"
+              onClick={() => onQuickRange(k)}
+              className="rounded-full border px-3 py-1.5 text-xs font-medium backdrop-blur-xl hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+              style={{
+                background: 'var(--card-bg)',
+                borderColor: 'var(--card-border)',
+                color: 'var(--text)'
+              }}
+            >
+              {t(('export.range.' + k) as TranslationKey)}
+            </button>
+          ))}
+        </div>
+      </Card>
+
+      <Card>
+        <CardHeading title={t('export.view.mergeTitle')} hint={t('export.view.mergeHint')} />
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setMergeOpen(true)}
+            className="rounded-full border px-3 py-1.5 text-xs font-medium backdrop-blur-xl hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+            style={{
+              background: 'var(--card-bg)',
+              borderColor: 'var(--card-border)',
+              color: 'var(--text)'
+            }}
+            title={t('export.view.mergeButtonTitle')}
+          >
+            {t('export.view.merge')}
+          </button>
+        </div>
+      </Card>
+
+      {/* The `key` remounts the modal per open so it re-reads the stored prefs
+          (its `initialPrefs` is a lazy useState). Dropping it leaves the prefs
+          from the first mount — before the settings load finishes — in place
+          for the rest of the session. Case 6 of the test guards this. */}
+      <ExportModal
+        key={pdfRange ? `${pdfRange.fromIso}-${pdfRange.toIso}` : 'closed'}
+        open={pdfRange !== null}
+        prefilledRange={pdfRange ?? undefined}
+        onClose={() => setPdfRange(null)}
+      />
+
+      <PdfMergeModal open={mergeOpen} onClose={() => setMergeOpen(false)} />
+    </div>
+  )
+}
+
+function Card({ children }: { children: React.ReactNode }): React.JSX.Element {
+  return (
+    <section
+      className="flex flex-col gap-3 rounded-xl border p-4 backdrop-blur-xl"
+      style={{ background: 'var(--card-bg)', borderColor: 'var(--card-border)' }}
+    >
+      {children}
+    </section>
+  )
+}
+
+function CardHeading({ title, hint }: { title: string; hint: string }): React.JSX.Element {
+  return (
+    <div className="flex flex-col gap-1">
+      <h2 className="text-sm font-semibold" style={{ color: 'var(--text)' }}>
+        {title}
+      </h2>
+      <p className="text-xs" style={{ color: 'var(--text3)' }}>
+        {hint}
+      </p>
+    </div>
+  )
+}

--- a/src/renderer/src/views/exportEntryPoints.test.tsx
+++ b/src/renderer/src/views/exportEntryPoints.test.tsx
@@ -1,0 +1,253 @@
+/**
+ * Characterization tests for the export entry points (#153).
+ *
+ * Written against the PRE-move implementation, where the export toolbar lives
+ * inside `CalendarView`, and kept green through the move into its own
+ * `ExportView`. Only the import and the rendered component change; every
+ * assertion below stays byte-identical, which is what makes this a proof that
+ * the move was lossless rather than a restatement of the new code.
+ *
+ * Case 6 is the one that matters, and it took two attempts to get right. The
+ * host renders the modal with `key={pdfRange ? ... : 'closed'}` so it REMOUNTS
+ * per open. The obvious guard — "reopening with another range updates the date
+ * inputs" (case 5) — does NOT protect that `key`: ExportModal also syncs
+ * `prefilledRange` into state from an effect (ExportModal.tsx:149-154), so the
+ * range arrives with or without a remount. Case 5 was verified to still pass
+ * with the `key` prop deleted, i.e. it confirms rather than distinguishes.
+ *
+ * What the remount actually protects is `initialPrefs` (ExportModal.tsx:46): a
+ * LAZY `useState`, evaluated once per mount. Without the remount the modal
+ * keeps whichever prefs existed at first mount — at app start that is before
+ * the settings load has finished, so the user's stored prefs would never
+ * appear. Case 6 pins that by changing the stored prefs between two opens; it
+ * was verified to FAIL with the `key` deleted and pass with it in place.
+ *
+ * Expected dates are computed here from `getQuickRange` + a local formatter
+ * instead of being read back from the component, so the test is an oracle and
+ * not a mirror.
+ */
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { fireEvent } from '@testing-library/dom'
+import ExportView from './ExportView'
+import { I18nProvider } from '../contexts/I18nContext'
+import { useSettingsStore } from '../store/settingsStore'
+import { DEFAULT_PREFS, type GroupBy } from '../components/exportPrefs'
+import { getQuickRange, type QuickRangeKind } from '../../../shared/dateRanges'
+
+// `globals` is off in vitest.config.ts, so Testing Library's auto-cleanup
+// afterEach is never registered — unmount explicitly or the queries see every
+// previous render.
+afterEach(cleanup)
+
+/** Same local-day formatting the view applies before handing the range over. */
+function isoDay(d: Date): string {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+function expectedRange(kind: QuickRangeKind): { fromIso: string; toIso: string } {
+  const r = getQuickRange(kind, new Date())
+  return { fromIso: isoDay(r.from), toIso: isoDay(r.to) }
+}
+
+// Button labels as the user sees them, spelled out rather than looked up by
+// i18n key: the key names move in this refactor, the visible text must not.
+const LABEL = {
+  lastMonth: '📄 Letzter Monat als PDF',
+  thisWeek: 'Diese Woche',
+  lastWeek: 'Letzte Woche',
+  thisMonth: 'Dieser Monat',
+  merge: 'PDFs zusammenführen'
+} as const
+
+const EXPORT_DIALOG_TITLE = 'Exportieren'
+const MERGE_DIALOG_TITLE = 'PDFs zusammenführen'
+
+type Store = Record<string, string>
+
+/** Mutable settings store so a test can change prefs between two opens. */
+function mockApi(initial: Store = {}): Store {
+  const store: Store = { ...initial }
+  const unsubscribe = (): void => {}
+  const api = {
+    entries: {
+      getByMonth: async () => ({ ok: true as const, data: [] }),
+      getRunning: async () => ({ ok: true as const, data: null }),
+      heartbeat: async () => ({ ok: true as const, data: undefined })
+    },
+    projects: { getAll: async () => ({ ok: true as const, data: [] }) },
+    clients: { getAll: async () => ({ ok: true as const, data: [] }) },
+    settings: {
+      getAll: async () => ({ ok: true as const, data: { ...store } }),
+      set: async (key: string, value: string) => {
+        store[key] = value
+        return { ok: true as const, data: undefined }
+      }
+    },
+    dashboard: { todayTotal: async () => ({ ok: true as const, data: 0 }) },
+    tray: { update: () => {} },
+    idle: { dismiss: async () => ({ ok: true as const, data: undefined }) },
+    onHotkeyToggle: () => unsubscribe,
+    onIdleDetected: () => unsubscribe,
+    onTrayQuickStart: () => unsubscribe,
+    onTrayStop: () => unsubscribe
+  }
+  ;(window as unknown as { api: typeof api }).api = api
+  return store
+}
+
+function prefsWith(groupBy: GroupBy): string {
+  return JSON.stringify({ ...DEFAULT_PREFS, groupBy })
+}
+
+/** The `groupBy` select inside the open export dialog (PDF tab). */
+function groupBySelect(): HTMLSelectElement {
+  const dialog = document.querySelector('[role="dialog"]')
+  if (!dialog) throw new Error('no dialog open')
+  const select = Array.from(dialog.querySelectorAll('select')).find((s) =>
+    s.querySelector('option[value="tag"]')
+  )
+  if (!select) throw new Error('groupBy select not found')
+  return select
+}
+
+async function loadSettings(): Promise<void> {
+  await act(async () => {
+    await useSettingsStore.getState().load()
+  })
+}
+
+interface Rendered {
+  container: HTMLElement
+}
+
+async function renderHost(): Promise<Rendered> {
+  const view = render(
+    <I18nProvider>
+      <ExportView />
+    </I18nProvider>
+  )
+  // Let any mount effects settle so the toolbar is past its loading state
+  // before the first click.
+  await act(async () => {})
+  return { container: view.container }
+}
+
+function clickButton(container: HTMLElement, label: string): void {
+  const button = Array.from(container.querySelectorAll('button')).find(
+    (b) => b.textContent?.trim() === label
+  )
+  if (!button) throw new Error(`button not found: ${label}`)
+  fireEvent.click(button)
+}
+
+/** The open dialog's heading, or null when no dialog is mounted. */
+function dialogTitle(): string | null {
+  return document.querySelector('#dialog-title')?.textContent?.trim() ?? null
+}
+
+/** `[from, to]` as currently shown in the export dialog's two date inputs. */
+function dateInputValues(): [string, string] {
+  const dialog = document.querySelector('[role="dialog"]')
+  if (!dialog) throw new Error('no dialog open')
+  const inputs = Array.from(dialog.querySelectorAll<HTMLInputElement>('input[type="date"]'))
+  if (inputs.length < 2) throw new Error(`expected 2 date inputs, found ${inputs.length}`)
+  return [inputs[0].value, inputs[1].value]
+}
+
+function closeDialog(): void {
+  fireEvent.keyDown(window, { key: 'Escape' })
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  mockApi()
+})
+
+describe('export entry points (#153 characterization)', () => {
+  it('1. no dialog is open before any trigger is clicked', async () => {
+    await renderHost()
+    expect(document.querySelector('[role="dialog"]')).toBeNull()
+  })
+
+  it('2. the hero button opens the export dialog prefilled with last month', async () => {
+    const { container } = await renderHost()
+    clickButton(container, LABEL.lastMonth)
+    await waitFor(() => expect(dialogTitle()).toBe(EXPORT_DIALOG_TITLE))
+
+    const { fromIso, toIso } = expectedRange('lastMonth')
+    expect(dateInputValues()).toEqual([fromIso, toIso])
+  })
+
+  it.each([
+    ['thisWeek', LABEL.thisWeek],
+    ['lastWeek', LABEL.lastWeek],
+    ['thisMonth', LABEL.thisMonth]
+  ] as const)('3. the %s pill opens the export dialog with that range', async (kind, label) => {
+    const { container } = await renderHost()
+    clickButton(container, label)
+    await waitFor(() => expect(dialogTitle()).toBe(EXPORT_DIALOG_TITLE))
+
+    const { fromIso, toIso } = expectedRange(kind)
+    expect(dateInputValues()).toEqual([fromIso, toIso])
+  })
+
+  it('4. the merge button opens the merge dialog, not the export dialog', async () => {
+    const { container } = await renderHost()
+    clickButton(container, LABEL.merge)
+    await waitFor(() => expect(dialogTitle()).toBe(MERGE_DIALOG_TITLE))
+
+    // The merge dialog has no from/to range — proves we opened the other one.
+    const dialog = document.querySelector('[role="dialog"]')
+    expect(dialog?.querySelectorAll('input[type="date"]').length).toBe(0)
+  })
+
+  it('5. reopening with a different range replaces the prefill', async () => {
+    const { container } = await renderHost()
+
+    clickButton(container, LABEL.lastMonth)
+    await waitFor(() => expect(dialogTitle()).toBe(EXPORT_DIALOG_TITLE))
+    expect(dateInputValues()).toEqual(Object.values(expectedRange('lastMonth')))
+
+    closeDialog()
+    await waitFor(() => expect(document.querySelector('[role="dialog"]')).toBeNull())
+
+    clickButton(container, LABEL.thisWeek)
+    await waitFor(() => expect(dialogTitle()).toBe(EXPORT_DIALOG_TITLE))
+
+    const thisWeek = expectedRange('thisWeek')
+    expect(dateInputValues()).toEqual([thisWeek.fromIso, thisWeek.toIso])
+    expect(dateInputValues()).not.toEqual(Object.values(expectedRange('lastMonth')))
+  })
+
+  it('6. reopening re-reads stored prefs — the remount contract', async () => {
+    // Prefs stored BEFORE the first render, so open #1 proves the modal reads
+    // the store at all (groupBy 'tag' is not the 'none' default).
+    const store = mockApi({ export_prefs: prefsWith('tag') })
+    await loadSettings()
+    const { container } = await renderHost()
+
+    clickButton(container, LABEL.lastMonth)
+    await waitFor(() => expect(dialogTitle()).toBe(EXPORT_DIALOG_TITLE))
+    expect(groupBySelect().value).toBe('tag')
+
+    closeDialog()
+    await waitFor(() => expect(document.querySelector('[role="dialog"]')).toBeNull())
+
+    // A second writer changes the stored prefs while the modal is closed —
+    // stands in for the real case, where the settings load simply finishes
+    // after the modal's first mount.
+    store.export_prefs = prefsWith('project')
+    await loadSettings()
+
+    clickButton(container, LABEL.thisWeek)
+    await waitFor(() => expect(dialogTitle()).toBe(EXPORT_DIALOG_TITLE))
+
+    // Fails without the remount `key`: the lazy initialPrefs from open #1
+    // would still be in state and the select would read 'tag'.
+    expect(groupBySelect().value).toBe('project')
+  })
+})

--- a/src/shared/dateRanges.test.ts
+++ b/src/shared/dateRanges.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getQuickRange } from './dateRanges'
+import { getQuickRange, localDateKey } from './dateRanges'
 
 /**
  * Construct a Date in local time (Y/M/D/H/M). All assertions below also use
@@ -87,5 +87,37 @@ describe('getQuickRange', () => {
     const r = getQuickRange('lastWeek', now)
     expect(dayKey(r.from)).toBe('2026-03-30')
     expect(dayKey(r.to)).toBe('2026-04-05')
+  })
+})
+
+/**
+ * `localDateKey` moved here from `CalendarView` in #153, where the export view
+ * needed the same formatting to hand a range to the export modal. `dayKey`
+ * above is kept as an independent copy on purpose, so the `getQuickRange`
+ * assertions do not lean on the function under test here.
+ */
+describe('localDateKey', () => {
+  it('zero-pads single-digit months and days', () => {
+    expect(localDateKey(local(2026, 1, 5))).toBe('2026-01-05')
+  })
+
+  it('does not pad values that are already two digits', () => {
+    expect(localDateKey(local(2026, 12, 31))).toBe('2026-12-31')
+  })
+
+  it('reports the local calendar day at midnight, not the UTC one', () => {
+    // The reason this helper exists instead of `toISOString().slice(0, 10)`:
+    // east of Greenwich, 00:30 local is still the previous day in UTC. The
+    // Date is built from local components, so this holds in every timezone.
+    expect(localDateKey(local(2026, 3, 15, 0, 30))).toBe('2026-03-15')
+  })
+
+  it('reports the local calendar day just before midnight', () => {
+    expect(localDateKey(local(2026, 3, 15, 23, 59))).toBe('2026-03-15')
+  })
+
+  it('does not roll over across a year boundary', () => {
+    expect(localDateKey(local(2026, 1, 1, 0, 1))).toBe('2026-01-01')
+    expect(localDateKey(local(2025, 12, 31, 23, 59))).toBe('2025-12-31')
   })
 })

--- a/src/shared/dateRanges.ts
+++ b/src/shared/dateRanges.ts
@@ -34,6 +34,21 @@ export function getQuickRange(kind: QuickRangeKind, now: Date): DateRange {
   }
 }
 
+/**
+ * `YYYY-MM-DD` for a Date's **local** calendar day.
+ *
+ * Deliberately not `toISOString().slice(0, 10)`, which converts to UTC first
+ * and therefore reports the previous day for any local time before the UTC
+ * offset (e.g. 00:30 in CEST). Used both for calendar grid keys and to hand a
+ * quick range to the export modal, which expects local day boundaries.
+ */
+export function localDateKey(d: Date): string {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
 export const QUICK_RANGE_LABELS: Record<QuickRangeKind, string> = {
   thisWeek: 'Diese Woche',
   lastWeek: 'Letzte Woche',

--- a/src/shared/locales/de.ts
+++ b/src/shared/locales/de.ts
@@ -177,11 +177,6 @@ export const de = {
   'calendar.nav.today': 'Heute',
   'calendar.status.loading': 'Lade…',
   'calendar.status.error': 'Fehler beim Laden',
-  'calendar.export.lastMonth': '📄 Letzter Monat als PDF',
-  'calendar.export.lastMonthTitle': 'Letzten Monat als PDF exportieren',
-  'calendar.export.rangeLabel': 'oder Zeitraum:',
-  'calendar.export.merge': 'PDFs zusammenführen',
-  'calendar.export.mergeTitle': 'Vorhandene PDFs zusammenführen',
   'calendar.header.week': 'KW',
   'calendar.days.mon': 'Mo',
   'calendar.days.tue': 'Di',
@@ -191,10 +186,6 @@ export const de = {
   'calendar.days.sat': 'Sa',
   'calendar.days.sun': 'So',
   'calendar.grid.aria': 'Kalender',
-  'calendar.range.thisWeek': 'Diese Woche',
-  'calendar.range.lastWeek': 'Letzte Woche',
-  'calendar.range.thisMonth': 'Dieser Monat',
-  'calendar.range.lastMonth': 'Letzter Monat',
   'calendar.months.jan': 'Januar',
   'calendar.months.feb': 'Februar',
   'calendar.months.mar': 'März',
@@ -348,6 +339,26 @@ export const de = {
   'quicknote.skip': 'Überspringen ({remaining}s)',
 
   // ── ExportModal ───────────────────────────────────────────────────────────
+  // ── ExportView (#153) — Einstiegspunkt, vorher in der Kalenderansicht ────
+  'export.view.title': 'Exportieren',
+  'export.view.timesTitle': 'Erfasste Zeiten exportieren',
+  'export.view.timesHint':
+    'Stundennachweis als PDF, Tabelle als CSV oder Kalenderdatei als iCal. Der gewählte Zeitraum lässt sich im Dialog noch anpassen.',
+  'export.view.lastMonth': '📄 Letzter Monat als PDF',
+  'export.view.lastMonthTitle': 'Letzten Monat als PDF exportieren',
+  'export.view.rangeLabel': 'oder Zeitraum:',
+  // Absichtlich nicht derselbe Text wie der Button darunter: die Überschrift
+  // benennt den Anlass, der Button die Aktion (und trägt denselben Wortlaut
+  // wie der Dialogtitel, damit der Klick vorhersagbar ist).
+  'export.view.mergeTitle': 'Stundennachweis und Rechnung',
+  'export.view.mergeHint':
+    'Stundennachweis und Rechnung zu einer PDF zusammenfassen, in der richtigen Reihenfolge.',
+  'export.view.merge': 'PDFs zusammenführen',
+  'export.view.mergeButtonTitle': 'Vorhandene PDFs zusammenführen',
+  'export.range.thisWeek': 'Diese Woche',
+  'export.range.lastWeek': 'Letzte Woche',
+  'export.range.thisMonth': 'Dieser Monat',
+  'export.range.lastMonth': 'Letzter Monat',
   'export.title': 'Exportieren',
   'export.tab.pdf': 'PDF — Stundennachweis',
   'export.tab.csv': 'CSV — Tabelle',
@@ -629,6 +640,7 @@ export const de = {
 
   // ── Auswertung (v1.10 #93) ────────────────────────────────────────────────
   'nav.analytics': 'Auswertung',
+  'nav.export': 'Export',
   'analytics.title': 'Auswertung',
   'analytics.month.hours': 'Stunden',
   'analytics.month.revenue': 'Umsatz',

--- a/src/shared/locales/en.ts
+++ b/src/shared/locales/en.ts
@@ -177,11 +177,6 @@ export const en: Record<TranslationKey, string> = {
   'calendar.nav.today': 'Today',
   'calendar.status.loading': 'Loading…',
   'calendar.status.error': 'Error loading',
-  'calendar.export.lastMonth': '📄 Last month as PDF',
-  'calendar.export.lastMonthTitle': 'Export last month as PDF',
-  'calendar.export.rangeLabel': 'or range:',
-  'calendar.export.merge': 'Merge PDFs',
-  'calendar.export.mergeTitle': 'Merge existing PDFs',
   'calendar.header.week': 'Wk',
   'calendar.days.mon': 'Mon',
   'calendar.days.tue': 'Tue',
@@ -191,10 +186,6 @@ export const en: Record<TranslationKey, string> = {
   'calendar.days.sat': 'Sat',
   'calendar.days.sun': 'Sun',
   'calendar.grid.aria': 'Calendar',
-  'calendar.range.thisWeek': 'This week',
-  'calendar.range.lastWeek': 'Last week',
-  'calendar.range.thisMonth': 'This month',
-  'calendar.range.lastMonth': 'Last month',
   'calendar.months.jan': 'January',
   'calendar.months.feb': 'February',
   'calendar.months.mar': 'March',
@@ -346,6 +337,26 @@ export const en: Record<TranslationKey, string> = {
   'quicknote.skip': 'Skip ({remaining}s)',
 
   // ── ExportModal ───────────────────────────────────────────────────────────
+  // ── ExportView (#153) — entry point, previously in the calendar view ──────
+  'export.view.title': 'Export',
+  'export.view.timesTitle': 'Export tracked time',
+  'export.view.timesHint':
+    'Timesheet as PDF, spreadsheet as CSV, or calendar file as iCal. You can still adjust the selected range in the dialog.',
+  'export.view.lastMonth': '📄 Last month as PDF',
+  'export.view.lastMonthTitle': 'Export last month as PDF',
+  'export.view.rangeLabel': 'or range:',
+  // Deliberately not the same text as the button below it: the heading names
+  // the occasion, the button the action (and matches the dialog title so the
+  // click is predictable).
+  'export.view.mergeTitle': 'Timesheet and invoice',
+  'export.view.mergeHint':
+    'Combine a timesheet and an invoice into a single PDF, in the right order.',
+  'export.view.merge': 'Merge PDFs',
+  'export.view.mergeButtonTitle': 'Merge existing PDFs',
+  'export.range.thisWeek': 'This week',
+  'export.range.lastWeek': 'Last week',
+  'export.range.thisMonth': 'This month',
+  'export.range.lastMonth': 'Last month',
   'export.title': 'Export',
   'export.tab.pdf': 'PDF — Time report',
   'export.tab.csv': 'CSV — Spreadsheet',
@@ -620,6 +631,7 @@ export const en: Record<TranslationKey, string> = {
 
   // ── Analytics (v1.10 #93) ─────────────────────────────────────────────────
   'nav.analytics': 'Analytics',
+  'nav.export': 'Export',
   'analytics.title': 'Analytics',
   'analytics.month.hours': 'Hours',
   'analytics.month.revenue': 'Revenue',


### PR DESCRIPTION
## Worum es geht

Das Export-Fenster war ausschließlich über die Zeitraum-Knöpfe in der **Kalender**-Ansicht erreichbar, das PDF-Zusammenführen über einen weiteren Knopf daneben. In der Navigation stand nirgends „Export" — wer danach suchte, fand nichts. Mit dem iCal-Export (#135) wiegt das schwerer als vorher: dessen ganzer Zweck ist ein dauerhafter zweiter Kalender-Layer, und danach sucht man unter „Export", nicht unter „Dieser Monat".

Es gibt jetzt einen Reiter **Export** zwischen _Auswertung_ und _Einstellungen_.

## Die Entscheidung, die von der Vorlage abweicht

#153 und der `TODOS`-Punkt „Merge modal Nav-Trigger" schlugen beide wörtlich einen **zweiten** Einstiegspunkt vor. Dieser PR macht etwas anderes: die Toolbar zieht **komplett** um, der Kalender verliert sie ganz.

Begründung: Beide Fenster hingen an der Kalenderansicht, ohne kalenderspezifisch zu sein. `onQuickRange` hat nie `cursor` oder `focusDay` angefasst — es hat nur einen Zeitraum vorbelegt und ein Fenster geöffnet. (Nachgesehen, nicht vermutet; das war die Bedingung dafür, dass der Umzug überhaupt verlustfrei sein kann.) Zwei zusätzliche Einstiegspunkte hätten vier Einstiegspunkte über zwei Ansichten ergeben — mehr Oberfläche, größere Handtest-Matrix, Ursache unangetastet.

**Kosten, ehrlich benannt:** Wer den Export bisher aus dem Kalender heraus startete, klickt jetzt einen Reiter weiter links. Aus der Standardansicht _Heute_ sind es unverändert zwei Klicks (vorher Kalender → Letzter Monat, jetzt Export → Letzter Monat); nur wer schon im Kalender stand, zahlt einen Klick.

Die Knöpfe selbst sind unverändert — gleiche Beschriftungen, gleiche Zeiträume, „Letzter Monat" weiterhin in Akzentfarbe, weil das der häufigste Rechnungs-Weg ist. Neu ist nur das Drumherum: zwei Karten mit Überschrift und Hinweistext.

Damit ist auch der `TODOS`-Punkt erledigt und das dort wie in #153 angemahnte Design-Gespräch geführt.

## Absicherung

`exportEntryPoints.test.tsx` (8 Fälle) entstand **vor** dem Umzug und stand gegen den alten Code in `CalendarView` grün. Danach zeigt dieselbe Datei unverändert auf `ExportView` — nur Import und gerenderte Komponente wechseln, jede Zusicherung bleibt gleich. Das ist der Beleg für den verlustfreien Umzug und nicht bloß eine Beschreibung des neuen Codes.

**Fall 6 verdient eine Notiz, weil der erste Versuch danebenlag.** Der naheliegende Wächter — „ein zweites Öffnen zeigt den neuen Zeitraum" — bewacht die tragende Stelle **nicht**. Das Fenster wird per `key` bei jedem Öffnen neu aufgebaut, bekommt den Zeitraum aber zusätzlich über einen Effekt (`ExportModal.tsx:149-154`); mit gelöschtem `key` blieb dieser Fall grün. Nachgemessen, nicht vermutet.

Tragend ist der `key` für die **gespeicherten Export-Einstellungen**: `initialPrefs` ist ein lazy `useState`, genau einmal pro Aufbau gelesen. Ohne Neuaufbau bliebe der Stand vom ersten Mount stehen — beim App-Start also der Stand *vor* dem Laden der Einstellungen. Fall 6 prüft, dass ein zweites Öffnen die inzwischen geänderten Einstellungen liest, und fällt mit gelöschtem `key` um (`expected 'tag' to be 'project'`). Er ist der einzige Fall, der die Bedingung unterscheidet statt sie zu bestätigen.

`localDateKey` wandert nach `shared/dateRanges.ts`, weil beide Ansichten es für die Zeitraum-Übergabe brauchen — verschoben statt kopiert, plus fünf eigene Tests. Sie darf nicht durch `toISOString().slice(0,10)` ersetzt werden, das östlich von Greenwich vor dem UTC-Versatz den Vortag meldet.

## Handtest

Im **gebauten Paket** über CDP getrieben (echte Pointer-/Tastatur-Events, nicht synthetische DOM-Klicks), gegen eine separate `userData` — die produktive DB wurde nicht angefasst, die laufende Installation nicht beendet.

| Geprüft | Ergebnis |
| --- | --- |
| Sechs Reiter bei 900 px | kein Umbruch, reichlich Luft (Screenshot) |
| Fokus beim Öffnen | wandert in den Dialog, auf das erste Formularfeld |
| Fokus bei Escape | zurück auf den auslösenden Knopf |
| „Letzter Monat" | 2026-06-01 … 2026-06-30 |
| „Diese Woche" | 2026-07-27 … 2026-08-02 (heute ist Montag) |
| Zweites Öffnen | ersetzt den Zeitraum, kein Rest vom ersten |
| Kalender | 0 von 5 Export-Knöpfen |
| Export | 5 von 5 |

Dabei **zwei Textfehler gefunden, die kein Test sieht**: die Karten-Überschrift war wortgleich mit ihrem eigenen Knopf („PDFs zusammenführen" doppelt), und der Hinweis sagte „Zeitraum wählen" direkt über der Beschriftung „ODER ZEITRAUM:". Beide korrigiert.

## Zahlen

- Tests **611 → 624** (8 Charakterisierung, 5 `localDateKey`), 0 skipped
- Lint unverändert **0 Fehler / 11 Warnungen** (alle vorbestehend, in nicht angefassten Dateien)
- `pnpm typecheck` sauber

Closes #153

---

## Nachtrag: Kalender-Breite (2. Commit)

Der Toolbar-Umzug hatte einen Folgefehler, der beim Nachsehen im laufenden Fenster auffiel: Die Kalender-Ansicht stand nur noch **369 px** breit in einem 886 px breiten Bereich, mit großer leerer Fläche daneben.

Ursache ist keine Kalender-Logik, sondern zwei Klassen im Zusammenspiel. Die Ansicht ist ein Flex-Item in der Spalten-Anordnung von `App`, und `mx-auto` lässt ein Flex-Item auf seinen **Inhalt** schrumpfen statt sich zu strecken. Bis zu diesem PR hielt die Export-Toolbar den Inhalt zufällig breit — fünf Pillen plus der per `ml-auto` nach rechts gedrückte Zusammenführen-Knopf ergaben zusammen rund **775 px** (an denselben Knöpfen in der neuen Ansicht nachgemessen, nicht geschätzt). Ohne sie ist das breiteste Kind das Monatsgitter, das auf seine intrinsische Breite schrumpft.

`w-full` behebt es. Der Kalender war damit die **einzige** Ansicht ohne diese Klasse — Heute, Kunden, Auswertung, Einstellungen und die neue Export-Ansicht tragen sie alle, aus genau diesem Grund.

**Ehrlich zum Vorzustand:** Der Kalender ist jetzt nicht wieder 775 px breit, sondern **830 px** — volle Bereichsbreite abzüglich Scrollbar. Die 775 px waren nie eine Entscheidung, sondern ein Nebenprodukt der Toolbar-Breite.

| Ansicht | Breite (in 886 px Bereich) |
| --- | --- |
| Kalender, vor dem Fix | 369 px |
| Kalender, nach dem Fix | 830 px |
| Auswertung / Export (Vergleich) | 838 px |

**Kein Test dazu, und das ist keine Nachlässigkeit:** jsdom rechnet kein Layout, `getBoundingClientRect` liefert dort überall 0. Diese Fehlerklasse ist für die Suite grundsätzlich unsichtbar und nur im laufenden Fenster messbar.

Warum im selben PR und nicht als Folge-PR: Der Fehler entsteht *durch* diesen PR, und der ist noch nicht gemergt. Ein gestapelter zweiter PR auf einen offenen Branch wäre genau die Konstellation, in der „gemergt" und „drin" auseinanderfallen — und `main` soll den schmalen Kalender nie enthalten.
