### PR TITLE
feat(#130): Microsoft-Konto verbinden — Auth-Fundament (1 von 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to TimeTrack are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **Microsoft-Konto verbinden (#130, Teil 1 von 3)** — Unter **Einstellungen → Integrationen** lässt sich ein Microsoft-Konto verbinden: Klick auf „Microsoft-Konto verbinden", Anmeldung im Browser, Zustimmung, fertig. Das ist die Grundlage für den Kalender-Import; **übernommen wird damit noch nichts** — dieser Teil richtet nur die Verbindung ein. Ein Knopf „Verbindung prüfen" fragt Microsoft, ob die Berechtigung wirklich noch trägt, statt nur zu behaupten, dass etwas gespeichert ist.
+
+  TimeTrack fragt ausschließlich **Lese**-Rechte am Kalender an (`Calendars.Read`) und schreibt nie hinein. Die Anmeldung läuft direkt zwischen der App und Microsoft — es gibt keinen Server dazwischen, und keine Zugangsdaten verlassen den Rechner. Funktioniert mit Geschäfts- und Schulkonten ebenso wie mit privaten Microsoft-Konten.
+
+  **Privacy:** Der Refresh-Token liegt verschlüsselt über die sichere Ablage des Betriebssystems (DPAPI unter Windows, Keychain unter macOS) in einer eigenen Datei neben der Datenbank — bewusst **nicht** in der Datenbank selbst, damit er nicht in jedes Backup wandert und beim Zurückspielen auf fremde Rechner landet. Steht keine sichere Ablage zur Verfügung (unter Linux typischerweise ein fehlender Schlüsselbund), verweigert TimeTrack das Speichern mit einer Erklärung, statt still im Klartext abzulegen.
+
+  **Bekannte Einschränkung, kein Fehler:** Solange wald-it kein von Microsoft verifizierter Herausgeber ist, dürfen Nutzer in **fremden** Firmen-Tenants der App nicht selbst zustimmen — dort erscheint „Genehmigung durch Administrator erforderlich". Das ist eine Entra-Richtlinie für Multi-Tenant-Apps, die mehr als die Basis-Anmeldung anfragen. Wer eine eigene App-Registrierung nutzen möchte, kann unter **Erweitert** eine eigene Anwendungs-ID hinterlegen.
+
 ### Changed
 
 - **Exportieren ist jetzt ein eigener Reiter (#153)** — Das Export-Fenster war ausschließlich über die Zeitraum-Knöpfe in der **Kalender**-Ansicht erreichbar, das Zusammenführen von PDFs über einen weiteren Knopf daneben. In der Navigation stand nirgends „Export": Wer danach suchte, fand nichts, und ein automatisierter Durchlauf von v1.15.0 fand ebenfalls nichts. Mit dem iCal-Export (#135) wog das schwerer als vorher, weil dessen ganzer Zweck ein dauerhafter zweiter Kalender-Layer ist — man sucht danach unter „Export", nicht unter „Dieser Monat". Es gibt jetzt einen Reiter **Export** zwischen _Auswertung_ und _Einstellungen_, der beide Wege beherbergt: Stundennachweis/CSV/iCal oben, PDFs zusammenführen darunter. Die Knöpfe selbst sind unverändert — gleiche Beschriftungen, gleiche Zeiträume, „Letzter Monat" weiterhin farblich hervorgehoben, weil das der häufigste Rechnungs-Weg ist.
@@ -15,6 +25,12 @@ All notable changes to TimeTrack are documented here.
   Der `TODOS`-Punkt „Merge modal Nav-Trigger" ist damit erledigt, das dort und in #153 angemahnte Design-Gespräch geführt.
 
 ### Internal
+
+- **Auth ohne neue Abhängigkeit (#130)** — Authorization Code + PKCE selbst implementiert statt `@azure/msal-node`. Die Bibliothek bringt über `jsonwebtoken` auch `jws`, `semver`, `ms` und sieben einzelne `lodash.*`-Pakete mit — bei zwölf Runtime-Abhängigkeiten ungefähr eine Verdopplung. Der Teil, der sie rechtfertigen würde, ist hier ungenutzt: als Public Client wird nichts signiert und kein Token für eine Sicherheitsentscheidung gelesen. Übrig bleiben zwei Form-POSTs, eine URL und eine Rotationsregel, über `fetch` + `AbortSignal.timeout` wie schon bei den Webhooks. Aufteilung wie dort: `shared/graphAuth.ts` ist reine Arithmetik und renderer-tauglich, die I/O liegt in `main/`.
+
+- **Der Handtest fand drei Fehler, die 763 grüne Tests nicht sahen (#130)** — Der Inhalt der neuen Sektion klebte am Kartenrand, weil `Section` kein Padding liefert (das steckt in `Row`); jsdom rechnet kein Layout, für diese Fehlerklasse ist die Suite grundsätzlich blind. Schwerer wogen zwei Pfad-Fehler: Der Token landete im **produktiven** `userData`-Verzeichnis, weil der Speicher den Pfad aus `mcp/socketPath.ts` nahm, der `%APPDATA%` Electron-frei rekonstruiert und ein überschriebenes `userData` nicht kennen kann. Der naheliegende Fix — ein lazy `require('./db')` — war schlimmer als der Fehler: electron-vite baut den Main-Prozess zu einer einzigen Datei, in der zur Laufzeit kein Modul `./db` existiert, sodass das Feature in **jedem** Build „sichere Ablage nicht verfügbar" meldete. Beides blieb unsichtbar, weil sämtliche Tests des Speichers das Verzeichnis injizieren und der Default-Pfad nie ausgeführt wurde. Deshalb gibt es jetzt keinen Default mehr: das Verzeichnis ist ein Pflichtfeld, der Compiler zeigt jede Stelle, die vorher still geraten hätte.
+
+- **Erneuerung gegen echtes Entra belegt (#130)** — Refresh-Token-Rotation ist die Stelle, an der selbst gebautes OAuth erfahrungsgemäß verrottet: Entra kann bei jeder Erneuerung einen neuen Refresh-Token ausgeben, und wer den verwirft, sperrt den Nutzer Stunden später aus. Neben Tests gegen Fakes wurde das einmal echt gemessen — mit vorübergehend angehobener Ablauf-Toleranz erzwungen, Erneuerung durchgeführt, vom Graph-Aufruf bestätigt, rotierter Token nachweislich auf die Platte geschrieben; die Gegenprobe mit normaler Toleranz erneuert erwartungsgemäß nicht.
 
 - **Charakterisierungstest für die Export-Einstiegspunkte (#153)** — `exportEntryPoints.test.tsx` sichert acht Verhaltensweisen ab (welcher Knopf welchen Zeitraum vorbelegt, welches Fenster aufgeht, dass ein zweites Öffnen den Zeitraum ersetzt) und wurde vor dem Umzug gegen den alten Code in `CalendarView` grün geschrieben; danach zeigt dieselbe Datei unverändert auf die neue `ExportView`. Das ist der Beleg, dass der Umzug nichts verloren hat, und nicht bloß eine Beschreibung des neuen Codes.
 

--- a/src/main/graphAccount.test.ts
+++ b/src/main/graphAccount.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { DEFAULT_CLIENT_ID, MSA_TENANT_ID, type StoredTokens } from '../shared/graphAuth'
+import {
+  CLIENT_ID_SETTING,
+  disconnect,
+  effectiveClientId,
+  getAccessToken,
+  getStatus,
+  type GraphAccountDeps
+} from './graphAccount'
+import { loadTokens, saveTokens, type SecretBox } from './graphTokenStore'
+
+function fakeBox(available = true): SecretBox {
+  return {
+    isEncryptionAvailable: () => available,
+    encryptString: (plain) => Buffer.from(`enc:${Buffer.from(plain, 'utf8').toString('base64')}`),
+    decryptString: (cipher) => {
+      const s = cipher.toString('utf8')
+      if (!s.startsWith('enc:')) throw new Error('bad ciphertext')
+      return Buffer.from(s.slice(4), 'base64').toString('utf8')
+    }
+  }
+}
+
+let dir: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'tt-graph-acct-'))
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+const NOW = 1_800_000_000_000
+
+function tokens(over: Partial<StoredTokens> = {}): StoredTokens {
+  return {
+    accessToken: 'access-1',
+    refreshToken: 'refresh-1',
+    expiresAtMs: NOW + 3600_000,
+    grantedScopes: ['Calendars.Read', 'offline_access'],
+    account: { username: 'r@wald-it.com', displayName: 'Robin', tenantId: 'tid-1' },
+    ...over
+  }
+}
+
+function deps(over: Partial<GraphAccountDeps> = {}): GraphAccountDeps {
+  const settings: Record<string, string> = {}
+  return {
+    getSetting: (k) => settings[k],
+    openExternal: () => {},
+    store: { dir, secretBox: fakeBox() },
+    auth: { now: () => NOW },
+    ...over
+  }
+}
+
+function withSettings(
+  settings: Record<string, string>,
+  over: Partial<GraphAccountDeps> = {}
+): GraphAccountDeps {
+  return deps({ getSetting: (k) => settings[k], ...over })
+}
+
+describe('effectiveClientId', () => {
+  it('uses the shipped id when nothing is configured', () => {
+    expect(effectiveClientId(deps())).toBe(DEFAULT_CLIENT_ID)
+  })
+
+  it('prefers a user-supplied id — the escape hatch for locked-down tenants', () => {
+    expect(effectiveClientId(withSettings({ [CLIENT_ID_SETTING]: 'own-id' }))).toBe('own-id')
+  })
+
+  it('ignores a blank override rather than sending an empty client id', () => {
+    expect(effectiveClientId(withSettings({ [CLIENT_ID_SETTING]: '   ' }))).toBe(DEFAULT_CLIENT_ID)
+  })
+})
+
+describe('getStatus', () => {
+  it('reports disconnected before anything is stored', () => {
+    const s = getStatus(deps())
+    expect(s.connected).toBe(false)
+    expect(s.account).toBeNull()
+    expect(s.usingCustomClientId).toBe(false)
+  })
+
+  it('reports the connected account without leaking token material', () => {
+    const d = deps()
+    saveTokens(tokens(), d.store)
+    const s = getStatus(d)
+    expect(s.connected).toBe(true)
+    expect(s.account?.username).toBe('r@wald-it.com')
+    expect(JSON.stringify(s)).not.toContain('refresh-1')
+    expect(JSON.stringify(s)).not.toContain('access-1')
+  })
+
+  it('flags a personal account, because Teams presence (#132) cannot work there', () => {
+    const d = deps()
+    saveTokens(
+      tokens({ account: { username: 'a@outlook.com', displayName: 'A', tenantId: MSA_TENANT_ID } }),
+      d.store
+    )
+    expect(getStatus(d).personalAccount).toBe(true)
+  })
+
+  it('does not flag a work account as personal', () => {
+    const d = deps()
+    saveTokens(tokens(), d.store)
+    expect(getStatus(d).personalAccount).toBe(false)
+  })
+
+  it('reports storage as unavailable and stays disconnected without a keychain', () => {
+    const d = deps({ store: { dir, secretBox: fakeBox(false) } })
+    const s = getStatus(d)
+    expect(s.storageAvailable).toBe(false)
+    expect(s.connected).toBe(false)
+  })
+
+  it('says when a custom client id is in effect', () => {
+    expect(getStatus(withSettings({ [CLIENT_ID_SETTING]: 'own-id' })).usingCustomClientId).toBe(
+      true
+    )
+  })
+})
+
+describe('getAccessToken', () => {
+  it('returns null when nothing is connected', async () => {
+    await expect(getAccessToken(deps())).resolves.toBeNull()
+  })
+
+  it('returns the stored token without a network call while it is fresh', async () => {
+    const fetchFn = vi.fn()
+    const d = deps({ auth: { now: () => NOW, fetchFn: fetchFn as unknown as typeof fetch } })
+    saveTokens(tokens(), d.store)
+    await expect(getAccessToken(d)).resolves.toBe('access-1')
+    expect(fetchFn).not.toHaveBeenCalled()
+  })
+
+  it('refreshes when the token is near expiry and returns the new one', async () => {
+    const d = deps({
+      auth: {
+        now: () => NOW,
+        fetchFn: (async () =>
+          ({
+            ok: true,
+            status: 200,
+            json: async () => ({
+              access_token: 'access-2',
+              refresh_token: 'rt-2',
+              expires_in: 3600
+            })
+          }) as unknown as Response) as unknown as typeof fetch
+      }
+    })
+    saveTokens(tokens({ expiresAtMs: NOW + 1000 }), d.store)
+    await expect(getAccessToken(d)).resolves.toBe('access-2')
+  })
+
+  it('PERSISTS the rotated refresh token — otherwise the next refresh fails', async () => {
+    const d = deps({
+      auth: {
+        now: () => NOW,
+        fetchFn: (async () =>
+          ({
+            ok: true,
+            status: 200,
+            json: async () => ({
+              access_token: 'access-2',
+              refresh_token: 'rt-2',
+              expires_in: 3600
+            })
+          }) as unknown as Response) as unknown as typeof fetch
+      }
+    })
+    saveTokens(tokens({ expiresAtMs: NOW + 1000 }), d.store)
+    await getAccessToken(d)
+
+    // Read the file back rather than trusting the return value: the rotated
+    // token has to be ON DISK. Keeping it only in memory is exactly the bug
+    // that locks the user out after the old one is invalidated.
+    const onDisk = loadTokens(d.store)
+    expect(onDisk?.refreshToken).toBe('rt-2')
+    expect(onDisk?.accessToken).toBe('access-2')
+    expect(onDisk?.expiresAtMs).toBe(NOW + 3600_000)
+  })
+
+  it('persists the refreshed access token even when nothing rotated', async () => {
+    const d = deps({
+      auth: {
+        now: () => NOW,
+        fetchFn: (async () =>
+          ({
+            ok: true,
+            status: 200,
+            json: async () => ({ access_token: 'access-2', expires_in: 3600 })
+          }) as unknown as Response) as unknown as typeof fetch
+      }
+    })
+    saveTokens(tokens({ expiresAtMs: NOW + 1000 }), d.store)
+    await getAccessToken(d)
+    const onDisk = loadTokens(d.store)
+    expect(onDisk?.accessToken).toBe('access-2')
+    expect(onDisk?.refreshToken).toBe('refresh-1') // carried over, not blanked
+  })
+
+  it('drops the connection on invalid_grant instead of claiming it still works', async () => {
+    const d = deps({
+      auth: {
+        now: () => NOW,
+        fetchFn: (async () =>
+          ({
+            ok: false,
+            status: 400,
+            json: async () => ({ error: 'invalid_grant' })
+          }) as unknown as Response) as unknown as typeof fetch
+      }
+    })
+    saveTokens(tokens({ expiresAtMs: NOW + 1000 }), d.store)
+    await expect(getAccessToken(d)).resolves.toBeNull()
+    expect(getStatus(d).connected).toBe(false)
+  })
+
+  it('keeps the connection on a transient server error and propagates it', async () => {
+    const d = deps({
+      auth: {
+        now: () => NOW,
+        fetchFn: (async () =>
+          ({
+            ok: false,
+            status: 503,
+            json: async () => ({ error: 'temporarily_unavailable' })
+          }) as unknown as Response) as unknown as typeof fetch
+      }
+    })
+    saveTokens(tokens({ expiresAtMs: NOW + 1000 }), d.store)
+    await expect(getAccessToken(d)).rejects.toThrow()
+    // A blip must not sign the user out.
+    expect(getStatus(d).connected).toBe(true)
+  })
+})
+
+describe('disconnect', () => {
+  it('forgets the connection and reports it', () => {
+    const d = deps()
+    saveTokens(tokens(), d.store)
+    expect(getStatus(d).connected).toBe(true)
+    expect(disconnect(d).connected).toBe(false)
+  })
+
+  it('is safe when nothing is connected', () => {
+    expect(() => disconnect(deps())).not.toThrow()
+  })
+})

--- a/src/main/graphAccount.ts
+++ b/src/main/graphAccount.ts
@@ -1,0 +1,221 @@
+/**
+ * The Microsoft account connection as the rest of the app sees it (#130).
+ *
+ * One place that owns: which client id is in effect, whether a connection
+ * exists, and how to get a usable access token. Everything above this — the IPC
+ * handlers, and later the calendar import (#130b) — goes through here rather
+ * than touching the flow or the store directly.
+ *
+ * The important piece is `getAccessToken`: callers must never have to think
+ * about expiry or rotation. It refreshes when needed and writes the result
+ * back, because Entra may hand out a new refresh token on every refresh and
+ * forgetting to persist that one locks the user out hours later.
+ */
+import {
+  DEFAULT_CLIENT_ID,
+  GraphAuthError,
+  isPersonalAccount,
+  needsRefresh
+} from '../shared/graphAuth'
+import type { AccountInfo, StoredTokens } from '../shared/graphAuth'
+import { refreshTokens } from './graphAuth'
+import type { GraphAuthConfig, GraphAuthDeps } from './graphAuth'
+import { connectAccount } from './graphConnect'
+import type { ConnectDeps } from './graphConnect'
+import {
+  clearTokens,
+  isStorageAvailable,
+  loadTokens,
+  saveTokens,
+  type TokenStoreDeps
+} from './graphTokenStore'
+
+/** Settings key holding a user-supplied client id that overrides the shipped one. */
+export const CLIENT_ID_SETTING = 'graph_client_id'
+
+export interface GraphAccountDeps {
+  /** Reads a value from the settings table. */
+  getSetting: (key: string) => string | undefined
+  /** Opens the system browser (Electron `shell.openExternal`). */
+  openExternal: (url: string) => Promise<void> | void
+  /** Required — the token store has no default location, see graphTokenStore.ts. */
+  store: TokenStoreDeps
+  auth?: GraphAuthDeps
+  log?: (message: string) => void
+}
+
+/** What the settings UI renders. Never contains token material. */
+export interface AccountStatus {
+  connected: boolean
+  account: AccountInfo | null
+  /** True for a personal Microsoft account — Teams presence (#132) is unavailable there. */
+  personalAccount: boolean
+  grantedScopes: string[]
+  /** False when the OS keychain is missing; connecting is refused in that case. */
+  storageAvailable: boolean
+  /** True when a user-supplied client id is in effect instead of the shipped one. */
+  usingCustomClientId: boolean
+}
+
+/**
+ * The client id in effect: a user override if set, otherwise the shipped one.
+ *
+ * The override exists for tenants that refuse third-party applications and for
+ * anyone who would rather use their own registration.
+ */
+export function effectiveClientId(deps: GraphAccountDeps): string {
+  const custom = deps.getSetting(CLIENT_ID_SETTING)?.trim()
+  return custom && custom.length > 0 ? custom : DEFAULT_CLIENT_ID
+}
+
+function configOf(deps: GraphAccountDeps): GraphAuthConfig {
+  return { clientId: effectiveClientId(deps) }
+}
+
+export function getStatus(deps: GraphAccountDeps): AccountStatus {
+  const storageAvailable = isStorageAvailable(deps.store)
+  const tokens = storageAvailable ? loadTokens(deps.store) : null
+  const custom = deps.getSetting(CLIENT_ID_SETTING)?.trim()
+  return {
+    connected: tokens !== null,
+    account: tokens?.account ?? null,
+    personalAccount: isPersonalAccount(tokens?.account ?? null),
+    grantedScopes: tokens?.grantedScopes ?? [],
+    storageAvailable,
+    usingCustomClientId: Boolean(custom && custom.length > 0)
+  }
+}
+
+/**
+ * Run the browser sign-in and persist the result.
+ *
+ * The storage check comes first on purpose: sending someone through a full
+ * sign-in only to discard the tokens afterwards would be the rudest possible
+ * ordering.
+ */
+export async function connect(
+  deps: GraphAccountDeps,
+  signal?: AbortSignal
+): Promise<AccountStatus> {
+  if (!isStorageAvailable(deps.store)) {
+    throw new GraphAuthError(
+      'Die sichere Ablage des Systems ist nicht verfügbar. Die Verbindung könnte nicht ' +
+        'gespeichert werden, deshalb wird die Anmeldung gar nicht erst gestartet.',
+      'storage_unavailable'
+    )
+  }
+  const connectDeps: ConnectDeps = {
+    openExternal: deps.openExternal,
+    log: deps.log,
+    ...deps.auth
+  }
+  const tokens = await connectAccount(configOf(deps), connectDeps, signal)
+  saveTokens(tokens, deps.store)
+  deps.log?.('graph account: connected')
+  return getStatus(deps)
+}
+
+/** Forget the connection. Does not revoke anything server-side — that is the user's own account page. */
+export function disconnect(deps: GraphAccountDeps): AccountStatus {
+  clearTokens(deps.store)
+  deps.log?.('graph account: disconnected')
+  return getStatus(deps)
+}
+
+/**
+ * A usable access token, refreshing first when the stored one is close to
+ * expiry. Returns `null` when nothing is connected.
+ *
+ * On `invalid_grant` the stored connection is dropped: the grant is gone for
+ * good (revoked, password changed, unused too long), and keeping a dead blob
+ * around would make the settings page claim a connection that cannot work.
+ */
+export async function getAccessToken(deps: GraphAccountDeps): Promise<string | null> {
+  const tokens = loadTokens(deps.store)
+  if (!tokens) return null
+
+  const now = deps.auth?.now?.() ?? Date.now()
+  if (!needsRefresh(tokens, now)) return tokens.accessToken
+
+  let refreshed: StoredTokens
+  try {
+    refreshed = await refreshTokens(configOf(deps), tokens, deps.auth)
+  } catch (err) {
+    if (err instanceof GraphAuthError && err.code === 'invalid_grant') {
+      deps.log?.('graph account: grant no longer valid, connection dropped')
+      clearTokens(deps.store)
+      return null
+    }
+    throw err
+  }
+  // Must be persisted even when only the access token changed — the refresh
+  // token may have rotated, and the old one stops working once it has.
+  saveTokens(refreshed, deps.store)
+  return refreshed.accessToken
+}
+
+/** Outcome of "check connection" — proves the stored token is accepted by Graph. */
+export interface VerifyResult {
+  /** From Graph's own `/me`, not from the id_token — a second, independent source. */
+  displayName: string | null
+  mail: string | null
+  /** True when this check had to renew the access token first. */
+  refreshed: boolean
+}
+
+const GRAPH_ME_URL = 'https://graph.microsoft.com/v1.0/me'
+const GRAPH_TIMEOUT_MS = 15_000
+
+/**
+ * Call Graph once with the stored credentials.
+ *
+ * Worth having as a button rather than only as an internal helper: until
+ * something actually calls Graph, "connected" only means "we hold a blob that
+ * decrypts". This turns that into a statement about the live grant — and it
+ * exercises the refresh path, which is otherwise only covered against fakes and
+ * would first be tried for real an hour into someone's workday.
+ */
+export async function verifyConnection(deps: GraphAccountDeps): Promise<VerifyResult> {
+  const before = loadTokens(deps.store)
+  if (!before) {
+    throw new GraphAuthError('Kein Microsoft-Konto verbunden.', 'not_connected')
+  }
+  const now = deps.auth?.now?.() ?? Date.now()
+  const willRefresh = needsRefresh(before, now)
+
+  const token = await getAccessToken(deps)
+  if (!token) {
+    throw new GraphAuthError(
+      'Die Verbindung ist nicht mehr gültig. Bitte das Microsoft-Konto erneut verbinden.',
+      'invalid_grant'
+    )
+  }
+
+  const fetchFn = deps.auth?.fetchFn ?? fetch
+  const res = await fetchFn(GRAPH_ME_URL, {
+    headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(GRAPH_TIMEOUT_MS)
+  })
+  if (!res.ok) {
+    // 401 here means the token was rejected despite looking fresh — worth
+    // saying plainly rather than dressing it up as a network hiccup.
+    throw new GraphAuthError(
+      res.status === 401
+        ? 'Microsoft hat das Zugriffstoken abgelehnt. Bitte erneut verbinden.'
+        : `Microsoft Graph antwortete mit HTTP ${res.status}.`,
+      `graph_${res.status}`
+    )
+  }
+  const body = (await res.json()) as Record<string, unknown>
+  deps.log?.(`graph account: verified via /me (refreshed=${willRefresh})`)
+  return {
+    displayName: typeof body.displayName === 'string' ? body.displayName : null,
+    mail:
+      typeof body.mail === 'string'
+        ? body.mail
+        : typeof body.userPrincipalName === 'string'
+          ? body.userPrincipalName
+          : null,
+    refreshed: willRefresh
+  }
+}

--- a/src/main/graphAuth.test.ts
+++ b/src/main/graphAuth.test.ts
@@ -1,0 +1,282 @@
+import { createHash } from 'node:crypto'
+import { describe, it, expect, vi } from 'vitest'
+import { GraphAuthError, type StoredTokens } from '../shared/graphAuth'
+import {
+  createPkcePair,
+  createState,
+  exchangeCode,
+  isGrantInvalid,
+  refreshTokens
+} from './graphAuth'
+
+/**
+ * A scripted `fetch`: each call shifts the next canned response off the queue.
+ * Records the URLs and bodies so the tests can assert what went on the wire —
+ * in particular that no client secret is ever sent and that tokens never reach
+ * the log.
+ */
+interface Call {
+  url: string
+  body: string
+}
+
+interface Scripted {
+  fetchFn: typeof fetch
+  calls: Call[]
+}
+
+type Canned = { status: number; body: unknown } | { throws: Error }
+
+function scriptedFetch(queue: Canned[]): Scripted {
+  const calls: Call[] = []
+  const fetchFn = (async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(url), body: String(init?.body ?? '') })
+    const next = queue.shift()
+    if (!next) throw new Error(`scriptedFetch: no canned response left for ${String(url)}`)
+    if ('throws' in next) throw next.throws
+    return {
+      ok: next.status >= 200 && next.status < 300,
+      status: next.status,
+      json: async () => {
+        if (next.body === '<<invalid json>>') throw new Error('not json')
+        return next.body
+      }
+    } as unknown as Response
+  }) as unknown as typeof fetch
+  return { fetchFn, calls }
+}
+
+/** Deterministic clock. */
+function fakeClock(startMs = 1_800_000_000_000): { now: () => number } {
+  return { now: () => startMs }
+}
+
+const CFG = { clientId: 'client-1' }
+
+const EXCHANGE = {
+  code: 'auth-code-1',
+  codeVerifier: 'verifier-1',
+  redirectUri: 'http://localhost:51234/timetrack'
+}
+
+function tokens(over: Partial<StoredTokens> = {}): StoredTokens {
+  return {
+    accessToken: 'access-1',
+    refreshToken: 'refresh-1',
+    expiresAtMs: 1_800_000_000_000,
+    grantedScopes: ['Calendars.Read'],
+    account: null,
+    ...over
+  }
+}
+
+const OK_TOKEN_BODY = {
+  access_token: 'at-1',
+  refresh_token: 'rt-1',
+  expires_in: 3600,
+  scope: 'Calendars.Read offline_access'
+}
+
+describe('createPkcePair', () => {
+  it('derives the challenge as base64url(SHA-256(verifier)) — RFC 7636 S256', () => {
+    const { verifier, challenge } = createPkcePair()
+    const expected = createHash('sha256')
+      .update(verifier)
+      .digest('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '')
+    expect(challenge).toBe(expected)
+  })
+
+  it('produces a verifier within the length the RFC allows', () => {
+    const { verifier } = createPkcePair()
+    expect(verifier.length).toBeGreaterThanOrEqual(43)
+    expect(verifier.length).toBeLessThanOrEqual(128)
+  })
+
+  it('emits only base64url characters — no padding, nothing needing escaping', () => {
+    const { verifier, challenge } = createPkcePair()
+    expect(verifier).toMatch(/^[A-Za-z0-9\-_]+$/)
+    expect(challenge).toMatch(/^[A-Za-z0-9\-_]+$/)
+  })
+
+  it('is different every time — a fixed verifier would defeat the whole mechanism', () => {
+    const seen = new Set(Array.from({ length: 20 }, () => createPkcePair().verifier))
+    expect(seen.size).toBe(20)
+  })
+
+  it('never equals its own challenge', () => {
+    const { verifier, challenge } = createPkcePair()
+    expect(challenge).not.toBe(verifier)
+  })
+})
+
+describe('createState', () => {
+  it('is unpredictable — it is the CSRF guard for the callback', () => {
+    const seen = new Set(Array.from({ length: 20 }, () => createState()))
+    expect(seen.size).toBe(20)
+  })
+
+  it('is url-safe, since it travels in a query string', () => {
+    expect(createState()).toMatch(/^[A-Za-z0-9\-_]+$/)
+  })
+})
+
+describe('exchangeCode', () => {
+  it('posts the code, the verifier and the redirect uri', async () => {
+    const c = fakeClock()
+    const s = scriptedFetch([{ status: 200, body: OK_TOKEN_BODY }])
+    const got = await exchangeCode(CFG, EXCHANGE, { fetchFn: s.fetchFn, now: c.now })
+    expect(got.accessToken).toBe('at-1')
+    expect(got.refreshToken).toBe('rt-1')
+    expect(s.calls[0].url).toContain('/common/oauth2/v2.0/token')
+    expect(s.calls[0].body).toContain('grant_type=authorization_code')
+    expect(s.calls[0].body).toContain('code=auth-code-1')
+    expect(s.calls[0].body).toContain('code_verifier=verifier-1')
+  })
+
+  it('refuses without a client id instead of calling out', async () => {
+    const s = scriptedFetch([])
+    await expect(exchangeCode({ clientId: '' }, EXCHANGE, { fetchFn: s.fetchFn })).rejects.toThrow(
+      /Client-ID/
+    )
+    expect(s.calls).toHaveLength(0)
+  })
+
+  it('surfaces the server description on an error response', async () => {
+    const s = scriptedFetch([
+      {
+        status: 400,
+        body: { error: 'invalid_grant', error_description: 'Redirect-URI passt nicht' }
+      }
+    ])
+    await expect(exchangeCode(CFG, EXCHANGE, { fetchFn: s.fetchFn })).rejects.toThrow(
+      'Redirect-URI passt nicht'
+    )
+  })
+
+  it('fails cleanly when the error body is not JSON (proxy/outage)', async () => {
+    const s = scriptedFetch([{ status: 502, body: '<<invalid json>>' }])
+    await expect(exchangeCode(CFG, EXCHANGE, { fetchFn: s.fetchFn })).rejects.toThrow(/HTTP 502/)
+  })
+
+  it('never logs the code, the verifier or the tokens', async () => {
+    const lines: string[] = []
+    const s = scriptedFetch([{ status: 200, body: OK_TOKEN_BODY }])
+    await exchangeCode(
+      CFG,
+      { ...EXCHANGE, code: 'SECRET-CODE', codeVerifier: 'SECRET-VERIFIER' },
+      { fetchFn: s.fetchFn, log: (m) => lines.push(m) }
+    )
+    const all = lines.join('\n')
+    expect(all).not.toContain('SECRET-CODE')
+    expect(all).not.toContain('SECRET-VERIFIER')
+    expect(all).not.toContain('at-1')
+    expect(all).not.toContain('rt-1')
+  })
+})
+
+describe('refreshTokens', () => {
+  it('sends the refresh grant and returns re-based tokens', async () => {
+    const c = fakeClock()
+    const s = scriptedFetch([
+      { status: 200, body: { access_token: 'at-2', refresh_token: 'rt-2', expires_in: 3600 } }
+    ])
+    const got = await refreshTokens(CFG, tokens(), { fetchFn: s.fetchFn, now: c.now })
+    expect(got.accessToken).toBe('at-2')
+    expect(got.refreshToken).toBe('rt-2')
+    expect(got.expiresAtMs).toBe(c.now() + 3600_000)
+    expect(s.calls[0].body).toContain('grant_type=refresh_token')
+  })
+
+  it('keeps the old refresh token when the response rotates nothing', async () => {
+    const s = scriptedFetch([{ status: 200, body: { access_token: 'at-2', expires_in: 3600 } }])
+    const got = await refreshTokens(CFG, tokens({ refreshToken: 'keep-me' }), {
+      fetchFn: s.fetchFn
+    })
+    expect(got.refreshToken).toBe('keep-me')
+  })
+
+  it('reports invalid_grant as a connection that must be re-established', async () => {
+    const s = scriptedFetch([
+      { status: 400, body: { error: 'invalid_grant', error_description: 'expired' } }
+    ])
+    const err = await refreshTokens(CFG, tokens(), { fetchFn: s.fetchFn }).catch((e) => e)
+    expect(err).toBeInstanceOf(GraphAuthError)
+    expect(isGrantInvalid(err)).toBe(true)
+    expect(String(err.message)).toMatch(/erneut verbinden/)
+  })
+
+  it('does not treat an ordinary server error as an invalid grant', async () => {
+    const s = scriptedFetch([{ status: 503, body: { error: 'temporarily_unavailable' } }])
+    const err = await refreshTokens(CFG, tokens(), { fetchFn: s.fetchFn }).catch((e) => e)
+    expect(isGrantInvalid(err)).toBe(false)
+  })
+
+  it('propagates a network failure rather than silently dropping the connection', async () => {
+    const s = scriptedFetch([{ throws: new Error('getaddrinfo ENOTFOUND') }])
+    await expect(refreshTokens(CFG, tokens(), { fetchFn: s.fetchFn })).rejects.toThrow(/ENOTFOUND/)
+  })
+
+  it('never logs the refresh token', async () => {
+    const lines: string[] = []
+    const s = scriptedFetch([{ status: 400, body: { error: 'invalid_grant' } }])
+    await refreshTokens(CFG, tokens({ refreshToken: 'SECRET-REFRESH' }), {
+      fetchFn: s.fetchFn,
+      log: (m) => lines.push(m)
+    }).catch(() => {})
+    expect(lines.join('\n')).not.toContain('SECRET-REFRESH')
+  })
+})
+
+describe('request hygiene', () => {
+  it('bounds every request with a timeout signal', async () => {
+    const seen: (AbortSignal | undefined)[] = []
+    const fetchFn = (async (_u: unknown, init?: RequestInit) => {
+      seen.push(init?.signal ?? undefined)
+      return {
+        ok: true,
+        status: 200,
+        json: async () => OK_TOKEN_BODY
+      } as unknown as Response
+    }) as unknown as typeof fetch
+    await refreshTokens(CFG, tokens(), { fetchFn })
+    expect(seen[0]).toBeInstanceOf(AbortSignal)
+  })
+
+  it('form-encodes with the content type Entra requires', async () => {
+    const headers: (HeadersInit | undefined)[] = []
+    const fetchFn = (async (_u: unknown, init?: RequestInit) => {
+      headers.push(init?.headers)
+      return {
+        ok: true,
+        status: 200,
+        json: async () => OK_TOKEN_BODY
+      } as unknown as Response
+    }) as unknown as typeof fetch
+    await refreshTokens(CFG, tokens(), { fetchFn })
+    expect(headers[0]).toMatchObject({ 'Content-Type': 'application/x-www-form-urlencoded' })
+  })
+
+  it('resolves its defaults without a deps object at all', async () => {
+    // Guards the resolve() defaults: a typo there (e.g. `deps.log ?? undefined`)
+    // would throw "is not a function" only at runtime. The client-id guard runs
+    // before any network call, so this exercises resolve() without hitting one.
+    // Awaited on purpose — `expect(() => asyncFn()).not.toThrow()` would pass
+    // for any rejection and leak an unhandled promise.
+    await expect(refreshTokens({ clientId: '' }, tokens())).rejects.toThrow(GraphAuthError)
+  })
+
+  it('reaches the network when a client id is present and no deps are injected', async () => {
+    // The complement of the case above: proves the guard was the only thing
+    // stopping it, so the test above really did run through resolve().
+    const spy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('blocked-in-test'))
+    try {
+      await expect(refreshTokens(CFG, tokens())).rejects.toThrow('blocked-in-test')
+      expect(spy).toHaveBeenCalledOnce()
+    } finally {
+      spy.mockRestore()
+    }
+  })
+})

--- a/src/main/graphAuth.ts
+++ b/src/main/graphAuth.ts
@@ -1,0 +1,204 @@
+/**
+ * Microsoft Graph authentication — the I/O half (#130).
+ *
+ * Authorization Code + PKCE. The protocol arithmetic lives in
+ * `shared/graphAuth.ts`; this module generates the PKCE secret, talks to the
+ * token endpoint, and nothing else. The loopback listener that catches the
+ * browser redirect is `graphLoopback.ts`.
+ *
+ * `fetch` and `now` are injected so the token exchange is testable without a
+ * network and without real time. House idiom, same as `main/webhooks.ts`:
+ * built-in `fetch` with `AbortSignal.timeout`, no HTTP client dependency.
+ *
+ * Logging rule for this file: **never log a token, an authorization code, or a
+ * code verifier.** Only error codes and counts. `electron-log` writes to a file
+ * on disk that users attach to bug reports.
+ */
+import { createHash, randomBytes } from 'node:crypto'
+import {
+  CALENDAR_SCOPES,
+  DEFAULT_TENANT,
+  GraphAuthError,
+  applyRefresh,
+  authCodeBody,
+  parseErrorEnvelope,
+  refreshBody,
+  tokenUrl,
+  tokensFromResponse,
+  type GraphTenant,
+  type StoredTokens
+} from '../shared/graphAuth'
+
+/** Per-request timeout. Generous: the token endpoint is occasionally slow. */
+const REQUEST_TIMEOUT_MS = 20_000
+
+export interface GraphAuthConfig {
+  clientId: string
+  tenant?: GraphTenant
+  scopes?: readonly string[]
+}
+
+export interface GraphAuthDeps {
+  fetchFn?: typeof fetch
+  now?: () => number
+  log?: (message: string) => void
+}
+
+interface Resolved {
+  fetchFn: typeof fetch
+  now: () => number
+  log: (message: string) => void
+}
+
+function resolve(deps: GraphAuthDeps): Resolved {
+  return {
+    fetchFn: deps.fetchFn ?? fetch,
+    now: deps.now ?? Date.now,
+    log: deps.log ?? ((): void => {})
+  }
+}
+
+function scopesOf(cfg: GraphAuthConfig): readonly string[] {
+  return cfg.scopes ?? CALENDAR_SCOPES
+}
+
+function tenantOf(cfg: GraphAuthConfig): GraphTenant {
+  return cfg.tenant ?? DEFAULT_TENANT
+}
+
+function assertClientId(cfg: GraphAuthConfig): void {
+  if (!cfg.clientId || cfg.clientId.trim() === '') {
+    throw new GraphAuthError(
+      'Keine Client-ID konfiguriert. Ohne registrierte Anwendung ist keine Anmeldung möglich.'
+    )
+  }
+}
+
+// ── PKCE ───────────────────────────────────────────────────────────────────
+
+export interface PkcePair {
+  /** Stays on this machine. Sent only to the token endpoint, never to the browser. */
+  verifier: string
+  /** Its SHA-256, sent in the browser URL. Useless without the verifier. */
+  challenge: string
+}
+
+function base64Url(buf: Buffer): string {
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+/**
+ * RFC 7636: a 43–128 character verifier and its S256 challenge.
+ *
+ * 32 random bytes give a 43-character verifier — the minimum length, and
+ * already 256 bits of entropy. This is what stops an authorization code that
+ * leaked on the loopback hop from being redeemable by anyone else.
+ */
+export function createPkcePair(): PkcePair {
+  const verifier = base64Url(randomBytes(32))
+  const challenge = base64Url(createHash('sha256').update(verifier).digest())
+  return { verifier, challenge }
+}
+
+/** CSRF guard: the callback must carry back exactly this value. */
+export function createState(): string {
+  return base64Url(randomBytes(16))
+}
+
+// ── Token endpoint ─────────────────────────────────────────────────────────
+
+async function postForm(
+  r: Resolved,
+  url: string,
+  body: string
+): Promise<{ ok: boolean; status: number; json: unknown }> {
+  const res = await r.fetchFn(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+  })
+  // The token endpoint answers JSON for both success and error. A proxy or an
+  // outage can still hand back HTML, hence the guarded parse.
+  let json: unknown = null
+  try {
+    json = await res.json()
+  } catch {
+    json = null
+  }
+  return { ok: res.ok, status: res.status, json }
+}
+
+/**
+ * Trade the authorization code for tokens.
+ *
+ * `redirectUri` must be byte-identical to the one used in the authorize
+ * request — Entra compares them, and a mismatch fails with `invalid_grant`,
+ * which reads confusingly like an expired session.
+ */
+export async function exchangeCode(
+  cfg: GraphAuthConfig,
+  params: { code: string; codeVerifier: string; redirectUri: string },
+  deps: GraphAuthDeps = {}
+): Promise<StoredTokens> {
+  assertClientId(cfg)
+  const r = resolve(deps)
+  const res = await postForm(
+    r,
+    tokenUrl(tenantOf(cfg)),
+    authCodeBody({
+      clientId: cfg.clientId,
+      code: params.code,
+      codeVerifier: params.codeVerifier,
+      redirectUri: params.redirectUri,
+      scopes: scopesOf(cfg)
+    })
+  )
+  if (!res.ok) {
+    const { code, description } = parseErrorEnvelope(res.json)
+    r.log(`graph auth: code exchange failed (status ${res.status}, code ${code ?? 'none'})`)
+    throw new GraphAuthError(description || `Anmeldung fehlgeschlagen (HTTP ${res.status}).`, code)
+  }
+  r.log('graph auth: tokens acquired')
+  return tokensFromResponse(res.json, r.now())
+}
+
+/**
+ * Exchange a refresh token for a fresh access token.
+ *
+ * Returns a NEW token object; the caller must persist it, because Entra may
+ * have rotated the refresh token (see `applyRefresh`). An `invalid_grant` here
+ * means the grant is gone for good — revoked, password changed, or expired
+ * through disuse — and the only honest response is to drop the connection and
+ * ask the user to sign in again.
+ */
+export async function refreshTokens(
+  cfg: GraphAuthConfig,
+  previous: StoredTokens,
+  deps: GraphAuthDeps = {}
+): Promise<StoredTokens> {
+  assertClientId(cfg)
+  const r = resolve(deps)
+  const res = await postForm(
+    r,
+    tokenUrl(tenantOf(cfg)),
+    refreshBody(cfg.clientId, previous.refreshToken, scopesOf(cfg))
+  )
+  if (!res.ok) {
+    const { code, description } = parseErrorEnvelope(res.json)
+    r.log(`graph auth: refresh failed (status ${res.status}, code ${code ?? 'none'})`)
+    if (code === 'invalid_grant') {
+      throw new GraphAuthError(
+        'Die Verbindung ist nicht mehr gültig. Bitte das Microsoft-Konto erneut verbinden.',
+        code
+      )
+    }
+    throw new GraphAuthError(description || `Erneuerung fehlgeschlagen (HTTP ${res.status}).`, code)
+  }
+  return applyRefresh(previous, res.json, r.now())
+}
+
+/** True when the grant is gone for good and the user must sign in again. */
+export function isGrantInvalid(err: unknown): boolean {
+  return err instanceof GraphAuthError && err.code === 'invalid_grant'
+}

--- a/src/main/graphConnect.test.ts
+++ b/src/main/graphConnect.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi } from 'vitest'
+import { GraphAuthError, type CallbackResult } from '../shared/graphAuth'
+import { connectAccount } from './graphConnect'
+import type { LoopbackHandle } from './graphLoopback'
+
+const CFG = { clientId: 'client-1' }
+
+const OK_TOKEN_BODY = {
+  access_token: 'at-1',
+  refresh_token: 'rt-1',
+  expires_in: 3600,
+  scope: 'Calendars.Read offline_access'
+}
+
+/**
+ * A fake listener whose callback is decided by the test. `deriveResult` gets
+ * the authorize URL, so a test can echo back the real `state` (the honest
+ * case) or a wrong one (the attack case).
+ */
+interface FakeLoopback {
+  startLoopbackFn: () => Promise<LoopbackHandle>
+  /** Call from `openExternal` — mirrors the real ordering: browser, then callback. */
+  deliver: (authorizeUrl: string) => void
+  closed: () => number
+  redirectUri: string
+}
+
+function fakeLoopback(deriveResult: (authorizeUrl: string) => CallbackResult): FakeLoopback {
+  const redirectUri = 'http://localhost:51234/timetrack'
+  let closes = 0
+  let resolveResult: ((r: CallbackResult) => void) | null = null
+  const result = new Promise<CallbackResult>((r) => {
+    resolveResult = r
+  })
+  const handle: LoopbackHandle = {
+    port: 51234,
+    redirectUri,
+    result,
+    close: () => {
+      closes++
+    }
+  }
+  return {
+    startLoopbackFn: async () => handle,
+    deliver: (url) => resolveResult?.(deriveResult(url)),
+    closed: () => closes,
+    redirectUri
+  }
+}
+
+function okFetch(): typeof fetch {
+  return (async () =>
+    ({
+      ok: true,
+      status: 200,
+      json: async () => OK_TOKEN_BODY
+    }) as unknown as Response) as unknown as typeof fetch
+}
+
+function stateFrom(url: string): string {
+  return new URL(url).searchParams.get('state') ?? ''
+}
+
+describe('connectAccount', () => {
+  it('opens the browser and returns tokens for a matching callback', async () => {
+    const opened: string[] = []
+    const lb = fakeLoopback((url) => ({ kind: 'code', code: 'the-code', state: stateFrom(url) }))
+    const tokens = await connectAccount(CFG, {
+      openExternal: (url) => {
+        opened.push(url)
+        lb.deliver(url)
+      },
+      startLoopbackFn: lb.startLoopbackFn,
+      fetchFn: okFetch()
+    })
+
+    expect(tokens.accessToken).toBe('at-1')
+    expect(opened).toHaveLength(1)
+    const q = new URL(opened[0]).searchParams
+    expect(q.get('redirect_uri')).toBe(lb.redirectUri)
+    expect(q.get('code_challenge_method')).toBe('S256')
+  })
+
+  it('REJECTS a callback whose state does not match — the CSRF guard', async () => {
+    const lb = fakeLoopback(() => ({ kind: 'code', code: 'foreign-code', state: 'not-ours' }))
+    const exchange = vi.fn()
+    const err = await connectAccount(CFG, {
+      openExternal: (url) => lb.deliver(url),
+      startLoopbackFn: lb.startLoopbackFn,
+      fetchFn: (async () => {
+        exchange()
+        throw new Error('must not reach the token endpoint')
+      }) as unknown as typeof fetch
+    }).catch((e) => e)
+
+    expect(err).toBeInstanceOf(GraphAuthError)
+    expect(err.code).toBe('state_mismatch')
+    // The point: a foreign code is never redeemed.
+    expect(exchange).not.toHaveBeenCalled()
+  })
+
+  it('generates a fresh state per attempt, so a replayed callback fails', async () => {
+    const seen: string[] = []
+    const run = async (): Promise<unknown> => {
+      const lb = fakeLoopback((url) => ({ kind: 'code', code: 'c', state: stateFrom(url) }))
+      return connectAccount(CFG, {
+        openExternal: (url) => {
+          seen.push(stateFrom(url))
+          lb.deliver(url)
+        },
+        startLoopbackFn: lb.startLoopbackFn,
+        fetchFn: okFetch()
+      })
+    }
+    await run()
+    await run()
+    expect(seen[0]).not.toBe(seen[1])
+  })
+
+  it('generates a fresh PKCE challenge per attempt', async () => {
+    const seen: string[] = []
+    const run = async (): Promise<unknown> => {
+      const lb = fakeLoopback((url) => ({ kind: 'code', code: 'c', state: stateFrom(url) }))
+      return connectAccount(CFG, {
+        openExternal: (url) => {
+          seen.push(new URL(url).searchParams.get('code_challenge') ?? '')
+          lb.deliver(url)
+        },
+        startLoopbackFn: lb.startLoopbackFn,
+        fetchFn: okFetch()
+      })
+    }
+    await run()
+    await run()
+    expect(seen[0]).not.toBe(seen[1])
+  })
+
+  it('translates a declined sign-in into a cancellation, not a failure', async () => {
+    const lb = fakeLoopback(() => ({
+      kind: 'error',
+      error: 'access_denied',
+      description: null,
+      state: null
+    }))
+    const err = await connectAccount(CFG, {
+      openExternal: (url) => lb.deliver(url),
+      startLoopbackFn: lb.startLoopbackFn,
+      fetchFn: okFetch()
+    }).catch((e) => e)
+    expect(err.code).toBe('access_denied')
+    expect(err.message).toMatch(/abgebrochen/)
+  })
+
+  it('explains the admin-approval case instead of leaving a dead end', async () => {
+    const lb = fakeLoopback(() => ({
+      kind: 'error',
+      error: 'consent_required',
+      description: null,
+      state: null
+    }))
+    const err = await connectAccount(CFG, {
+      openExternal: (url) => lb.deliver(url),
+      startLoopbackFn: lb.startLoopbackFn,
+      fetchFn: okFetch()
+    }).catch((e) => e)
+    expect(err.message).toMatch(/Administrator/)
+  })
+
+  it('closes the listener on success', async () => {
+    const lb = fakeLoopback((url) => ({ kind: 'code', code: 'c', state: stateFrom(url) }))
+    await connectAccount(CFG, {
+      openExternal: (url) => lb.deliver(url),
+      startLoopbackFn: lb.startLoopbackFn,
+      fetchFn: okFetch()
+    })
+    expect(lb.closed()).toBe(1)
+  })
+
+  it('closes the listener even when the exchange fails', async () => {
+    const lb = fakeLoopback((url) => ({ kind: 'code', code: 'c', state: stateFrom(url) }))
+    await connectAccount(CFG, {
+      openExternal: (url) => lb.deliver(url),
+      startLoopbackFn: lb.startLoopbackFn,
+      fetchFn: (async () =>
+        ({
+          ok: false,
+          status: 400,
+          json: async () => ({ error: 'invalid_grant' })
+        }) as unknown as Response) as unknown as typeof fetch
+    }).catch(() => {})
+    expect(lb.closed()).toBe(1)
+  })
+
+  it('closes the listener when the state check rejects', async () => {
+    const lb = fakeLoopback(() => ({ kind: 'code', code: 'c', state: 'wrong' }))
+    await connectAccount(CFG, {
+      openExternal: (url) => lb.deliver(url),
+      startLoopbackFn: lb.startLoopbackFn,
+      fetchFn: okFetch()
+    }).catch(() => {})
+    expect(lb.closed()).toBe(1)
+  })
+
+  it('never logs the code or the verifier', async () => {
+    const lines: string[] = []
+    const lb = fakeLoopback((url) => ({
+      kind: 'code',
+      code: 'SECRET-CODE',
+      state: stateFrom(url)
+    }))
+    await connectAccount(CFG, {
+      openExternal: (url) => lb.deliver(url),
+      startLoopbackFn: lb.startLoopbackFn,
+      fetchFn: okFetch(),
+      log: (m) => lines.push(m)
+    })
+    const all = lines.join('\n')
+    expect(all).not.toContain('SECRET-CODE')
+    expect(all).not.toContain('code_verifier')
+  })
+})

