### PR TITLE
release: v1.16.1 — calendar import learns client+project per domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to TimeTrack are documented here.
 > **Language note:** Entries up to v1.15.1 are in German (historical record);
 > from v1.16.0 onward, entries are written in English.
 
-## [Unreleased]
+## [1.16.1] — 2026-07-29
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "time-tracking",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "Schlanker Desktop-Zeiterfasser für Windows — Toggl-Track-Style, lokal, ohne Cloud.",
   "main": "./out/main/index.js",
   "author": "skoedr",


### PR DESCRIPTION
Minimal release commit, same shape as #175: version bump + the `## [Unreleased]` heading becomes `## [1.16.1] — 2026-07-29`. Content is one feature, reviewed in #177 (closes the loop on #176, found in the first hands-on test after v1.16.0).

Notes extraction dry-run: 7 lines, one entry, stops before the 1.16.0 block.

After merge: tag `v1.16.1` on the squash commit → `release.yml` builds and publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)