### PR TITLE
release: v1.16.0 — calendar import complete, export as its own tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to TimeTrack are documented here.
 > **Language note:** Entries up to v1.15.1 are in German (historical record);
 > from v1.16.0 onward, entries are written in English.
 
-## [Unreleased]
+## [1.16.0] — 2026-07-29
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "time-tracking",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "description": "Schlanker Desktop-Zeiterfasser für Windows — Toggl-Track-Style, lokal, ohne Cloud.",
   "main": "./out/main/index.js",
   "author": "skoedr",


### PR DESCRIPTION
Minimal release commit, same shape as #162: version bump + the `## [Unreleased]` heading becomes `## [1.16.0] — 2026-07-29`. No content edits — every entry was reviewed in its feature PR (#153/#163, #130a/#166, #170, #171, #172, #174).

**Scope (decided on #130, 2026-07-29):** v1.16.0 = #153 + #130 complete (a+b+c). #132 Teams presence comes later on the same auth foundation. Publisher Verification is a gate before promoting the import beyond Robin's own tenant, not a release blocker (noted on #130).

**Release notes:** since #137 the publish job pulls the block under `## [1.16.0]` as the release body. The awk extraction was dry-run against this exact section: 47 lines, four feature areas, stops cleanly before the 1.15.1 block (the only '1.15' occurrence inside is prose in the #153 entry).

**State on this branch:** 856 passed, 0 skipped; lint 0 errors / 11 pre-existing warnings; typecheck green. `licenses.json` is regenerated by the prebuild hook in the release workflow (local == CI, settled in the v1.15 cycle).

After merge: tag `v1.16.0` on the squash commit → `release.yml` builds and publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)