--- a/src/main/graphConnect.ts
+++ b/src/main/graphConnect.ts
@@ -1,0 +1,99 @@
+/**
+ * "Connect a Microsoft account", end to end (#130).
+ *
+ * Ties together the three pieces that must not be used separately: the loopback
+ * listener, the PKCE pair, and the token exchange. It exists mainly so the two
+ * checks that are easy to forget cannot be forgotten:
+ *
+ * 1. **The `state` comparison.** `parseCallbackQuery` deliberately refuses a
+ *    code without a state, but only the side that GENERATED the state can tell
+ *    whether it is the right one. Leaving that to the caller means it is a
+ *    comment in a doc block instead of a guard in the code path — so it lives
+ *    here, and there is no exported path that skips it.
+ * 2. **Closing the listener.** A thrown exchange error must not leave a socket
+ *    bound, hence the `finally`.
+ *
+ * `openExternal` is injected: in the app it is Electron's shell, in tests a
+ * function that captures the URL. That makes the whole flow testable without
+ * Electron and without a browser.
+ */
+import { GraphAuthError, buildAuthorizeUrl, describeAuthorizeError } from '../shared/graphAuth'
+import type { GraphTenant, StoredTokens } from '../shared/graphAuth'
+import { CALENDAR_SCOPES, DEFAULT_TENANT } from '../shared/graphAuth'
+import { createPkcePair, createState, exchangeCode } from './graphAuth'
+import type { GraphAuthConfig, GraphAuthDeps } from './graphAuth'
+import { startLoopback } from './graphLoopback'
+import type { LoopbackDeps, LoopbackHandle } from './graphLoopback'
+
+export interface ConnectDeps extends GraphAuthDeps {
+  /** Opens the system browser. Electron: `shell.openExternal`. */
+  openExternal: (url: string) => Promise<void> | void
+  /** Injectable for tests; defaults to the real listener. */
+  startLoopbackFn?: (deps?: LoopbackDeps, signal?: AbortSignal) => Promise<LoopbackHandle>
+  /** How long the user has to finish signing in. */
+  timeoutMs?: number
+}
+
+/**
+ * Run the full connect flow and return tokens the caller should persist.
+ *
+ * Throws `GraphAuthError` for every user-visible failure, so the settings UI
+ * has one error type to render.
+ */
+export async function connectAccount(
+  cfg: GraphAuthConfig,
+  deps: ConnectDeps,
+  signal?: AbortSignal
+): Promise<StoredTokens> {
+  const log = deps.log ?? ((): void => {})
+  const startFn = deps.startLoopbackFn ?? startLoopback
+  const tenant: GraphTenant = cfg.tenant ?? DEFAULT_TENANT
+  const scopes = cfg.scopes ?? CALENDAR_SCOPES
+
+  const handle = await startFn({ timeoutMs: deps.timeoutMs, log: deps.log }, signal)
+  try {
+    const pkce = createPkcePair()
+    const state = createState()
+
+    const url = buildAuthorizeUrl({
+      clientId: cfg.clientId,
+      tenant,
+      scopes,
+      redirectUri: handle.redirectUri,
+      state,
+      codeChallenge: pkce.challenge
+    })
+
+    await deps.openExternal(url)
+    log('graph connect: browser opened, awaiting callback')
+
+    const callback = await handle.result
+
+    if (callback.kind === 'error') {
+      throw describeAuthorizeError(callback.error, callback.description)
+    }
+
+    // The CSRF guard. A callback carrying a code we did not ask for must be
+    // discarded — redeeming it would bind this app to someone else's sign-in.
+    if (callback.state !== state) {
+      log('graph connect: state mismatch, callback discarded')
+      throw new GraphAuthError(
+        'Die Antwort der Anmeldung gehört nicht zu dieser Anfrage. Bitte erneut versuchen.',
+        'state_mismatch'
+      )
+    }
+
+    return await exchangeCode(
+      cfg,
+      {
+        code: callback.code,
+        codeVerifier: pkce.verifier,
+        // Byte-identical to the authorize request — Entra compares them.
+        redirectUri: handle.redirectUri
+      },
+      deps
+    )
+  } finally {
+    handle.close()
+  }
+}

--- a/src/main/graphHandlers.ts
+++ b/src/main/graphHandlers.ts
@@ -1,0 +1,100 @@
+/**
+ * IPC surface for the Microsoft account connection (#130).
+ *
+ * Thin on purpose: everything that decides anything lives in `graphAccount.ts`.
+ * What this layer owns is the one thing the renderer cannot — keeping the
+ * in-flight sign-in cancellable, so closing the settings page or pressing
+ * "cancel" actually tears down the loopback listener instead of leaving it
+ * bound until it times out.
+ *
+ * `graph:status` deliberately returns no token material; see `AccountStatus`.
+ */
+import { ipcMain, shell } from 'electron'
+import type Database from 'better-sqlite3'
+import log from 'electron-log/main'
+import { getDbPath } from './db'
+import { tokenDirForDbPath } from './graphTokenStore'
+import type { IpcResult } from '../shared/types'
+import {
+  connect,
+  disconnect,
+  getStatus,
+  verifyConnection,
+  type AccountStatus,
+  type VerifyResult,
+  type GraphAccountDeps
+} from './graphAccount'
+
+function ok<T>(data: T): IpcResult<T> {
+  return { ok: true, data }
+}
+function fail(error: unknown): IpcResult<never> {
+  return { ok: false, error: error instanceof Error ? error.message : String(error) }
+}
+
+export function registerGraphHandlers(db: Database.Database): void {
+  const deps: GraphAccountDeps = {
+    getSetting: (key) => {
+      const row = db.prepare(`SELECT value FROM settings WHERE key = ?`).get(key) as
+        | { value: string }
+        | undefined
+      return row?.value
+    },
+    openExternal: (url) => shell.openExternal(url),
+    // Anchored on the database the app actually opened — not on a
+    // reconstructed %APPDATA% path, which cannot see an overridden userData.
+    store: { dir: tokenDirForDbPath(getDbPath()) },
+    log: (m) => log.info(m)
+  }
+
+  // Only one sign-in can be in flight; a second "connect" click replaces the
+  // first rather than leaving two listeners and two browser tabs behind.
+  let inFlight: AbortController | null = null
+
+  ipcMain.handle('graph:status', (): IpcResult<AccountStatus> => {
+    try {
+      return ok(getStatus(deps))
+    } catch (e) {
+      return fail(e)
+    }
+  })
+
+  ipcMain.handle('graph:connect', async (): Promise<IpcResult<AccountStatus>> => {
+    inFlight?.abort()
+    const ctrl = new AbortController()
+    inFlight = ctrl
+    try {
+      return ok(await connect(deps, ctrl.signal))
+    } catch (e) {
+      return fail(e)
+    } finally {
+      if (inFlight === ctrl) inFlight = null
+    }
+  })
+
+  ipcMain.handle('graph:cancelConnect', (): IpcResult<void> => {
+    inFlight?.abort()
+    inFlight = null
+    return ok(undefined)
+  })
+
+  ipcMain.handle('graph:verify', async (): Promise<IpcResult<VerifyResult>> => {
+    try {
+      return ok(await verifyConnection(deps))
+    } catch (e) {
+      return fail(e)
+    }
+  })
+
+  ipcMain.handle('graph:disconnect', (): IpcResult<AccountStatus> => {
+    try {
+      // A sign-in still running would otherwise write its tokens back moments
+      // after the user asked to be disconnected.
+      inFlight?.abort()
+      inFlight = null
+      return ok(disconnect(deps))
+    } catch (e) {
+      return fail(e)
+    }
+  })
+}

--- a/src/main/graphLoopback.test.ts
+++ b/src/main/graphLoopback.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Integration tests against the real listener — no mocking.
+ *
+ * A loopback HTTP server is cheap enough to start for real, and mocking it away
+ * would skip exactly the parts that can break: which interfaces it binds, what
+ * it does with requests that are not the callback, and whether it actually
+ * releases the port again.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { connect } from 'node:net'
+import { REDIRECT_PATH } from '../shared/graphAuth'
+import { LoopbackError, startLoopback, type LoopbackHandle } from './graphLoopback'
+
+const open: LoopbackHandle[] = []
+
+afterEach(() => {
+  for (const h of open.splice(0)) h.close()
+})
+
+async function start(...args: Parameters<typeof startLoopback>): Promise<LoopbackHandle> {
+  const h = await startLoopback(...args)
+  open.push(h)
+  return h
+}
+
+/** Is there a usable IPv6 loopback on this machine? */
+function hasIpv6Loopback(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const sock = connect({ host: '::1', port }, () => {
+      sock.destroy()
+      resolve(true)
+    })
+    sock.on('error', () => {
+      sock.destroy()
+      resolve(false)
+    })
+  })
+}
+
+function callbackUrl(host: string, port: number, query: string): string {
+  return `http://${host}:${port}${REDIRECT_PATH}${query}`
+}
+
+describe('startLoopback', () => {
+  it('reports a redirect uri that matches its own port and the registered path', async () => {
+    const h = await start()
+    expect(h.redirectUri).toBe(`http://localhost:${h.port}${REDIRECT_PATH}`)
+    expect(h.port).toBeGreaterThan(0)
+  })
+
+  it('resolves with the code and state from a successful callback', async () => {
+    const h = await start()
+    const res = await fetch(callbackUrl('127.0.0.1', h.port, '?code=abc&state=xyz'))
+    expect(res.status).toBe(200)
+    await expect(h.result).resolves.toEqual({ kind: 'code', code: 'abc', state: 'xyz' })
+  })
+
+  it('resolves with the error when the user declines', async () => {
+    const h = await start()
+    await fetch(
+      callbackUrl('127.0.0.1', h.port, '?error=access_denied&error_description=nope&state=xyz')
+    )
+    await expect(h.result).resolves.toEqual({
+      kind: 'error',
+      error: 'access_denied',
+      description: 'nope',
+      state: 'xyz'
+    })
+  })
+
+  it('never puts the authorization code into the page it serves', async () => {
+    // The page ends up in browser history and on screen; the code must not.
+    const h = await start()
+    const res = await fetch(callbackUrl('127.0.0.1', h.port, '?code=SECRET-CODE&state=xyz'))
+    expect(await res.text()).not.toContain('SECRET-CODE')
+    await h.result
+  })
+
+  it('answers 404 for other paths without ending the wait', async () => {
+    const h = await start()
+    const res = await fetch(`http://127.0.0.1:${h.port}/favicon.ico`)
+    expect(res.status).toBe(404)
+
+    // Still waiting: the real callback can arrive afterwards.
+    const settled = await Promise.race([
+      h.result.then(() => 'settled'),
+      new Promise((r) => setTimeout(() => r('pending'), 50))
+    ])
+    expect(settled).toBe('pending')
+
+    await fetch(callbackUrl('127.0.0.1', h.port, '?code=abc&state=xyz'))
+    await expect(h.result).resolves.toMatchObject({ kind: 'code' })
+  })
+
+  it('answers 400 for a code without state and keeps waiting', async () => {
+    const h = await start()
+    const res = await fetch(callbackUrl('127.0.0.1', h.port, '?code=abc'))
+    expect(res.status).toBe(400)
+
+    const settled = await Promise.race([
+      h.result.then(() => 'settled'),
+      new Promise((r) => setTimeout(() => r('pending'), 50))
+    ])
+    expect(settled).toBe('pending')
+  })
+
+  it('listens on the IPv6 loopback too — localhost resolves to ::1 first on Windows', async () => {
+    const h = await start()
+    if (!(await hasIpv6Loopback(h.port))) {
+      // No IPv6 stack here; the v4-only fallback is the documented behaviour.
+      expect(h.port).toBeGreaterThan(0)
+      return
+    }
+    const res = await fetch(callbackUrl('[::1]', h.port, '?code=v6&state=xyz'))
+    expect(res.status).toBe(200)
+    await expect(h.result).resolves.toMatchObject({ kind: 'code', code: 'v6' })
+  })
+
+  it('rejects on timeout instead of waiting forever', async () => {
+    const h = await start({ timeoutMs: 30 })
+    const err = await h.result.catch((e) => e)
+    expect(err).toBeInstanceOf(LoopbackError)
+    expect(err.code).toBe('timeout')
+  })
+
+  it('rejects when the user cancels while waiting', async () => {
+    const ctrl = new AbortController()
+    const h = await start({}, ctrl.signal)
+    ctrl.abort()
+    const err = await h.result.catch((e) => e)
+    expect(err).toBeInstanceOf(LoopbackError)
+    expect(err.code).toBe('cancelled')
+  })
+
+  it('refuses to start at all when already aborted', async () => {
+    const ctrl = new AbortController()
+    ctrl.abort()
+    await expect(startLoopback({}, ctrl.signal)).rejects.toMatchObject({ code: 'cancelled' })
+  })
+
+  it('releases the port after a callback, so a second sign-in can bind again', async () => {
+    const h = await start()
+    const port = h.port
+    await fetch(callbackUrl('127.0.0.1', port, '?code=abc&state=xyz'))
+    await h.result
+
+    // The listener closes itself on success; the socket must really be gone.
+    await expect(fetch(callbackUrl('127.0.0.1', port, '?code=second&state=xyz'))).rejects.toThrow()
+  })
+
+  it('survives close() being called more than once', async () => {
+    const h = await start()
+    expect(() => {
+      h.close()
+      h.close()
+    }).not.toThrow()
+  })
+
+  it('hands out a different port per run, so two attempts cannot collide', async () => {
+    const a = await start()
+    const b = await start()
+    expect(a.port).not.toBe(b.port)
+  })
+})

--- a/src/main/graphLoopback.ts
+++ b/src/main/graphLoopback.ts
@@ -1,0 +1,214 @@
+/**
+ * Loopback listener for the OAuth redirect (#130).
+ *
+ * After the user signs in, Microsoft sends the browser to
+ * `http://localhost:<port>/timetrack?code=…&state=…`. This module is what
+ * catches that request: a short-lived HTTP server bound to the loopback
+ * interface only, alive for exactly one callback.
+ *
+ * Two things here are less obvious than they look:
+ *
+ * **Dual stack.** The redirect URI has to say `localhost` (Entra's portal will
+ * not accept an `http://127.0.0.1` redirect URI at all), but on Windows
+ * `localhost` usually resolves to `::1` first. A server bound only to
+ * `127.0.0.1` therefore gets a refused connection from the browser, which
+ * surfaces as "the sign-in did nothing". So we bind BOTH stacks on the same
+ * port and let whichever one the browser picks win.
+ *
+ * **It stays on the machine.** Binding is explicitly to the loopback addresses,
+ * never `0.0.0.0`/`::`, so the authorization code never crosses the network
+ * interface. That is also what makes plain `http` acceptable here — RFC 8252
+ * §8.3 allows it precisely because the redirect never leaves the device.
+ */
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
+import { REDIRECT_PATH, parseCallbackQuery, redirectUriForPort } from '../shared/graphAuth'
+import type { CallbackResult } from '../shared/graphAuth'
+
+/** How long the user gets to complete the sign-in before we give up. */
+const DEFAULT_TIMEOUT_MS = 5 * 60_000
+
+export class LoopbackError extends Error {
+  constructor(
+    message: string,
+    readonly code: 'timeout' | 'cancelled' | 'listen_failed'
+  ) {
+    super(message)
+    this.name = 'LoopbackError'
+  }
+}
+
+export interface LoopbackDeps {
+  timeoutMs?: number
+  log?: (message: string) => void
+}
+
+export interface LoopbackHandle {
+  /** The port both stacks are bound to. */
+  port: number
+  /** Exactly the value that must go into the authorize request. */
+  redirectUri: string
+  /** Resolves on the first valid callback; rejects on timeout or cancel. */
+  result: Promise<CallbackResult>
+  /** Idempotent. Safe to call from a `finally`. */
+  close: () => void
+}
+
+/** Minimal self-contained page; no external assets, works offline. */
+function resultPage(title: string, body: string): string {
+  return `<!doctype html>
+<html lang="de"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${title}</title>
+<style>
+  body{font-family:system-ui,-apple-system,Segoe UI,sans-serif;background:#111827;color:#e5e7eb;
+       display:flex;min-height:100vh;align-items:center;justify-content:center;margin:0}
+  main{max-width:28rem;padding:2rem;text-align:center}
+  h1{font-size:1.25rem;margin:0 0 .5rem}
+  p{color:#9ca3af;line-height:1.5;margin:0}
+</style></head>
+<body><main><h1>${title}</h1><p>${body}</p></main></body></html>`
+}
+
+const PAGE_OK = resultPage(
+  'Verbunden',
+  'Du kannst dieses Fenster schließen und zu TimeTrack zurückkehren.'
+)
+const PAGE_FAILED = resultPage(
+  'Nicht verbunden',
+  'Die Anmeldung wurde nicht abgeschlossen. Zurück in TimeTrack kannst du es erneut versuchen.'
+)
+
+function listenOn(server: Server, host: string, port: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onError = (err: Error): void => reject(err)
+    server.once('error', onError)
+    server.listen(port, host, () => {
+      server.removeListener('error', onError)
+      resolve()
+    })
+  })
+}
+
+/** Node 18+ — without this a keep-alive browser connection can hold `close()` open. */
+function hardClose(server: Server): void {
+  const withAll = server as Server & { closeAllConnections?: () => void }
+  try {
+    withAll.closeAllConnections?.()
+  } catch {
+    /* best effort */
+  }
+  server.close(() => {})
+}
+
+/**
+ * Start listening. The caller must `close()` when done — a `finally` block, so
+ * a thrown exchange error cannot leave a socket open.
+ *
+ * `signal` lets the UI cancel (dialog closed, user clicked abort).
+ */
+export async function startLoopback(
+  deps: LoopbackDeps = {},
+  signal?: AbortSignal
+): Promise<LoopbackHandle> {
+  const log = deps.log ?? ((): void => {})
+  const timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS
+
+  let settle: ((r: CallbackResult) => void) | null = null
+  let fail: ((e: Error) => void) | null = null
+  const result = new Promise<CallbackResult>((resolve, reject) => {
+    settle = resolve
+    fail = reject
+  })
+
+  const servers: Server[] = []
+  let closed = false
+  let timer: NodeJS.Timeout | null = null
+
+  const close = (): void => {
+    if (closed) return
+    closed = true
+    if (timer) clearTimeout(timer)
+    for (const s of servers) hardClose(s)
+    signal?.removeEventListener('abort', onAbort)
+  }
+
+  function onAbort(): void {
+    fail?.(new LoopbackError('Anmeldung abgebrochen.', 'cancelled'))
+    close()
+  }
+
+  const handler = (req: IncomingMessage, res: ServerResponse): void => {
+    // `req.url` is path + query only; the Host header is irrelevant to us.
+    const url = new URL(req.url ?? '/', 'http://localhost')
+    if (url.pathname !== REDIRECT_PATH) {
+      // Browsers cheerfully ask for /favicon.ico and sometimes prefetch. Those
+      // must not be mistaken for a callback, nor end the wait.
+      res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' })
+      res.end('Not found')
+      return
+    }
+
+    const parsed = parseCallbackQuery(url.search)
+    if (!parsed) {
+      // Right path, unusable query — e.g. a code without state. Answer, but do
+      // not resolve: the real callback may still be on its way.
+      res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8' })
+      res.end(PAGE_FAILED)
+      return
+    }
+
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+    res.end(parsed.kind === 'code' ? PAGE_OK : PAGE_FAILED)
+    log(`graph loopback: callback received (${parsed.kind})`)
+    settle?.(parsed)
+    // Closing here — not in the caller — keeps the window in which a second
+    // request could arrive as small as possible.
+    close()
+  }
+
+  // Bind IPv4 first with port 0 to let the OS choose, then reuse that port for
+  // IPv6. If the v6 bind fails (no IPv6 stack, port taken on that stack only),
+  // carry on with v4: the browser falls back.
+  const v4 = createServer(handler)
+  servers.push(v4)
+  try {
+    await listenOn(v4, '127.0.0.1', 0)
+  } catch (err) {
+    close()
+    throw new LoopbackError(
+      `Lokaler Empfangs-Port konnte nicht geöffnet werden: ${(err as Error).message}`,
+      'listen_failed'
+    )
+  }
+  const address = v4.address()
+  if (address === null || typeof address === 'string') {
+    close()
+    throw new LoopbackError('Lokaler Empfangs-Port lieferte keine Adresse.', 'listen_failed')
+  }
+  const port = address.port
+
+  const v6 = createServer(handler)
+  try {
+    await listenOn(v6, '::1', port)
+    servers.push(v6)
+  } catch {
+    log('graph loopback: no IPv6 loopback, IPv4 only')
+    hardClose(v6)
+  }
+
+  if (signal?.aborted) {
+    close()
+    throw new LoopbackError('Anmeldung abgebrochen.', 'cancelled')
+  }
+  signal?.addEventListener('abort', onAbort, { once: true })
+
+  timer = setTimeout(() => {
+    fail?.(new LoopbackError('Zeitüberschreitung bei der Anmeldung.', 'timeout'))
+    close()
+  }, timeoutMs)
+  // Do not keep the process alive just for this.
+  timer.unref?.()
+
+  log(`graph loopback: listening on ${port} (${servers.length} stack(s))`)
+  return { port, redirectUri: redirectUriForPort(port), result, close }
+}

--- a/src/main/graphTokenStore.test.ts
+++ b/src/main/graphTokenStore.test.ts
@@ -11,6 +11,7 @@ import {
   isStorageAvailable,
   loadTokens,
   saveTokens,
+  tokenDirForDbPath,
   type SecretBox
 } from './graphTokenStore'
 
@@ -185,6 +186,34 @@ describe('clearTokens', () => {
       clearTokens({ dir, secretBox: fakeBox() })
       clearTokens({ dir, secretBox: fakeBox() })
     }).not.toThrow()
+  })
+})
+
+describe('tokenDirForDbPath — where the file belongs when no dir is injected', () => {
+  /**
+   * Regression guard for a bug found in the first real handtest (#130).
+   *
+   * The default location used to come from `mcp/socketPath.ts`'s `userDataDir()`,
+   * which RECONSTRUCTS `%APPDATA%\time-tracking` without Electron so the
+   * standalone MCP server can find the DB. That resolver cannot know about an
+   * overridden userData location, while `main/db.ts` uses
+   * `app.getPath('userData')`, which does. Running the app with
+   * `--user-data-dir` therefore wrote the token next to a database the app was
+   * not using — in the production directory, during a supposedly isolated test.
+   *
+   * Every other test in this file injects `dir`, so none of them could see it.
+   * This one pins the rule itself: the token sits beside the DB that is open.
+   */
+  it('puts the token next to the database the app actually opened', () => {
+    expect(tokenDirForDbPath(join('X', 'custom-profile', 'timetrack.sqlite'))).toBe(
+      join('X', 'custom-profile')
+    )
+  })
+
+  it('follows an overridden location instead of a reconstructed default', () => {
+    const overridden = tokenDirForDbPath(join('D:', 'portable', 'tt', 'timetrack.sqlite'))
+    expect(overridden).toBe(join('D:', 'portable', 'tt'))
+    expect(overridden).not.toContain('AppData')
   })
 })
 

--- a/src/main/graphTokenStore.test.ts
+++ b/src/main/graphTokenStore.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import type { StoredTokens } from '../shared/graphAuth'
+import {
+  TOKEN_FILENAME,
+  TokenStoreError,
+  clearTokens,
+  hasStoredTokens,
+  isStorageAvailable,
+  loadTokens,
+  saveTokens,
+  type SecretBox
+} from './graphTokenStore'
+
+/**
+ * A stand-in for `safeStorage`. The "encryption" is a reversible scramble — the
+ * point is not to test crypto (that is the OS's job) but to prove that what
+ * lands on disk is not the plaintext, and that an unreadable file is handled
+ * rather than thrown.
+ */
+function fakeBox(available = true): SecretBox & { calls: { encrypt: number } } {
+  const calls = { encrypt: 0 }
+  return {
+    calls,
+    isEncryptionAvailable: () => available,
+    encryptString: (plain: string) => {
+      calls.encrypt++
+      return Buffer.from(`enc:${Buffer.from(plain, 'utf8').toString('base64')}`, 'utf8')
+    },
+    decryptString: (cipher: Buffer) => {
+      const s = cipher.toString('utf8')
+      if (!s.startsWith('enc:')) throw new Error('bad ciphertext')
+      return Buffer.from(s.slice(4), 'base64').toString('utf8')
+    }
+  }
+}
+
+let dir: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'tt-graph-store-'))
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+const TOKENS: StoredTokens = {
+  accessToken: 'access-secret-1',
+  refreshToken: 'refresh-secret-1',
+  expiresAtMs: 1_800_000_000_000,
+  grantedScopes: ['Calendars.Read', 'offline_access'],
+  account: { username: 'r@wald-it.com', displayName: 'Robin', tenantId: 'tid-1' }
+}
+
+function filePath(): string {
+  return join(dir, TOKEN_FILENAME)
+}
+
+describe('saveTokens / loadTokens', () => {
+  it('round-trips the full token object', () => {
+    const box = fakeBox()
+    saveTokens(TOKENS, { dir, secretBox: box })
+    expect(loadTokens({ dir, secretBox: box })).toEqual(TOKENS)
+  })
+
+  it('writes ciphertext — the refresh token must not be readable on disk', () => {
+    const box = fakeBox()
+    saveTokens(TOKENS, { dir, secretBox: box })
+    const raw = readFileSync(filePath(), 'utf8')
+    expect(raw).not.toContain('refresh-secret-1')
+    expect(raw).not.toContain('access-secret-1')
+    expect(box.calls.encrypt).toBe(1)
+  })
+
+  it('stores nothing in the database directory beyond its own file', () => {
+    saveTokens(TOKENS, { dir, secretBox: fakeBox() })
+    // Only the token file; in particular no leftover .tmp from the atomic write.
+    expect(existsSync(`${filePath()}.tmp`)).toBe(false)
+  })
+
+  it('replaces a previous connection instead of appending', () => {
+    const box = fakeBox()
+    saveTokens(TOKENS, { dir, secretBox: box })
+    saveTokens({ ...TOKENS, refreshToken: 'refresh-secret-2' }, { dir, secretBox: box })
+    expect(loadTokens({ dir, secretBox: box })?.refreshToken).toBe('refresh-secret-2')
+  })
+
+  it('refuses to store anything when the OS keychain is unavailable', () => {
+    // The alternative would be writing a refresh token to disk in the clear.
+    const box = fakeBox(false)
+    const err = (() => {
+      try {
+        saveTokens(TOKENS, { dir, secretBox: box })
+        return null
+      } catch (e) {
+        return e as TokenStoreError
+      }
+    })()
+    expect(err).toBeInstanceOf(TokenStoreError)
+    expect(err?.code).toBe('encryption_unavailable')
+    expect(existsSync(filePath())).toBe(false)
+    expect(box.calls.encrypt).toBe(0)
+  })
+
+  it('never puts token material into the log', () => {
+    const lines: string[] = []
+    saveTokens(TOKENS, { dir, secretBox: fakeBox(), log: (m) => lines.push(m) })
+    loadTokens({ dir, secretBox: fakeBox(), log: (m) => lines.push(m) })
+    const all = lines.join('\n')
+    expect(all).not.toContain('refresh-secret-1')
+    expect(all).not.toContain('access-secret-1')
+  })
+})
+
+describe('loadTokens — the ways a stored connection goes bad', () => {
+  it('returns null when nothing was ever stored', () => {
+    expect(loadTokens({ dir, secretBox: fakeBox() })).toBeNull()
+  })
+
+  it('returns null instead of throwing when the blob cannot be decrypted', () => {
+    // The realistic case: the file came from another machine, or the OS key
+    // changed. Throwing here would crash the app on startup.
+    writeFileSync(filePath(), Buffer.from('not-encrypted-by-us', 'utf8'))
+    const lines: string[] = []
+    expect(loadTokens({ dir, secretBox: fakeBox(), log: (m) => lines.push(m) })).toBeNull()
+    expect(lines.join('\n')).toMatch(/unreadable/)
+  })
+
+  it('returns null when the decrypted content is not JSON', () => {
+    const box = fakeBox()
+    writeFileSync(filePath(), box.encryptString('this is not json'))
+    expect(loadTokens({ dir, secretBox: box })).toBeNull()
+  })
+
+  it.each([
+    ['missing refreshToken', { accessToken: 'a', expiresAtMs: 1 }],
+    ['empty refreshToken', { accessToken: 'a', refreshToken: '', expiresAtMs: 1 }],
+    ['missing accessToken', { refreshToken: 'r', expiresAtMs: 1 }],
+    ['expiresAtMs as a string', { accessToken: 'a', refreshToken: 'r', expiresAtMs: '1' }],
+    ['not an object', 'nope'],
+    ['null', null]
+  ])('returns null for a malformed blob (%s)', (_label, payload) => {
+    const box = fakeBox()
+    writeFileSync(filePath(), box.encryptString(JSON.stringify(payload)))
+    expect(loadTokens({ dir, secretBox: box })).toBeNull()
+  })
+
+  it('does not delete the file it could not read', () => {
+    // Silent deletion of something we merely failed to understand would be rude
+    // and unrecoverable; the next successful connect overwrites it anyway.
+    writeFileSync(filePath(), Buffer.from('garbage', 'utf8'))
+    loadTokens({ dir, secretBox: fakeBox() })
+    expect(existsSync(filePath())).toBe(true)
+  })
+})
+
+describe('hasStoredTokens', () => {
+  it('is false before anything is stored and true afterwards', () => {
+    const box = fakeBox()
+    expect(hasStoredTokens({ dir, secretBox: box })).toBe(false)
+    saveTokens(TOKENS, { dir, secretBox: box })
+    expect(hasStoredTokens({ dir, secretBox: box })).toBe(true)
+  })
+
+  it('is false for a stored-but-unusable blob, not merely for a missing file', () => {
+    writeFileSync(filePath(), Buffer.from('garbage', 'utf8'))
+    expect(hasStoredTokens({ dir, secretBox: fakeBox() })).toBe(false)
+  })
+})
+
+describe('clearTokens', () => {
+  it('removes the stored connection', () => {
+    const box = fakeBox()
+    saveTokens(TOKENS, { dir, secretBox: box })
+    clearTokens({ dir, secretBox: box })
+    expect(existsSync(filePath())).toBe(false)
+    expect(loadTokens({ dir, secretBox: box })).toBeNull()
+  })
+
+  it('is idempotent — disconnecting when nothing is connected must not throw', () => {
+    expect(() => {
+      clearTokens({ dir, secretBox: fakeBox() })
+      clearTokens({ dir, secretBox: fakeBox() })
+    }).not.toThrow()
+  })
+})
+
+describe('isStorageAvailable', () => {
+  it('mirrors the keychain state', () => {
+    expect(isStorageAvailable({ dir, secretBox: fakeBox(true) })).toBe(true)
+    expect(isStorageAvailable({ dir, secretBox: fakeBox(false) })).toBe(false)
+  })
+
+  it('reports false rather than throwing when safeStorage itself blows up', () => {
+    const hostile: SecretBox = {
+      isEncryptionAvailable: () => {
+        throw new Error('no keyring')
+      },
+      encryptString: () => Buffer.alloc(0),
+      decryptString: () => ''
+    }
+    expect(isStorageAvailable({ dir, secretBox: hostile })).toBe(false)
+  })
+})

--- a/src/main/graphTokenStore.ts
+++ b/src/main/graphTokenStore.ts
@@ -23,8 +23,7 @@
  * worse than one that says it cannot run here.
  */
 import { chmodSync, existsSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
-import { userDataDir } from '../mcp/socketPath'
+import { dirname, join } from 'node:path'
 import type { StoredTokens } from '../shared/graphAuth'
 
 export const TOKEN_FILENAME = 'graph-account.enc'
@@ -37,9 +36,24 @@ export interface SecretBox {
 }
 
 export interface TokenStoreDeps {
+  /**
+   * Directory to keep the file in — **required, deliberately with no default**.
+   *
+   * There used to be one, and it caused two bugs in a row. First it came from
+   * `mcp/socketPath.ts`'s `userDataDir()`, which reconstructs `%APPDATA%` for
+   * the Electron-free MCP server and therefore cannot see an overridden
+   * userData location: the token landed next to a database the app was not
+   * using. The obvious repair — lazily `require('./db')` — was worse, because
+   * electron-vite bundles main into a single file where `require('./db')` has
+   * nothing to resolve at runtime; the whole feature reported "keychain
+   * unavailable" in every build.
+   *
+   * Neither was visible to the unit tests, which always inject `dir`. So the
+   * default is gone and the caller has to say where it goes; `graphHandlers.ts`
+   * takes it from the database the app actually opened.
+   */
+  dir: string
   secretBox?: SecretBox
-  /** Directory to keep the file in. Defaults to the userData dir beside the DB. */
-  dir?: string
   log?: (message: string) => void
 }
 
@@ -66,6 +80,16 @@ function electronSecretBox(): SecretBox {
   return safeStorage
 }
 
+/**
+ * Where the token belongs, given the path of the database the app opened.
+ *
+ * Same anchor as `mcpBridge.ts` (`dirname(getDbPath())`), and the reason it is
+ * a named function is so the rule can be tested without an Electron app.
+ */
+export function tokenDirForDbPath(dbPath: string): string {
+  return dirname(dbPath)
+}
+
 function resolve(deps: TokenStoreDeps): {
   box: SecretBox
   file: string
@@ -73,13 +97,13 @@ function resolve(deps: TokenStoreDeps): {
 } {
   return {
     box: deps.secretBox ?? electronSecretBox(),
-    file: join(deps.dir ?? userDataDir(), TOKEN_FILENAME),
+    file: join(deps.dir, TOKEN_FILENAME),
     log: deps.log ?? ((): void => {})
   }
 }
 
 /** Whether tokens can be stored at all on this machine. */
-export function isStorageAvailable(deps: TokenStoreDeps = {}): boolean {
+export function isStorageAvailable(deps: TokenStoreDeps): boolean {
   try {
     return resolve(deps).box.isEncryptionAvailable()
   } catch {
@@ -94,7 +118,7 @@ export function isStorageAvailable(deps: TokenStoreDeps = {}): boolean {
  * leave a half-written blob that decrypts to garbage and silently drops the
  * connection.
  */
-export function saveTokens(tokens: StoredTokens, deps: TokenStoreDeps = {}): void {
+export function saveTokens(tokens: StoredTokens, deps: TokenStoreDeps): void {
   const { box, file, log } = resolve(deps)
   if (!box.isEncryptionAvailable()) {
     throw new TokenStoreError(
@@ -150,7 +174,7 @@ function isStoredTokens(v: unknown): v is StoredTokens {
  * file. Throwing here would turn a restored backup on a new machine into a
  * crash on startup.
  */
-export function loadTokens(deps: TokenStoreDeps = {}): StoredTokens | null {
+export function loadTokens(deps: TokenStoreDeps): StoredTokens | null {
   const { box, file, log } = resolve(deps)
   if (!existsSync(file)) return null
   let parsed: unknown
@@ -170,12 +194,12 @@ export function loadTokens(deps: TokenStoreDeps = {}): StoredTokens | null {
 }
 
 /** True when a connection is stored and usable. */
-export function hasStoredTokens(deps: TokenStoreDeps = {}): boolean {
+export function hasStoredTokens(deps: TokenStoreDeps): boolean {
   return loadTokens(deps) !== null
 }
 
 /** Remove the stored connection. Idempotent — "disconnect" when nothing is stored is fine. */
-export function clearTokens(deps: TokenStoreDeps = {}): void {
+export function clearTokens(deps: TokenStoreDeps): void {
   const { file, log } = resolve(deps)
   try {
     if (existsSync(file)) {

--- a/src/main/graphTokenStore.ts
+++ b/src/main/graphTokenStore.ts
@@ -1,0 +1,188 @@
+/**
+ * At-rest storage for the Microsoft Graph tokens (#130).
+ *
+ * A refresh token is a bearer credential for someone's mailbox and calendar in
+ * a foreign tenant. That is a different class of secret from what this repo
+ * stored before — the webhook secrets sit in the `settings` table in plain text
+ * (`webhooks.ts`), and the MCP write token is a locally generated value that is
+ * worthless elsewhere. So this one is encrypted with Electron's `safeStorage`
+ * (DPAPI on Windows, Keychain on macOS, libsecret on Linux) and kept in its own
+ * file rather than in the database.
+ *
+ * **Why not the `settings` table.** Backups copy the `.sqlite` file
+ * (`backup.ts`), so a token in there would travel into every backup and, on
+ * restore, onto other machines — where `safeStorage` cannot decrypt it anyway
+ * (DPAPI is user- and machine-bound). Keeping it beside the DB means a restore
+ * simply does not touch the connection, which is the honest behaviour: the
+ * connection belongs to this machine, not to the data.
+ *
+ * **No plaintext fallback.** If `safeStorage` reports that encryption is not
+ * available — the realistic case is a Linux session with no keyring — saving
+ * fails with an explanation instead of silently writing the refresh token to
+ * disk in the clear. A feature that quietly downgrades its own protection is
+ * worse than one that says it cannot run here.
+ */
+import { chmodSync, existsSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { userDataDir } from '../mcp/socketPath'
+import type { StoredTokens } from '../shared/graphAuth'
+
+export const TOKEN_FILENAME = 'graph-account.enc'
+
+/** The slice of Electron's `safeStorage` this module needs. Injectable for tests. */
+export interface SecretBox {
+  isEncryptionAvailable: () => boolean
+  encryptString: (plain: string) => Buffer
+  decryptString: (cipher: Buffer) => string
+}
+
+export interface TokenStoreDeps {
+  secretBox?: SecretBox
+  /** Directory to keep the file in. Defaults to the userData dir beside the DB. */
+  dir?: string
+  log?: (message: string) => void
+}
+
+export class TokenStoreError extends Error {
+  constructor(
+    message: string,
+    readonly code: 'encryption_unavailable' | 'write_failed'
+  ) {
+    super(message)
+    this.name = 'TokenStoreError'
+  }
+}
+
+/**
+ * Electron's real `safeStorage`, resolved lazily.
+ *
+ * Imported through a function rather than at module load so the module can be
+ * unit-tested under `ELECTRON_RUN_AS_NODE`, where `require('electron')` yields
+ * a path string instead of the API.
+ */
+function electronSecretBox(): SecretBox {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- #130: lazy, see above
+  const { safeStorage } = require('electron') as { safeStorage: SecretBox }
+  return safeStorage
+}
+
+function resolve(deps: TokenStoreDeps): {
+  box: SecretBox
+  file: string
+  log: (m: string) => void
+} {
+  return {
+    box: deps.secretBox ?? electronSecretBox(),
+    file: join(deps.dir ?? userDataDir(), TOKEN_FILENAME),
+    log: deps.log ?? ((): void => {})
+  }
+}
+
+/** Whether tokens can be stored at all on this machine. */
+export function isStorageAvailable(deps: TokenStoreDeps = {}): boolean {
+  try {
+    return resolve(deps).box.isEncryptionAvailable()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Persist tokens, replacing anything already stored.
+ *
+ * Written to a temporary file and renamed into place: a crash midway must not
+ * leave a half-written blob that decrypts to garbage and silently drops the
+ * connection.
+ */
+export function saveTokens(tokens: StoredTokens, deps: TokenStoreDeps = {}): void {
+  const { box, file, log } = resolve(deps)
+  if (!box.isEncryptionAvailable()) {
+    throw new TokenStoreError(
+      'Die sichere Ablage des Systems ist nicht verfügbar, deshalb wird die Verbindung nicht ' +
+        'gespeichert. Unter Linux fehlt dafür meist ein Schlüsselbund (z. B. gnome-keyring).',
+      'encryption_unavailable'
+    )
+  }
+  const cipher = box.encryptString(JSON.stringify(tokens))
+  const tmp = `${file}.tmp`
+  try {
+    writeFileSync(tmp, cipher, { mode: 0o600 })
+    try {
+      chmodSync(tmp, 0o600)
+    } catch {
+      // chmod is a no-op / unsupported on Windows — the file still isn't shared.
+    }
+    renameSync(tmp, file)
+  } catch (err) {
+    try {
+      if (existsSync(tmp)) unlinkSync(tmp)
+    } catch {
+      /* best effort */
+    }
+    throw new TokenStoreError(
+      `Die Verbindung konnte nicht gespeichert werden: ${(err as Error).message}`,
+      'write_failed'
+    )
+  }
+  log('graph token store: tokens saved')
+}
+
+/** Shape check — a decrypted blob from an older or corrupted file may be anything. */
+function isStoredTokens(v: unknown): v is StoredTokens {
+  if (v === null || typeof v !== 'object') return false
+  const o = v as Record<string, unknown>
+  return (
+    typeof o.accessToken === 'string' &&
+    o.accessToken.length > 0 &&
+    typeof o.refreshToken === 'string' &&
+    o.refreshToken.length > 0 &&
+    typeof o.expiresAtMs === 'number' &&
+    Number.isFinite(o.expiresAtMs)
+  )
+}
+
+/**
+ * Read the stored tokens, or `null` when there is no usable connection.
+ *
+ * Never throws for a missing, unreadable, undecryptable or malformed file. All
+ * of those mean the same thing to the rest of the app — "not connected" — and
+ * the recovery is identical: the user connects again, which overwrites the
+ * file. Throwing here would turn a restored backup on a new machine into a
+ * crash on startup.
+ */
+export function loadTokens(deps: TokenStoreDeps = {}): StoredTokens | null {
+  const { box, file, log } = resolve(deps)
+  if (!existsSync(file)) return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(box.decryptString(readFileSync(file)))
+  } catch (err) {
+    // Typically: the file was copied from another machine, or the OS key
+    // changed. Deliberately no token material in the message.
+    log(`graph token store: stored connection unreadable (${(err as Error).name})`)
+    return null
+  }
+  if (!isStoredTokens(parsed)) {
+    log('graph token store: stored connection has an unexpected shape, ignoring')
+    return null
+  }
+  return parsed
+}
+
+/** True when a connection is stored and usable. */
+export function hasStoredTokens(deps: TokenStoreDeps = {}): boolean {
+  return loadTokens(deps) !== null
+}
+
+/** Remove the stored connection. Idempotent — "disconnect" when nothing is stored is fine. */
+export function clearTokens(deps: TokenStoreDeps = {}): void {
+  const { file, log } = resolve(deps)
+  try {
+    if (existsSync(file)) {
+      unlinkSync(file)
+      log('graph token store: tokens cleared')
+    }
+  } catch (err) {
+    log(`graph token store: could not remove the stored connection (${(err as Error).message})`)
+  }
+}

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -20,6 +20,7 @@ import { mergeExportHandler, mergeOnlyHandler, pdfInfoHandler } from './pdfMerge
 import { registerAnalyticsHandlers } from './analyticsHandlers'
 import { registerBudgetHandlers } from './budgetHandlers'
 import { registerTagHandlers } from './tagHandlers'
+import { registerGraphHandlers } from './graphHandlers'
 import { buildMcpRegistration, type McpRegistration } from './mcpLaunch'
 import type {
   Client,
@@ -1041,6 +1042,9 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
 
   // ── Tags (v1.12 #107) ────────────────────────────────────────────────
   registerTagHandlers(db)
+
+  // ── Microsoft Graph account (#130) ───────────────────────────
+  registerGraphHandlers(db)
 }
 
 /**

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -20,6 +20,7 @@ import type {
   AnalyticsSummary,
   BudgetStatus
 } from '../shared/types'
+import type { AccountStatus, VerifyResult } from '../main/graphAccount'
 
 declare global {
   interface Window {
@@ -190,6 +191,13 @@ declare global {
       }
       analytics: {
         getSummary(q: MonthQuery): Promise<IpcResult<AnalyticsSummary>>
+      }
+      graph: {
+        status(): Promise<IpcResult<AccountStatus>>
+        connect(): Promise<IpcResult<AccountStatus>>
+        cancelConnect(): Promise<IpcResult<void>>
+        verify(): Promise<IpcResult<VerifyResult>>
+        disconnect(): Promise<IpcResult<AccountStatus>>
       }
       update: {
         getStatus(): Promise<IpcResult<UpdateStatus>>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -21,6 +21,7 @@ import type {
   AnalyticsSummary
 } from '../shared/types'
 import type { CsvRequest } from '../main/csvExport'
+import type { AccountStatus, VerifyResult } from '../main/graphAccount'
 import type { IcalRequest } from '../main/icalExport'
 
 // ── v1.8 #76: FOUC prevention ─────────────────────────────────────────────
@@ -240,6 +241,14 @@ const api = {
   analytics: {
     getSummary: (q: MonthQuery): Promise<IpcResult<AnalyticsSummary>> =>
       ipcRenderer.invoke('analytics:summary', q)
+  },
+  // #130 — Microsoft account (calendar import). `status` never carries tokens.
+  graph: {
+    status: (): Promise<IpcResult<AccountStatus>> => ipcRenderer.invoke('graph:status'),
+    connect: (): Promise<IpcResult<AccountStatus>> => ipcRenderer.invoke('graph:connect'),
+    cancelConnect: (): Promise<IpcResult<void>> => ipcRenderer.invoke('graph:cancelConnect'),
+    verify: (): Promise<IpcResult<VerifyResult>> => ipcRenderer.invoke('graph:verify'),
+    disconnect: (): Promise<IpcResult<AccountStatus>> => ipcRenderer.invoke('graph:disconnect')
   },
   // v1.5 PR B — auto-updater
   update: {

--- a/src/renderer/src/components/GraphAccountSection.tsx
+++ b/src/renderer/src/components/GraphAccountSection.tsx
@@ -1,0 +1,245 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useT } from '../contexts/I18nContext'
+import type { AccountStatus } from '../../../main/graphAccount'
+
+/**
+ * "Connect a Microsoft account" (#130).
+ *
+ * Nothing here decides anything — the main process owns the flow and this only
+ * renders its outcome. Two behaviours are worth stating because they are easy
+ * to get wrong in a settings pane:
+ *
+ * - The connect button stays busy for as long as the browser is open, and the
+ *   cancel next to it really aborts the sign-in (it tears down the loopback
+ *   listener in main). A spinner that cannot be stopped would strand the user
+ *   whenever they close the browser tab instead of finishing.
+ * - The personal-account hint exists because Teams presence (#132) is not
+ *   available for those accounts at all. Better to say so where the account is
+ *   shown than to offer something later that cannot work.
+ */
+export function GraphAccountSection(): React.JSX.Element {
+  const t = useT()
+  const [status, setStatus] = useState<AccountStatus | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [clientId, setClientId] = useState('')
+  const [clientIdSaved, setClientIdSaved] = useState(false)
+  const [verifying, setVerifying] = useState(false)
+  const [verifyMsg, setVerifyMsg] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    const res = await window.api.graph.status()
+    if (res.ok) setStatus(res.data)
+    else setError(res.error)
+  }, [])
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- #130: dauerhaft — asynchroner IPC-Abruf des Verbindungsstatus beim Mount, kein dedizierter Store
+    void refresh()
+    void window.api.settings.getAll().then((res) => {
+      if (res.ok) setClientId(res.data.graph_client_id ?? '')
+    })
+  }, [refresh])
+
+  async function onConnect(): Promise<void> {
+    setBusy(true)
+    setError(null)
+    const res = await window.api.graph.connect()
+    setBusy(false)
+    if (res.ok) setStatus(res.data)
+    else setError(res.error)
+  }
+
+  async function onCancel(): Promise<void> {
+    await window.api.graph.cancelConnect()
+    // The pending connect() settles on its own with a cancellation error; this
+    // just stops the browser-side wait from looking like it is still running.
+    setBusy(false)
+  }
+
+  async function onVerify(): Promise<void> {
+    setVerifying(true)
+    setError(null)
+    setVerifyMsg(null)
+    const res = await window.api.graph.verify()
+    setVerifying(false)
+    if (!res.ok) {
+      setError(res.error)
+      // A rejected grant means the main process already dropped the connection;
+      // re-reading the status is what turns the pane back to "not connected".
+      await refresh()
+      return
+    }
+    const who = res.data.mail ?? res.data.displayName ?? ''
+    setVerifyMsg(
+      res.data.refreshed
+        ? t('settings.graph.verifyOkRefreshed', { who })
+        : t('settings.graph.verifyOk', { who })
+    )
+  }
+
+  async function onDisconnect(): Promise<void> {
+    setError(null)
+    setVerifyMsg(null)
+    const res = await window.api.graph.disconnect()
+    if (res.ok) setStatus(res.data)
+    else setError(res.error)
+  }
+
+  async function onSaveClientId(): Promise<void> {
+    await window.api.settings.set('graph_client_id', clientId.trim())
+    setClientIdSaved(true)
+    await refresh()
+  }
+
+  const connected = status?.connected === true
+  const storageMissing = status !== null && !status.storageAvailable
+
+  return (
+    // Padding belongs here, not in `Section`: that wrapper is a bare card and
+    // every existing child supplies its own insets via `Row` (px-[18px]/py-[13px]).
+    // Without them the content sits flush against the border and the first
+    // character of each line is clipped.
+    <div className="flex min-w-0 flex-col gap-3 px-[18px] py-[13px]">
+      <p className="text-xs" style={{ color: 'var(--text3)' }}>
+        {t('settings.graph.desc')}
+      </p>
+
+      {storageMissing && (
+        <p className="text-xs text-amber-300">{t('settings.graph.storageUnavailable')}</p>
+      )}
+
+      {connected ? (
+        <div className="flex flex-col gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              className="inline-flex w-fit items-center rounded-full px-2.5 py-0.5 text-xs font-semibold"
+              style={{ background: 'var(--green-bg)', color: 'var(--green)' }}
+            >
+              {t('settings.graph.connected')}
+            </span>
+            <span className="text-sm" style={{ color: 'var(--text)' }}>
+              {status?.account?.displayName ?? status?.account?.username ?? ''}
+            </span>
+            {status?.account?.username && status.account.displayName && (
+              <span className="text-xs" style={{ color: 'var(--text3)' }}>
+                {status.account.username}
+              </span>
+            )}
+          </div>
+
+          {status?.personalAccount && (
+            <p className="text-xs" style={{ color: 'var(--text3)' }}>
+              {t('settings.graph.personalAccountNote')}
+            </p>
+          )}
+
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={() => void onVerify()}
+              disabled={verifying}
+              className="rounded-lg border px-3 py-1.5 text-xs font-medium hover:bg-white/10 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+              style={{ borderColor: 'var(--card-border)', color: 'var(--text)' }}
+            >
+              {verifying ? t('settings.graph.verifying') : t('settings.graph.verify')}
+            </button>
+            <button
+              type="button"
+              onClick={() => void onDisconnect()}
+              className="rounded-lg border px-3 py-1.5 text-xs font-medium hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+              style={{ borderColor: 'var(--card-border)', color: 'var(--text)' }}
+            >
+              {t('settings.graph.disconnect')}
+            </button>
+          </div>
+
+          {verifyMsg && (
+            <p className="text-xs" style={{ color: 'var(--green)' }}>
+              {verifyMsg}
+            </p>
+          )}
+        </div>
+      ) : (
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={() => void onConnect()}
+            disabled={busy || storageMissing}
+            className="rounded-lg px-3 py-1.5 text-xs font-semibold text-white hover:opacity-90 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-indigo-300"
+            style={{ background: 'var(--accent)' }}
+          >
+            {busy ? t('settings.graph.connecting') : t('settings.graph.connect')}
+          </button>
+          {busy && (
+            <>
+              <span className="text-xs" style={{ color: 'var(--text3)' }}>
+                {t('settings.graph.browserHint')}
+              </span>
+              <button
+                type="button"
+                onClick={() => void onCancel()}
+                className="rounded-lg border px-3 py-1.5 text-xs font-medium hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                style={{ borderColor: 'var(--card-border)', color: 'var(--text2)' }}
+              >
+                {t('settings.graph.cancel')}
+              </button>
+            </>
+          )}
+        </div>
+      )}
+
+      {error && (
+        <p className="text-xs" style={{ color: 'var(--danger)' }}>
+          {error}
+        </p>
+      )}
+
+      {/* Escape hatch for tenants that block third-party apps, and for anyone
+          who would rather use their own registration. */}
+      <details className="mt-1">
+        <summary className="cursor-pointer text-xs" style={{ color: 'var(--text3)' }}>
+          {t('settings.graph.advanced')}
+        </summary>
+        <div className="mt-2 flex flex-col gap-2">
+          <p className="text-xs" style={{ color: 'var(--text3)' }}>
+            {t('settings.graph.clientIdHint')}
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <input
+              type="text"
+              value={clientId}
+              onChange={(e) => {
+                setClientId(e.target.value)
+                setClientIdSaved(false)
+              }}
+              placeholder={t('settings.graph.clientIdPlaceholder')}
+              spellCheck={false}
+              // `min-w-0` so a long GUID shrinks instead of pushing the Save
+              // button out of the card in a narrow settings pane.
+              className="min-w-0 flex-1 rounded-lg border px-3 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-indigo-400"
+              style={{
+                background: 'var(--card-bg)',
+                borderColor: 'var(--card-border)',
+                color: 'var(--text)'
+              }}
+            />
+            <button
+              type="button"
+              onClick={() => void onSaveClientId()}
+              className="rounded-lg border px-3 py-1.5 text-xs font-medium hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+              style={{ borderColor: 'var(--card-border)', color: 'var(--text)' }}
+            >
+              {t('common.save')}
+            </button>
+            {clientIdSaved && (
+              <span className="text-xs" style={{ color: 'var(--green)' }}>
+                {t('settings.graph.clientIdSaved')}
+              </span>
+            )}
+          </div>
+        </div>
+      </details>
+    </div>
+  )
+}

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -10,6 +10,7 @@ import { useRounding } from '../contexts/RoundingContext'
 import { Toggle } from '../components/Toggle'
 import { useUiPrefsStore } from '../store/uiPrefsStore'
 import TagManagementView from './TagManagementView'
+import { GraphAccountSection } from '../components/GraphAccountSection'
 import {
   WEBHOOK_EVENTS,
   isValidWebhookUrl,
@@ -814,9 +815,13 @@ export default function SettingsView(): React.JSX.Element {
         {/* Tags */}
         {tab === 'tags' && <TagManagementView />}
 
-        {/* Integrationen — MCP (v1.14 #128) */}
+        {/* Integrationen — Microsoft-Konto (#130) + MCP (v1.14 #128) */}
         {tab === 'integrations' && (
           <>
+            <Section title={t('settings.graph.section')}>
+              <GraphAccountSection />
+            </Section>
+
             <Section title={t('settings.mcp.section')}>
               <Row label={t('settings.mcp.section')} hint={t('settings.mcp.desc')} stacked>
                 <span

--- a/src/shared/graphAuth.test.ts
+++ b/src/shared/graphAuth.test.ts
@@ -1,0 +1,421 @@
+import { describe, it, expect } from 'vitest'
+import {
+  CALENDAR_SCOPES,
+  DEFAULT_CLIENT_ID,
+  EXPIRY_SKEW_MS,
+  GraphAuthError,
+  MSA_TENANT_ID,
+  REDIRECT_PATH,
+  applyRefresh,
+  authCodeBody,
+  authorizeUrl,
+  buildAuthorizeUrl,
+  describeAuthorizeError,
+  isPersonalAccount,
+  needsRefresh,
+  parseCallbackQuery,
+  parseErrorEnvelope,
+  parseIdTokenClaims,
+  redirectUriForPort,
+  refreshBody,
+  tokenUrl,
+  tokensFromResponse,
+  type StoredTokens
+} from './graphAuth'
+
+/** Build an unsigned id_token with the given payload (header/signature unused). */
+function fakeIdToken(payload: Record<string, unknown>): string {
+  const b64 = (o: unknown): string =>
+    Buffer.from(JSON.stringify(o), 'utf8')
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '')
+  return `${b64({ alg: 'none' })}.${b64(payload)}.signature-not-verified`
+}
+
+const NOW = 1_800_000_000_000
+
+function tokens(over: Partial<StoredTokens> = {}): StoredTokens {
+  return {
+    accessToken: 'access-1',
+    refreshToken: 'refresh-1',
+    expiresAtMs: NOW + 3600_000,
+    grantedScopes: ['Calendars.Read', 'offline_access'],
+    account: { username: 'a@b.test', displayName: 'A B', tenantId: 'tid-1' },
+    ...over
+  }
+}
+
+describe('scopes and endpoints', () => {
+  it('requests offline_access — without it no refresh token is issued', () => {
+    expect(CALENDAR_SCOPES).toContain('offline_access')
+  })
+
+  it('does NOT request Presence.ReadWrite (that belongs to #132, on opt-in)', () => {
+    expect(CALENDAR_SCOPES).not.toContain('Presence.ReadWrite')
+    expect(CALENDAR_SCOPES.some((s) => s.toLowerCase().includes('presence'))).toBe(false)
+  })
+
+  it('asks for read-only calendar access, never write', () => {
+    expect(CALENDAR_SCOPES).toContain('Calendars.Read')
+    expect(CALENDAR_SCOPES.some((s) => s.includes('ReadWrite'))).toBe(false)
+  })
+
+  it('builds the common-authority endpoints', () => {
+    expect(authorizeUrl('common')).toBe(
+      'https://login.microsoftonline.com/common/oauth2/v2.0/authorize'
+    )
+    expect(tokenUrl('common')).toBe('https://login.microsoftonline.com/common/oauth2/v2.0/token')
+  })
+
+  it('url-encodes a tenant GUID or a hostile tenant value', () => {
+    expect(tokenUrl('contoso.onmicrosoft.com')).toContain('/contoso.onmicrosoft.com/')
+    expect(authorizeUrl('a/../b')).not.toContain('a/../b')
+  })
+
+  it('ships a client id, since without one nothing can sign in', () => {
+    expect(DEFAULT_CLIENT_ID).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    )
+  })
+})
+
+describe('loopback redirect', () => {
+  it('carries the registered path — Entra ignores the port but not the path', () => {
+    expect(redirectUriForPort(51234)).toBe(`http://localhost:51234${REDIRECT_PATH}`)
+  })
+
+  it('produces the same path for any port, which is what makes ephemeral ports work', () => {
+    for (const port of [1024, 51234, 65535]) {
+      expect(new URL(redirectUriForPort(port)).pathname).toBe(REDIRECT_PATH)
+    }
+  })
+
+  it('uses http on localhost — allowed precisely because the hop never leaves the device', () => {
+    const u = new URL(redirectUriForPort(1234))
+    expect(u.protocol).toBe('http:')
+    expect(u.hostname).toBe('localhost')
+  })
+})
+
+const AUTHORIZE_PARAMS = {
+  clientId: 'client-1',
+  tenant: 'common' as const,
+  scopes: CALENDAR_SCOPES,
+  redirectUri: 'http://localhost:51234/timetrack',
+  state: 'state-abc',
+  codeChallenge: 'challenge-xyz'
+}
+
+describe('buildAuthorizeUrl', () => {
+  it('requests a code with S256 — the point of PKCE', () => {
+    const q = new URL(buildAuthorizeUrl(AUTHORIZE_PARAMS)).searchParams
+    expect(q.get('response_type')).toBe('code')
+    expect(q.get('code_challenge')).toBe('challenge-xyz')
+    expect(q.get('code_challenge_method')).toBe('S256')
+  })
+
+  it('never sends the verifier itself, only the challenge', () => {
+    const url = buildAuthorizeUrl(AUTHORIZE_PARAMS)
+    expect(url).not.toContain('code_verifier')
+  })
+
+  it('passes redirect_uri and state through unchanged', () => {
+    const q = new URL(buildAuthorizeUrl(AUTHORIZE_PARAMS)).searchParams
+    expect(q.get('redirect_uri')).toBe('http://localhost:51234/timetrack')
+    expect(q.get('state')).toBe('state-abc')
+  })
+
+  it('forces an account picker instead of silently reusing the browser session', () => {
+    // A "connect an account" button that connects whatever account happens to
+    // be signed in elsewhere is the wrong behaviour, and hard to notice.
+    expect(new URL(buildAuthorizeUrl(AUTHORIZE_PARAMS)).searchParams.get('prompt')).toBe(
+      'select_account'
+    )
+  })
+
+  it('asks for the query response mode, which is what the loopback can read', () => {
+    expect(new URL(buildAuthorizeUrl(AUTHORIZE_PARAMS)).searchParams.get('response_mode')).toBe(
+      'query'
+    )
+  })
+
+  it('space-separates the scopes', () => {
+    expect(new URL(buildAuthorizeUrl(AUTHORIZE_PARAMS)).searchParams.get('scope')).toBe(
+      CALENDAR_SCOPES.join(' ')
+    )
+  })
+})
+
+describe('request bodies', () => {
+  it('exchanges the code with the verifier and the same redirect_uri', () => {
+    const body = authCodeBody({
+      clientId: 'client-1',
+      code: 'the-code',
+      codeVerifier: 'the-verifier',
+      redirectUri: 'http://localhost:51234/timetrack',
+      scopes: CALENDAR_SCOPES
+    })
+    expect(body).toContain('grant_type=authorization_code')
+    expect(body).toContain('code=the-code')
+    expect(body).toContain('code_verifier=the-verifier')
+    expect(body).toContain('redirect_uri=http%3A%2F%2Flocalhost%3A51234%2Ftimetrack')
+  })
+
+  it('sends grant_type=refresh_token when refreshing', () => {
+    const body = refreshBody('client-1', 'refresh-1', ['Calendars.Read'])
+    expect(body).toContain('grant_type=refresh_token')
+    expect(body).toContain('refresh_token=refresh-1')
+  })
+
+  it('never puts a client secret in any body or URL (public client)', () => {
+    const bodies = [
+      authCodeBody({
+        clientId: 'c',
+        code: 'x',
+        codeVerifier: 'v',
+        redirectUri: 'http://localhost:1/timetrack',
+        scopes: CALENDAR_SCOPES
+      }),
+      refreshBody('c', 'r', CALENDAR_SCOPES),
+      buildAuthorizeUrl(AUTHORIZE_PARAMS)
+    ]
+    for (const body of bodies) expect(body).not.toContain('client_secret')
+  })
+})
+
+describe('parseCallbackQuery', () => {
+  it('reads code and state from the redirect', () => {
+    expect(parseCallbackQuery('?code=abc&state=xyz')).toEqual({
+      kind: 'code',
+      code: 'abc',
+      state: 'xyz'
+    })
+  })
+
+  it('works with or without the leading question mark', () => {
+    expect(parseCallbackQuery('code=abc&state=xyz')).toEqual({
+      kind: 'code',
+      code: 'abc',
+      state: 'xyz'
+    })
+  })
+
+  it('reports an OAuth error instead of pretending nothing arrived', () => {
+    expect(
+      parseCallbackQuery('?error=access_denied&error_description=User+cancelled&state=xyz')
+    ).toEqual({
+      kind: 'error',
+      error: 'access_denied',
+      description: 'User cancelled',
+      state: 'xyz'
+    })
+  })
+
+  it('returns null when neither a code nor an error is present', () => {
+    // e.g. a browser prefetch or a favicon hit on the listener.
+    expect(parseCallbackQuery('')).toBeNull()
+    expect(parseCallbackQuery('?something=else')).toBeNull()
+  })
+
+  it('returns null for a code without state — state is the CSRF guard', () => {
+    expect(parseCallbackQuery('?code=abc')).toBeNull()
+  })
+})
+
+describe('describeAuthorizeError', () => {
+  it('phrases a cancelled sign-in as cancelled, not as a failure', () => {
+    const err = describeAuthorizeError('access_denied', null)
+    expect(err.message).toMatch(/abgebrochen/)
+    expect(err.code).toBe('access_denied')
+  })
+
+  it.each(['consent_required', 'interaction_required'])(
+    'explains %s as the admin-approval case rather than a dead end',
+    (code) => {
+      const err = describeAuthorizeError(code, null)
+      expect(err.message).toMatch(/Administrator/)
+    }
+  )
+
+  it('falls back to the server description for anything else', () => {
+    expect(describeAuthorizeError('weird_error', 'Serverdetail').message).toBe('Serverdetail')
+  })
+
+  it('still yields a message when the server sends no description', () => {
+    expect(describeAuthorizeError('weird_error', null).message.length).toBeGreaterThan(0)
+  })
+})
+
+describe('tokensFromResponse', () => {
+  it('turns expires_in into an absolute expiry', () => {
+    const t = tokensFromResponse(
+      { access_token: 'at', refresh_token: 'rt', expires_in: 3599, scope: 'Calendars.Read' },
+      NOW
+    )
+    expect(t.accessToken).toBe('at')
+    expect(t.refreshToken).toBe('rt')
+    expect(t.expiresAtMs).toBe(NOW + 3599_000)
+    expect(t.grantedScopes).toEqual(['Calendars.Read'])
+  })
+
+  it('accepts expires_in delivered as a string', () => {
+    const t = tokensFromResponse(
+      { access_token: 'at', refresh_token: 'rt', expires_in: '600' },
+      NOW
+    )
+    expect(t.expiresAtMs).toBe(NOW + 600_000)
+  })
+
+  it('fails loudly when offline_access was not granted', () => {
+    expect(() => tokensFromResponse({ access_token: 'at', expires_in: 3600 }, NOW)).toThrow(
+      /refresh_token/
+    )
+  })
+
+  it('fails when there is no access token', () => {
+    expect(() => tokensFromResponse({ refresh_token: 'rt' }, NOW)).toThrow(GraphAuthError)
+  })
+
+  it('picks the display account out of the id_token', () => {
+    const t = tokensFromResponse(
+      {
+        access_token: 'at',
+        refresh_token: 'rt',
+        id_token: fakeIdToken({ preferred_username: 'r@wald-it.com', name: 'Robin', tid: 'tid-9' })
+      },
+      NOW
+    )
+    expect(t.account).toEqual({
+      username: 'r@wald-it.com',
+      displayName: 'Robin',
+      tenantId: 'tid-9'
+    })
+  })
+})
+
+describe('applyRefresh — the rotation rule', () => {
+  it('adopts a rotated refresh token when the server sends one', () => {
+    const next = applyRefresh(
+      tokens(),
+      { access_token: 'access-2', refresh_token: 'refresh-2', expires_in: 3600 },
+      NOW
+    )
+    expect(next.refreshToken).toBe('refresh-2')
+    expect(next.accessToken).toBe('access-2')
+  })
+
+  it('KEEPS the previous refresh token when the response omits one', () => {
+    // The failure this guards: writing `undefined` here locks the user out at
+    // the next refresh, hours later, with no way to tell why.
+    const next = applyRefresh(tokens(), { access_token: 'access-2', expires_in: 3600 }, NOW)
+    expect(next.refreshToken).toBe('refresh-1')
+  })
+
+  it('never leaves the refresh token empty', () => {
+    for (const body of [
+      { access_token: 'a', expires_in: 60 },
+      { access_token: 'a', refresh_token: '', expires_in: 60 },
+      { access_token: 'a', refresh_token: null, expires_in: 60 }
+    ]) {
+      expect(applyRefresh(tokens(), body, NOW).refreshToken).toBe('refresh-1')
+    }
+  })
+
+  it('carries the account over — a refresh response has no id_token', () => {
+    const next = applyRefresh(tokens(), { access_token: 'a', expires_in: 60 }, NOW)
+    expect(next.account).toEqual(tokens().account)
+  })
+
+  it('carries the granted scopes over when the response omits them', () => {
+    const next = applyRefresh(tokens(), { access_token: 'a', expires_in: 60 }, NOW)
+    expect(next.grantedScopes).toEqual(['Calendars.Read', 'offline_access'])
+  })
+
+  it('takes fresh scopes when the response does list them', () => {
+    const next = applyRefresh(
+      tokens(),
+      { access_token: 'a', expires_in: 60, scope: 'Calendars.Read User.Read' },
+      NOW
+    )
+    expect(next.grantedScopes).toEqual(['Calendars.Read', 'User.Read'])
+  })
+
+  it('re-bases the expiry on the refresh time, not the original login', () => {
+    const later = NOW + 5_000_000
+    expect(applyRefresh(tokens(), { access_token: 'a', expires_in: 3600 }, later).expiresAtMs).toBe(
+      later + 3600_000
+    )
+  })
+
+  it('throws when the refresh response has no access token', () => {
+    expect(() => applyRefresh(tokens(), { refresh_token: 'r' }, NOW)).toThrow(GraphAuthError)
+  })
+})
+
+describe('needsRefresh', () => {
+  it('is false for a token with plenty of life left', () => {
+    expect(needsRefresh(tokens({ expiresAtMs: NOW + 3600_000 }), NOW)).toBe(false)
+  })
+
+  it('is true once expired', () => {
+    expect(needsRefresh(tokens({ expiresAtMs: NOW - 1 }), NOW)).toBe(true)
+  })
+
+  it('refreshes early by the skew so a request cannot die in flight', () => {
+    const justInside = tokens({ expiresAtMs: NOW + EXPIRY_SKEW_MS - 1 })
+    const justOutside = tokens({ expiresAtMs: NOW + EXPIRY_SKEW_MS + 1 })
+    expect(needsRefresh(justInside, NOW)).toBe(true)
+    expect(needsRefresh(justOutside, NOW)).toBe(false)
+  })
+})
+
+describe('parseIdTokenClaims', () => {
+  it('returns null for absent or malformed input rather than throwing', () => {
+    expect(parseIdTokenClaims(null)).toBeNull()
+    expect(parseIdTokenClaims(undefined)).toBeNull()
+    expect(parseIdTokenClaims('')).toBeNull()
+    expect(parseIdTokenClaims('not-a-jwt')).toBeNull()
+    expect(parseIdTokenClaims('a.!!!not-base64!!!.c')).toBeNull()
+  })
+
+  it('decodes base64url payloads containing non-ASCII names', () => {
+    const claims = parseIdTokenClaims(fakeIdToken({ name: 'Renée Müller', tid: 't' }))
+    expect(claims?.displayName).toBe('Renée Müller')
+  })
+
+  it('falls back to the email claim when preferred_username is absent', () => {
+    expect(parseIdTokenClaims(fakeIdToken({ email: 'x@y.test' }))?.username).toBe('x@y.test')
+  })
+
+  it('returns null when the payload holds none of the display claims', () => {
+    expect(parseIdTokenClaims(fakeIdToken({ aud: 'client', iss: 'entra' }))).toBeNull()
+  })
+})
+
+describe('isPersonalAccount', () => {
+  it('recognises the well-known MSA tenant (Teams presence is unavailable there)', () => {
+    expect(isPersonalAccount({ username: null, displayName: null, tenantId: MSA_TENANT_ID })).toBe(
+      true
+    )
+  })
+
+  it('treats a work/school tenant and an unknown account as not personal', () => {
+    expect(isPersonalAccount({ username: null, displayName: null, tenantId: 'tid-1' })).toBe(false)
+    expect(isPersonalAccount(null)).toBe(false)
+  })
+})
+
+describe('parseErrorEnvelope', () => {
+  it('extracts code and description', () => {
+    expect(parseErrorEnvelope({ error: 'slow_down', error_description: 'wait' })).toEqual({
+      code: 'slow_down',
+      description: 'wait'
+    })
+  })
+
+  it('yields nulls for a body that is not an OAuth error envelope', () => {
+    expect(parseErrorEnvelope('<html>502</html>')).toEqual({ code: null, description: null })
+  })
+})

--- a/src/shared/graphAuth.ts
+++ b/src/shared/graphAuth.ts
@@ -1,0 +1,379 @@
+/**
+ * Microsoft Graph authentication — pure protocol logic (#130).
+ *
+ * Authorization Code + PKCE with a loopback redirect: the user clicks
+ * "connect", the system browser opens Microsoft's sign-in page, and the reply
+ * lands on a short-lived local listener. That is the flow behind the familiar
+ * "connect your Microsoft account" button; the device-code flow this started
+ * out as made the user re-type a code, and is additionally the flow most often
+ * blocked by Conditional Access in company tenants.
+ *
+ * No Electron, no `fetch`, no clock, and no crypto here: everything is a total
+ * function over its inputs, so the rotation rule and the expiry arithmetic can
+ * be tested without a network. PKCE generation needs `node:crypto` and would
+ * break the renderer (this module is renderer-safe, like `shared/webhooks.ts`),
+ * so it lives in `src/main/graphAuth.ts` together with the I/O.
+ *
+ * Why hand-rolled instead of `@azure/msal-node`: this is a **public client** —
+ * no client secret, nothing signed, no token parsed for a security decision. So
+ * MSAL's `jsonwebtoken` subtree, which is what it pulls in along with seven
+ * `lodash.*` packages, would be dead weight in a repo with twelve runtime
+ * dependencies. What remains is two form POSTs, a URL, and one rotation rule.
+ *
+ * Protocol reference:
+ * https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow
+ */
+
+/** `common` also admits personal Microsoft accounts, which is the point (#130). */
+export type GraphTenant = 'common' | 'organizations' | 'consumers' | (string & {})
+
+export const DEFAULT_TENANT: GraphTenant = 'common'
+
+/**
+ * The app registration shipped with TimeTrack (wald-it, registered 2026-07-27).
+ *
+ * A public-client id is an identifier, not a secret: it is in every copy of the
+ * installed app anyway, and without a user's own consent nothing can be read
+ * with it. Tokens travel directly between the app and Microsoft — no server of
+ * ours is involved at any point.
+ *
+ * Overridable in Settings → Integrationen, for tenants that refuse third-party
+ * apps and for anyone who would rather use their own registration.
+ *
+ * Known limit (not a code problem): Entra's risk-based step-up consent blocks
+ * *end users in other tenants* from consenting to a multitenant app registered
+ * after 2020-11-08 whose publisher is unverified, once it asks for more than
+ * basic sign-in — which `Calendars.Read` does. Until wald-it is a verified
+ * publisher, users outside this registration's own tenant will see "Need admin
+ * approval" instead of a consent prompt.
+ * https://learn.microsoft.com/en-us/entra/identity-platform/publisher-verification-overview
+ */
+export const DEFAULT_CLIENT_ID = '734cb982-f7b7-4dbf-91b1-cf95470bcd2a'
+
+/**
+ * Scopes for the calendar import.
+ *
+ * `offline_access` is what makes a refresh token be issued at all — without it
+ * the connection dies with the first access token. `openid`/`profile` are only
+ * there so the settings UI can name the connected account.
+ *
+ * Deliberately NOT here: `Presence.ReadWrite` for the Teams mirror (#132).
+ * Asking for write access to someone's Teams presence while setting up a
+ * calendar import would be the wrong order — that scope gets requested when the
+ * feature is switched on, not before. #132 is parked anyway: presence is "Not
+ * supported" for personal Microsoft accounts.
+ */
+export const CALENDAR_SCOPES = ['offline_access', 'openid', 'profile', 'Calendars.Read'] as const
+
+export function authorityBase(tenant: GraphTenant): string {
+  return `https://login.microsoftonline.com/${encodeURIComponent(tenant)}`
+}
+
+export function authorizeUrl(tenant: GraphTenant): string {
+  return `${authorityBase(tenant)}/oauth2/v2.0/authorize`
+}
+
+export function tokenUrl(tenant: GraphTenant): string {
+  return `${authorityBase(tenant)}/oauth2/v2.0/token`
+}
+
+/**
+ * Path of the loopback redirect. Must match the app registration exactly.
+ *
+ * Entra ignores the **port** of a localhost redirect URI, which is what lets us
+ * bind an ephemeral port without registering every one of them — but it does
+ * NOT ignore the path. Hence a named path rather than a bare `http://localhost`.
+ * https://learn.microsoft.com/en-us/entra/identity-platform/reply-url
+ */
+export const REDIRECT_PATH = '/timetrack'
+
+export function redirectUriForPort(port: number): string {
+  return `http://localhost:${port}${REDIRECT_PATH}`
+}
+
+/** Tokens plus an absolute expiry, so freshness never depends on when we asked. */
+export interface StoredTokens {
+  accessToken: string
+  refreshToken: string
+  /** Epoch ms. Absolute, not a duration. */
+  expiresAtMs: number
+  /** Scopes the server actually granted (may differ from what we asked for). */
+  grantedScopes: string[]
+  /** Display-only, from the id_token. Never used for authorization. */
+  account: AccountInfo | null
+}
+
+export interface AccountInfo {
+  /** `preferred_username` — usually the e-mail address. */
+  username: string | null
+  /** `name` — the display name. */
+  displayName: string | null
+  /** `tid` — lets the UI tell a work/school account from a personal one. */
+  tenantId: string | null
+}
+
+/**
+ * Personal Microsoft accounts always carry this well-known tenant id. Teams
+ * presence (#132) is unavailable for them, so the UI needs to be able to say so
+ * instead of offering a switch that cannot work.
+ */
+export const MSA_TENANT_ID = '9188040d-6c67-4c5b-b112-36a304b66dad'
+
+export function isPersonalAccount(account: AccountInfo | null): boolean {
+  return account?.tenantId === MSA_TENANT_ID
+}
+
+// ── Request bodies ─────────────────────────────────────────────────────────
+
+/**
+ * The URL the system browser is sent to.
+ *
+ * `code_challenge_method=S256` is the whole point of PKCE: the verifier never
+ * leaves this machine, so an authorization code intercepted on the loopback
+ * hop is useless without it. `prompt=select_account` is deliberate — without it
+ * Entra silently reuses whatever account the browser is already signed in with,
+ * which is exactly wrong for a "connect an account" button.
+ */
+export function buildAuthorizeUrl(params: {
+  clientId: string
+  tenant: GraphTenant
+  scopes: readonly string[]
+  redirectUri: string
+  state: string
+  codeChallenge: string
+}): string {
+  const q = new URLSearchParams({
+    client_id: params.clientId,
+    response_type: 'code',
+    redirect_uri: params.redirectUri,
+    response_mode: 'query',
+    scope: params.scopes.join(' '),
+    state: params.state,
+    code_challenge: params.codeChallenge,
+    code_challenge_method: 'S256',
+    prompt: 'select_account'
+  })
+  return `${authorizeUrl(params.tenant)}?${q.toString()}`
+}
+
+export function authCodeBody(params: {
+  clientId: string
+  code: string
+  codeVerifier: string
+  redirectUri: string
+  scopes: readonly string[]
+}): string {
+  return new URLSearchParams({
+    grant_type: 'authorization_code',
+    client_id: params.clientId,
+    code: params.code,
+    redirect_uri: params.redirectUri,
+    code_verifier: params.codeVerifier,
+    scope: params.scopes.join(' ')
+  }).toString()
+}
+
+/** Outcome of the browser redirect landing on the loopback listener. */
+export type CallbackResult =
+  | { kind: 'code'; code: string; state: string }
+  | { kind: 'error'; error: string; description: string | null; state: string | null }
+
+/**
+ * Read the callback query string.
+ *
+ * The `state` check itself is the caller's job — but note it must compare
+ * against the value it generated, not merely check presence: state is the CSRF
+ * guard for this flow, and a callback carrying someone else's code would
+ * otherwise be accepted.
+ */
+export function parseCallbackQuery(search: string): CallbackResult | null {
+  const q = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search)
+  const error = q.get('error')
+  if (error) {
+    return {
+      kind: 'error',
+      error,
+      description: q.get('error_description'),
+      state: q.get('state')
+    }
+  }
+  const code = q.get('code')
+  const state = q.get('state')
+  if (!code || !state) return null
+  return { kind: 'code', code, state }
+}
+
+export function refreshBody(
+  clientId: string,
+  refreshToken: string,
+  scopes: readonly string[]
+): string {
+  return new URLSearchParams({
+    grant_type: 'refresh_token',
+    client_id: clientId,
+    refresh_token: refreshToken,
+    scope: scopes.join(' ')
+  }).toString()
+}
+
+// ── Response parsing ───────────────────────────────────────────────────────
+
+/** Thrown for a terminal protocol failure; the caller reverts to signed-out. */
+export class GraphAuthError extends Error {
+  constructor(
+    message: string,
+    /** OAuth `error` code when the server supplied one. */
+    readonly code: string | null = null
+  ) {
+    super(message)
+    this.name = 'GraphAuthError'
+  }
+}
+
+/**
+ * Turn an OAuth error from the authorize step into something a user can act on.
+ *
+ * `access_denied` is the ordinary "I clicked cancel" case and must not read
+ * like a malfunction. `consent_required` / `interaction_required` are what the
+ * publisher-verification restriction surfaces as for users in other tenants —
+ * worth naming explicitly, because "Need admin approval" is otherwise a dead
+ * end with no explanation.
+ */
+export function describeAuthorizeError(error: string, description: string | null): GraphAuthError {
+  switch (error) {
+    case 'access_denied':
+      return new GraphAuthError('Die Anmeldung wurde abgebrochen.', error)
+    case 'consent_required':
+    case 'interaction_required':
+      return new GraphAuthError(
+        'Die Zustimmung muss von einem Administrator erteilt werden. ' +
+          'In vielen Firmen-Tenants dürfen Nutzer Apps ohne verifizierten Herausgeber nicht selbst freigeben.',
+        error
+      )
+    default:
+      return new GraphAuthError(description || 'Die Anmeldung ist fehlgeschlagen.', error)
+  }
+}
+
+/** Build absolute-expiry tokens from a `/token` success body. */
+export function tokensFromResponse(json: unknown, nowMs: number): StoredTokens {
+  const o = asRecord(json)
+  const accessToken = str(o.access_token)
+  const refreshToken = str(o.refresh_token)
+  if (!accessToken) throw new GraphAuthError('Antwort ohne access_token.')
+  if (!refreshToken) {
+    // Means `offline_access` was not granted — the connection would silently
+    // break at the first expiry, so fail loudly now instead.
+    throw new GraphAuthError(
+      'Antwort ohne refresh_token — offline_access wurde nicht erteilt. ' +
+        'Ohne ihn müsste die Anmeldung stündlich wiederholt werden.'
+    )
+  }
+  return {
+    accessToken,
+    refreshToken,
+    expiresAtMs: nowMs + (num(o.expires_in) ?? 3600) * 1000,
+    grantedScopes: (str(o.scope) ?? '').split(' ').filter(Boolean),
+    account: parseIdTokenClaims(str(o.id_token))
+  }
+}
+
+/**
+ * Fold a refresh response onto the tokens we already hold.
+ *
+ * The rotation rule is the whole reason this is a named function: Entra may
+ * return a NEW refresh token, and dropping it means the next refresh fails
+ * after the old one is invalidated. If the response omits one, the previous
+ * refresh token stays valid and must be carried over — writing `undefined`
+ * there is how a hand-rolled client locks the user out a day later.
+ *
+ * The account claims are likewise carried over: a refresh response has no
+ * id_token unless `openid` was re-requested, and losing the display name would
+ * blank the settings UI for no reason.
+ */
+export function applyRefresh(previous: StoredTokens, json: unknown, nowMs: number): StoredTokens {
+  const o = asRecord(json)
+  const accessToken = str(o.access_token)
+  if (!accessToken) throw new GraphAuthError('Erneuerung ohne access_token.')
+  const rotated = str(o.refresh_token)
+  const claims = parseIdTokenClaims(str(o.id_token))
+  const scopes = (str(o.scope) ?? '').split(' ').filter(Boolean)
+  return {
+    accessToken,
+    refreshToken: rotated ?? previous.refreshToken,
+    expiresAtMs: nowMs + (num(o.expires_in) ?? 3600) * 1000,
+    grantedScopes: scopes.length > 0 ? scopes : previous.grantedScopes,
+    account: claims ?? previous.account
+  }
+}
+
+/**
+ * Treat a token as expired slightly early so a request cannot die in flight.
+ * 120s covers both normal latency and modest clock skew against Entra.
+ */
+export const EXPIRY_SKEW_MS = 120_000
+
+export function needsRefresh(tokens: StoredTokens, nowMs: number): boolean {
+  return nowMs >= tokens.expiresAtMs - EXPIRY_SKEW_MS
+}
+
+/**
+ * Read the display claims out of an id_token.
+ *
+ * Deliberately does NOT verify the signature, and the result must never gate
+ * access to anything: the token arrived over TLS from the token endpoint in
+ * direct response to our own request, and it is used only to print which
+ * account is connected. Entra's own documentation warns against parsing tokens
+ * for APIs you do not own — an id_token issued to this client is the one token
+ * that is ours to read, and even so we only take three display fields from it.
+ */
+export function parseIdTokenClaims(idToken: string | null | undefined): AccountInfo | null {
+  if (!idToken) return null
+  const parts = idToken.split('.')
+  if (parts.length < 2) return null
+  try {
+    const json = JSON.parse(base64UrlDecode(parts[1])) as Record<string, unknown>
+    const info: AccountInfo = {
+      username: str(json.preferred_username) ?? str(json.email),
+      displayName: str(json.name),
+      tenantId: str(json.tid)
+    }
+    // All-null means nothing usable was in there; report absence, not an
+    // object full of nulls the UI would have to special-case anyway.
+    if (!info.username && !info.displayName && !info.tenantId) return null
+    return info
+  } catch {
+    return null
+  }
+}
+
+function base64UrlDecode(input: string): string {
+  const padded = input.replace(/-/g, '+').replace(/_/g, '/')
+  const withPad = padded + '='.repeat((4 - (padded.length % 4)) % 4)
+  return Buffer.from(withPad, 'base64').toString('utf8')
+}
+
+// ── Narrow helpers ─────────────────────────────────────────────────────────
+
+function asRecord(v: unknown): Record<string, unknown> {
+  return v !== null && typeof v === 'object' ? (v as Record<string, unknown>) : {}
+}
+
+function str(v: unknown): string | null {
+  return typeof v === 'string' && v.length > 0 ? v : null
+}
+
+function num(v: unknown): number | null {
+  if (typeof v === 'number' && Number.isFinite(v)) return v
+  if (typeof v === 'string' && v.trim() !== '' && Number.isFinite(Number(v))) return Number(v)
+  return null
+}
+
+/** OAuth error envelope, as far as we rely on it. */
+export function parseErrorEnvelope(json: unknown): {
+  code: string | null
+  description: string | null
+} {
+  const o = asRecord(json)
+  return { code: str(o.error), description: str(o.error_description) }
+}

--- a/src/shared/locales/de.ts
+++ b/src/shared/locales/de.ts
@@ -554,6 +554,30 @@ export const de = {
   'settings.nav.about': 'Über',
   'settings.nav.integrations': 'Integrationen',
   // ── Integrationen — MCP (v1.14 #128) ──────────────────────────────────────
+  // ── Microsoft-Konto (#130) ──────────────────────────────────────────────
+  'settings.graph.section': 'Microsoft-Konto',
+  'settings.graph.desc':
+    'Verbinde dein Microsoft-Konto, um Outlook-Termine als Eintrags-Entwürfe zu übernehmen. TimeTrack liest den Kalender nur — es schreibt nie hinein. Die Anmeldung läuft direkt zwischen dieser App und Microsoft.',
+  'settings.graph.connect': 'Microsoft-Konto verbinden',
+  'settings.graph.connecting': 'Warte auf Anmeldung …',
+  'settings.graph.browserHint': 'Die Anmeldung wurde im Browser geöffnet.',
+  'settings.graph.cancel': 'Abbrechen',
+  'settings.graph.connected': 'Verbunden',
+  'settings.graph.disconnect': 'Verbindung trennen',
+  'settings.graph.verify': 'Verbindung prüfen',
+  'settings.graph.verifying': 'Prüfe …',
+  'settings.graph.verifyOk': 'Verbindung funktioniert — Microsoft meldet {who}.',
+  'settings.graph.verifyOkRefreshed':
+    'Verbindung funktioniert — das Zugriffstoken wurde dabei erneuert. Microsoft meldet {who}.',
+  'settings.graph.personalAccountNote':
+    'Privates Microsoft-Konto. Der Kalender-Import funktioniert damit; die Teams-Status-Spiegelung nicht — die gibt es nur für Geschäfts- und Schulkonten.',
+  'settings.graph.storageUnavailable':
+    'Die sichere Ablage des Systems ist nicht verfügbar, deshalb kann keine Verbindung gespeichert werden. Unter Linux fehlt dafür meist ein Schlüsselbund (z. B. gnome-keyring).',
+  'settings.graph.advanced': 'Erweitert: eigene Anwendungs-ID',
+  'settings.graph.clientIdHint':
+    'Nur nötig, wenn dein Tenant fremde Anwendungen blockiert oder du eine eigene Registrierung verwenden willst. Leer lassen für die mitgelieferte.',
+  'settings.graph.clientIdPlaceholder': 'Application (client) ID',
+  'settings.graph.clientIdSaved': 'Gespeichert',
   'settings.mcp.section': 'Model Context Protocol (MCP)',
   'settings.mcp.desc':
     'Erlaubt Werkzeugen wie Claude Code, deine Zeiterfassung auszulesen — z. B. Stunden pro Kunde/Projekt auswerten oder eine Rechnung vorbereiten.',

--- a/src/shared/locales/en.ts
+++ b/src/shared/locales/en.ts
@@ -547,6 +547,30 @@ export const en: Record<TranslationKey, string> = {
   'settings.nav.about': 'About',
   'settings.nav.integrations': 'Integrations',
   // ── Integrations — MCP (v1.14 #128) ───────────────────────────────────────
+  // ── Microsoft account (#130) ────────────────────────────────────────────
+  'settings.graph.section': 'Microsoft account',
+  'settings.graph.desc':
+    'Connect your Microsoft account to turn Outlook events into draft entries. TimeTrack only reads the calendar — it never writes to it. Sign-in happens directly between this app and Microsoft.',
+  'settings.graph.connect': 'Connect Microsoft account',
+  'settings.graph.connecting': 'Waiting for sign-in …',
+  'settings.graph.browserHint': 'Sign-in has been opened in your browser.',
+  'settings.graph.cancel': 'Cancel',
+  'settings.graph.connected': 'Connected',
+  'settings.graph.disconnect': 'Disconnect',
+  'settings.graph.verify': 'Check connection',
+  'settings.graph.verifying': 'Checking …',
+  'settings.graph.verifyOk': 'Connection works — Microsoft reports {who}.',
+  'settings.graph.verifyOkRefreshed':
+    'Connection works — the access token was renewed in the process. Microsoft reports {who}.',
+  'settings.graph.personalAccountNote':
+    'Personal Microsoft account. Calendar import works; mirroring your Teams status does not — that is available for work and school accounts only.',
+  'settings.graph.storageUnavailable':
+    'The system keychain is unavailable, so no connection can be stored. On Linux this usually means a missing keyring (e.g. gnome-keyring).',
+  'settings.graph.advanced': 'Advanced: your own application ID',
+  'settings.graph.clientIdHint':
+    'Only needed if your tenant blocks third-party applications, or if you would rather use your own registration. Leave empty for the bundled one.',
+  'settings.graph.clientIdPlaceholder': 'Application (client) ID',
+  'settings.graph.clientIdSaved': 'Saved',
   'settings.mcp.section': 'Model Context Protocol (MCP)',
   'settings.mcp.desc':
     'Lets tools like Claude Code read your time tracking — e.g. summarise hours per client/project or prepare an invoice.',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -200,6 +200,10 @@ export interface Settings {
   // v1.15 #134 — Outbound-webhook targets as a JSON blob (see shared/webhooks.ts).
   // One settings row like export_prefs; seeded '[]' by migration 020.
   webhook_targets?: string
+  // v1.16 #130 — Optional override for the shipped Entra client id, for tenants
+  // that block third-party apps. Empty/absent means "use the bundled one".
+  // The tokens themselves are NOT here — see main/graphTokenStore.ts.
+  graph_client_id?: string
 }
 
 export interface CreateClientInput {


### PR DESCRIPTION
Teil 1 von 3 zu #130. Nach diesem PR kann man ein Microsoft-Konto **verbinden** — übernommen wird noch nichts. Terminabruf und Domain→Kunde-Mapping folgen in #130b, der Übernahme-Dialog in #130c.

Der Zuschnitt ist Absicht: Auth zuerst und allein, mit Review, bevor Features darauf stapeln.

## Zwei Abweichungen vom Issue

**Authorization Code + PKCE statt Device-Code.** Das Issue schlägt Device-Code vor; gebaut ist der Browser-Flow. Ausschlaggebend war die gewünschte UX — „Microsoft-Konto verbinden" öffnet den Browser, man meldet sich an und stimmt zu, statt einen Code abzutippen. Zwei weitere Punkte sprechen dafür: Es ist der Standardweg für Desktop-Apps, und ausgerechnet Device-Code wird in Firmen-Tenants zunehmend per Conditional Access blockiert.

**Kein `@azure/msal-node`.** Erst gemessen, dann entschieden: Die Bibliothek bringt über `jsonwebtoken` auch `jws`, `semver`, `ms` und **sieben einzelne `lodash.*`-Pakete** mit — bei zwölf Runtime-Abhängigkeiten ungefähr eine Verdopplung. Der Teil, der sie rechtfertigen würde, ist hier tot: Als **Public Client** wird nichts signiert und kein Token für eine Sicherheitsentscheidung gelesen. Übrig bleiben zwei Form-POSTs, eine URL und eine Rotationsregel, über `fetch` + `AbortSignal.timeout` wie schon in `webhooks.ts`.

Aufteilung wie dort: `shared/graphAuth.ts` ist reine Arithmetik über seine Eingaben und bleibt renderer-tauglich (kein `node:crypto`), die I/O liegt in `main/`.

## Die Stellen, an denen selbst gebautes OAuth verrottet

Vier, und jede hat ihren Wächter:

- **Refresh-Token-Rotation.** Entra kann bei jeder Erneuerung einen neuen Refresh-Token liefern; wer den verwirft, sperrt den Nutzer Stunden später aus, ohne dass jemand die Ursache sieht. `applyRefresh` übernimmt einen rotierten Token und behält sonst den alten — vier Tests, einer explizit für „Antwort ohne `refresh_token`".
- **Ablauf.** Gespeichert wird ein absoluter Zeitpunkt, keine Dauer, und erneuert wird 120 s früher, damit keine Anfrage unterwegs stirbt.
- **PKCE.** Verifier aus 32 Zufallsbytes, Challenge als `base64url(SHA-256)`, S256. Ein Test rechnet die Ableitung unabhängig nach, statt sie zu behaupten.
- **`state`.** Eigener Zufallswert als CSRF-Schutz. `parseCallbackQuery` verweigert einen Code ohne `state`, und der Vergleich mit dem selbst erzeugten Wert liegt in `graphConnect.ts` — als **Verzweigung im einzigen exportierten Pfad**, nicht als Kommentar beim Aufrufer. Ein Test belegt, dass ein fremder Code den Token-Endpoint nie erreicht.

Fehlendes `offline_access` ist ein harter Fehler statt stiller Übernahme — ohne den müsste man sich stündlich neu anmelden. `Presence.ReadWrite` ist bewusst **nicht** im Scope-Satz: Schreibrecht auf die Teams-Presence beim Einrichten eines Kalender-Imports zu verlangen wäre die falsche Reihenfolge, und #132 ist ohnehin geparkt (für private Microsoft-Konten laut Graph-Doku „Not supported").

`prompt=select_account` ist gesetzt, weil Entra sonst still das im Browser angemeldete Konto übernimmt — bei einem Knopf namens „Konto verbinden" das falsche Verhalten und schwer zu bemerken.

## Loopback

Zwei Punkte darin sind weniger offensichtlich, als sie aussehen:

- **Dual Stack.** Die Redirect-URI *muss* `localhost` sagen (das Entra-Portal nimmt `http://127.0.0.1` gar nicht an), aber unter Windows löst `localhost` meist zuerst auf `::1` auf. Ein Server nur auf `127.0.0.1` bekommt dann eine abgelehnte Verbindung — was sich als „die Anmeldung tut nichts" äußert. Deshalb beide Stacks auf demselben Port, mit IPv4-Fallback.
- **Es bleibt auf dem Rechner.** Gebunden wird ausdrücklich auf die Loopback-Adressen, nie `0.0.0.0`. Der Authorization Code überquert das Interface nicht — genau deshalb ist hier auch einfaches `http` zulässig (RFC 8252 §8.3).

Der Redirect trägt den Pfad `/timetrack`: Entra ignoriert bei localhost den **Port** — das erlaubt einen freien Port zur Laufzeit —, den **Pfad** aber nicht.

## Token-Speicher

Ein Refresh-Token ist ein Bearer-Credential für Postfach und Kalender in einem fremden Tenant — eine andere Klasse als das, was hier bisher gespeichert wurde (Webhook-Secrets liegen im Klartext in `settings`, der MCP-Token ist lokal erzeugt und anderswo wertlos). Deshalb `safeStorage` und eine eigene Datei.

**Nicht in die `settings`-Tabelle**, und das ist nachgesehen: `backup.ts` kopiert ausschließlich die `.sqlite` (Zeilen 84 und 105). Ein Token dort wäre in jedem Backup und beim Zurückspielen auf fremden Rechnern — wo `safeStorage` ihn ohnehin nicht entschlüsseln kann. Daneben abgelegt fasst ein Restore die Verbindung schlicht nicht an, was das ehrliche Verhalten ist: Die Verbindung gehört zur Maschine, nicht zu den Daten.

**Kein Klartext-Notausgang.** Fehlt die sichere Ablage, scheitert das Speichern mit einer Erklärung. Ein Feature, das seinen eigenen Schutz leise herunterstuft, ist schlimmer als eines, das sagt, dass es hier nicht geht.

## Was der Handtest gefunden hat — und was das über die Tests sagt

**Drei Fehler, alle unsichtbar für 763 grüne Tests.**

| Fund | Ursache | Warum kein Test ihn sah |
| --- | --- | --- |
| Inhalt klebte am Kartenrand | `Section` liefert kein Padding — das steckt in `Row` | jsdom rechnet kein Layout |
| Token im **produktiven** `userData` | falscher der zwei Pfad-Anker: `mcp/socketPath.ts` rekonstruiert `%APPDATA%` Electron-frei und kennt ein überschriebenes `userData` nicht; `main/db.ts` nimmt `app.getPath('userData')` | alle Store-Tests injizieren `dir` |
| „Sichere Ablage nicht verfügbar" in **jedem** Build | mein Fix für Nr. 2: `require('./db')` landet wörtlich im Bundle, wo electron-vite main zu einer Datei baut und es kein `./db` gibt → wirft → `isStorageAvailable` fängt alles → `false` | dito |

Der Reparaturversuch war schlimmer als der Fehler: Nr. 2 traf nur bei überschriebenem `userData`, Nr. 3 traf alle.

Konsequenz im Code: **kein Default mehr.** `TokenStoreDeps.dir` ist Pflichtfeld, der Compiler zeigt jede Stelle, die vorher still geraten hätte, und `graphHandlers.ts` nimmt den Pfad aus der Datenbank, die die App tatsächlich geöffnet hat. Die Begründung steht am Feld, **beide** Fehlversuche benannt, damit der Default nicht aus Bequemlichkeit zurückkommt. Dazu zwei Regressionstests auf `tokenDirForDbPath`, die nicht den Speicher prüfen, sondern die Regel.

## Belegt gegen echtes Entra

Konto `robin@wald-it.com`, gegen eine separate `userData`:

| Geprüft | Ergebnis |
| --- | --- |
| Registrierung | von Entra akzeptiert, kein `AADSTS…` |
| Loopback | getroffen, Erfolgsseite erschienen |
| `state`-Prüfung | bestanden |
| id_token | Name, Adresse und Tenant korrekt gelesen |
| Kontoart | Arbeitskonto **nicht** als privat erkannt |
| Datei auf der Platte | `v10`-Präfix, kein Klartext, 0600, kein `.tmp`-Rest |
| Graph `/me` | akzeptiert das Token |

**Die Erneuerung war die verbleibende Lücke** — nur gegen Fakes belegt, und ausgerechnet die Stelle, an der handgebautes OAuth kippt. Deshalb einmal echt gemessen, mit Kontrolle:

| Ablauf-Toleranz | `refreshed` | Graph | Token-Datei |
| --- | --- | --- | --- |
| temporär 2 h | **true** | akzeptiert | neu geschrieben (Rotation persistiert) |
| normal 120 s | **false** | akzeptiert | unverändert |

Die Messung unterscheidet also, statt nur zu bestätigen. Die Toleranz ist zurückgedreht, `git diff` auf der Datei leer.

## Offen, bewusst

- **Publisher Verification ist das Release-Gate**, nicht die Kür. Entras risk-based step-up consent verhindert, dass Endnutzer in **fremden** Tenants einer nach dem 08.11.2020 registrierten Multi-Tenant-App ohne verifizierten Herausgeber zustimmen, sobald sie mehr als Basis-Anmeldung anfragt — was `Calendars.Read` tut. Beim Herausgeber selbst funktioniert es (eigener Tenant + Admin-Consent). Kostenlos, aber ein Prozess: Partner One ID aus einem verifizierten CPP-Konto, Publisher-Domain nicht `*.onmicrosoft.com`. `describeAuthorizeError` benennt den Fall im Klartext, statt Nutzer vor einem unerklärten „Genehmigung durch Administrator erforderlich" stehen zu lassen.
- **Nur unter Windows getestet.** macOS-Keychain, Linux-Keyring und das Loopback-Verhalten dort sind ungeprüft. Bei dieser App hat „sollte gehen" schon einmal nicht gereicht (#145).

## Zahlen

- Tests **611 → 750** (139 neue), 0 skipped
- Lint unverändert **0 Fehler / 11 Warnungen** (alle vorbestehend, in nicht angefassten Dateien)
- `pnpm typecheck` sauber, `pnpm build` sauber

Refs #130
