### PR TITLE
feat(#132): Teams presence mirroring — Busy + status message while a timer runs

### DIFF
--- a/src/main/graphAccount.ts
+++ b/src/main/graphAccount.ts
@@ -12,10 +12,12 @@
  * forgetting to persist that one locks the user out hours later.
  */
 import {
+  CALENDAR_SCOPES,
   DEFAULT_CLIENT_ID,
   GraphAuthError,
   isPersonalAccount,
-  needsRefresh
+  needsRefresh,
+  PRESENCE_SCOPE
 } from '../shared/graphAuth'
 import type { AccountInfo, StoredTokens } from '../shared/graphAuth'
 import { refreshTokens } from './graphAuth'
@@ -69,7 +71,14 @@ export function effectiveClientId(deps: GraphAccountDeps): string {
 }
 
 function configOf(deps: GraphAccountDeps): GraphAuthConfig {
-  return { clientId: effectiveClientId(deps) }
+  // Scopes follow the enabled features (#132): the presence scope is only
+  // requested once mirroring is switched on, so a calendar-only user never
+  // consents to more than the import needs.
+  const scopes =
+    deps.getSetting('presence_enabled') === '1'
+      ? [...CALENDAR_SCOPES, PRESENCE_SCOPE]
+      : [...CALENDAR_SCOPES]
+  return { clientId: effectiveClientId(deps), scopes }
 }
 
 export function getStatus(deps: GraphAccountDeps): AccountStatus {

--- a/src/main/graphHandlers.ts
+++ b/src/main/graphHandlers.ts
@@ -41,8 +41,10 @@ function fail(error: unknown): IpcResult<never> {
   return { ok: false, error: error instanceof Error ? error.message : String(error) }
 }
 
-export function registerGraphHandlers(db: Database.Database): void {
-  const deps: GraphAccountDeps = {
+/** The one place these deps are assembled — shared with the presence
+ *  reconciler wiring in index.ts (#132). */
+export function graphAccountDepsFor(db: Database.Database): GraphAccountDeps {
+  return {
     getSetting: (key) => {
       const row = db.prepare(`SELECT value FROM settings WHERE key = ?`).get(key) as
         | { value: string }
@@ -55,6 +57,10 @@ export function registerGraphHandlers(db: Database.Database): void {
     store: { dir: tokenDirForDbPath(getDbPath()) },
     log: (m) => log.info(m)
   }
+}
+
+export function registerGraphHandlers(db: Database.Database): void {
+  const deps: GraphAccountDeps = graphAccountDepsFor(db)
 
   // Only one sign-in can be in flight; a second "connect" click replaces the
   // first rather than leaving two listeners and two browser tabs behind.

--- a/src/main/graphPresence.test.ts
+++ b/src/main/graphPresence.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Tests for the presence reconciler (#132). Injected fetch — no network, no
+ * Electron. The module keeps applied state across calls, so every test resets
+ * it first.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  desiredMessage,
+  reconcilePresence,
+  resetPresenceStateForTests,
+  type PresenceDeps
+} from './graphPresence'
+import type { RunningStatus } from './mcpBridgeCore'
+
+const RUNNING: RunningStatus = {
+  id: 1,
+  client_id: 1,
+  project_id: 10,
+  description: '',
+  started_at: '2026-06-10T09:00:00.000Z',
+  client_name: 'Acme',
+  project_name: 'Rollout'
+}
+
+interface FetchCall {
+  url: string
+  method: string
+  body: unknown
+}
+
+function makeDeps(
+  o: Partial<{
+    enabled: boolean
+    showClient: boolean
+    language: string
+    connected: boolean
+    personal: boolean
+    scopes: string[]
+    token: string | null
+    failWith: number
+    now: number
+  }> = {}
+): { deps: PresenceDeps; calls: FetchCall[]; logs: string[] } {
+  const calls: FetchCall[] = []
+  const logs: string[] = []
+  const settings: Record<string, string> = {
+    presence_enabled: o.enabled === false ? '0' : '1',
+    presence_show_client: o.showClient === true ? '1' : '0',
+    language: o.language ?? 'de'
+  }
+  const fetchFn = (async (url: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({
+      url: String(url),
+      method: init?.method ?? 'GET',
+      body: init?.body ? JSON.parse(String(init.body)) : null
+    })
+    if (o.failWith !== undefined) return new Response('', { status: o.failWith })
+    if (String(url).includes('/me?$select=id')) {
+      return new Response(JSON.stringify({ id: 'user-guid-1' }), { status: 200 })
+    }
+    return new Response('', { status: 200 })
+  }) as typeof fetch
+  const deps: PresenceDeps = {
+    getSetting: (k) => settings[k],
+    getAccountStatus: () => ({
+      connected: o.connected !== false,
+      personalAccount: o.personal === true,
+      grantedScopes: o.scopes ?? ['Calendars.Read', 'Presence.ReadWrite']
+    }),
+    getAccessToken: async () => (o.token === undefined ? 'tok' : o.token),
+    getClientId: () => 'app-client-id',
+    fetchFn,
+    now: () => o.now ?? 1_750_000_000_000,
+    log: (m) => logs.push(m)
+  }
+  return { deps, calls, logs }
+}
+
+/** The setPresence/clearPresence session calls. */
+function sessionCalls(calls: FetchCall[]): FetchCall[] {
+  return calls.filter((c) => c.url.includes('setPresence') || c.url.includes('clearPresence'))
+}
+
+/** The setStatusMessage calls only (ignoring the one-time /me lookup). */
+function statusCalls(calls: FetchCall[]): FetchCall[] {
+  return calls.filter((c) => c.url.includes('setStatusMessage'))
+}
+
+describe('desiredMessage', () => {
+  it('renders generic, client, client+project, and language variants', () => {
+    expect(desiredMessage(null, true, 'de')).toBe('')
+    expect(desiredMessage(RUNNING, false, 'de')).toBe('🔴 Fokus')
+    expect(desiredMessage(RUNNING, true, 'de')).toBe('🔴 Fokus: Acme — Rollout')
+    expect(desiredMessage({ ...RUNNING, project_name: null }, true, 'de')).toBe('🔴 Fokus: Acme')
+    expect(desiredMessage(RUNNING, false, 'en')).toBe('🔴 Focus')
+  })
+})
+
+describe('reconcilePresence', () => {
+  beforeEach(() => resetPresenceStateForTests())
+
+  it('sets the message on start: /me lookup once, then setStatusMessage with expiry', async () => {
+    const { deps, calls } = makeDeps({ showClient: true })
+    await reconcilePresence(deps, RUNNING)
+    expect(calls[0].url).toContain('/me?$select=id')
+    const set = statusCalls(calls)
+    expect(set).toHaveLength(1)
+    expect(set[0].url).toBe(
+      'https://graph.microsoft.com/v1.0/users/user-guid-1/presence/setStatusMessage'
+    )
+    const body = set[0].body as {
+      statusMessage: { message: { content: string; contentType: string }; expiryDateTime?: unknown }
+    }
+    expect(body.statusMessage.message).toEqual({
+      content: '🔴 Fokus: Acme — Rollout',
+      contentType: 'text'
+    })
+    expect(body.statusMessage.expiryDateTime).toMatchObject({ timeZone: 'UTC' })
+  })
+
+  it('is idempotent: same state twice → one Graph write, cached user id', async () => {
+    const { deps, calls } = makeDeps()
+    await reconcilePresence(deps, RUNNING)
+    await reconcilePresence(deps, RUNNING)
+    expect(statusCalls(calls)).toHaveLength(1)
+    expect(calls.filter((c) => c.url.includes('/me?$select=id'))).toHaveLength(1)
+  })
+
+  it('sets a Busy/InACall session alongside the message', async () => {
+    const { deps, calls } = makeDeps()
+    await reconcilePresence(deps, RUNNING)
+    const sessions = sessionCalls(calls)
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0].url).toContain('/presence/setPresence')
+    expect(sessions[0].body).toEqual({
+      sessionId: 'app-client-id',
+      availability: 'Busy',
+      activity: 'InACall',
+      expirationDuration: 'PT1H'
+    })
+  })
+
+  it('renews the expiring session on an unchanged state after 25 minutes', async () => {
+    const t0 = 1_750_000_000_000
+    const early = makeDeps({ now: t0 })
+    await reconcilePresence(early.deps, RUNNING)
+    const late = makeDeps({ now: t0 + 26 * 60 * 1000 })
+    await reconcilePresence(late.deps, RUNNING)
+    expect(sessionCalls(late.calls)).toHaveLength(1)
+  })
+
+  it('stop clears both message and session; a 404 on clearPresence counts as cleared', async () => {
+    const { deps, calls } = makeDeps()
+    await reconcilePresence(deps, RUNNING)
+    // clearPresence answers 404 when the session already expired:
+    const fetchInner = deps.fetchFn!
+    deps.fetchFn = (async (url: RequestInfo | URL, init?: RequestInit) => {
+      if (String(url).includes('clearPresence')) {
+        await fetchInner(url, init) // still record the call
+        return new Response('', { status: 404 })
+      }
+      return fetchInner(url, init)
+    }) as typeof fetch
+    await reconcilePresence(deps, null)
+    const sessions = sessionCalls(calls)
+    expect(sessions.map((c) => c.url.split('/presence/')[1])).toEqual([
+      'setPresence',
+      'clearPresence'
+    ])
+    expect(sessions[1].body).toEqual({ sessionId: 'app-client-id' })
+    // 404 counted as success → a further poke does nothing more.
+    await reconcilePresence(deps, null)
+    expect(sessionCalls(calls)).toHaveLength(2)
+  })
+
+  it('clears with empty content on stop — but only after having set something', async () => {
+    const { deps, calls } = makeDeps()
+    await reconcilePresence(deps, null) // idle, never set → must not touch Teams
+    expect(calls).toHaveLength(0)
+    await reconcilePresence(deps, RUNNING)
+    await reconcilePresence(deps, null)
+    const set = statusCalls(calls)
+    expect(set).toHaveLength(2)
+    expect(
+      (set[1].body as { statusMessage: { message: { content: string } } }).statusMessage.message
+        .content
+    ).toBe('')
+  })
+
+  it('switching the feature off clears our own message once', async () => {
+    const on = makeDeps()
+    await reconcilePresence(on.deps, RUNNING)
+    // Same module state, feature now disabled:
+    const off = makeDeps({ enabled: false })
+    await reconcilePresence(off.deps, RUNNING)
+    await reconcilePresence(off.deps, RUNNING)
+    expect(statusCalls(off.calls)).toHaveLength(1)
+    expect(
+      (statusCalls(off.calls)[0].body as { statusMessage: { message: { content: string } } })
+        .statusMessage.message.content
+    ).toBe('')
+  })
+
+  it('does nothing for personal accounts, missing connection, or missing scope', async () => {
+    for (const opts of [{ personal: true }, { connected: false }, { scopes: ['Calendars.Read'] }]) {
+      resetPresenceStateForTests()
+      const { deps, calls } = makeDeps(opts)
+      await reconcilePresence(deps, RUNNING)
+      expect(calls).toHaveLength(0)
+    }
+  })
+
+  it('logs the missing scope so the user can find out why nothing happens', async () => {
+    const { deps, logs } = makeDeps({ scopes: ['Calendars.Read'] })
+    await reconcilePresence(deps, RUNNING)
+    expect(logs.some((l) => l.includes('reconnect required'))).toBe(true)
+  })
+
+  it('a failed write is not marked applied — the next poke retries', async () => {
+    const failing = makeDeps({ failWith: 500 })
+    await reconcilePresence(failing.deps, RUNNING)
+    const ok = makeDeps()
+    await reconcilePresence(ok.deps, RUNNING)
+    expect(statusCalls(ok.calls)).toHaveLength(1)
+  })
+
+  it('never throws when fetch rejects', async () => {
+    const { deps } = makeDeps()
+    deps.fetchFn = (async () => {
+      throw new Error('offline')
+    }) as typeof fetch
+    await expect(reconcilePresence(deps, RUNNING)).resolves.toBeUndefined()
+  })
+
+  it('privacy switch mid-run re-renders the message', async () => {
+    const generic = makeDeps({ showClient: false })
+    await reconcilePresence(generic.deps, RUNNING)
+    const withClient = makeDeps({ showClient: true })
+    await reconcilePresence(withClient.deps, RUNNING)
+    const set = statusCalls(withClient.calls)
+    expect(set).toHaveLength(1)
+    expect(
+      (set[0].body as { statusMessage: { message: { content: string } } }).statusMessage.message
+        .content
+    ).toBe('🔴 Fokus: Acme — Rollout')
+  })
+})

--- a/src/main/graphPresence.ts
+++ b/src/main/graphPresence.ts
@@ -1,0 +1,243 @@
+/**
+ * Teams presence mirroring (#132) — state-driven, never event-driven.
+ *
+ * `reconcilePresence` is poked whenever the timer state may have changed (the
+ * `tray:update` choke point covers every source: UI, tray, hotkey, mini-widget,
+ * idle handlers, and — via the renderer resync — MCP writes and hardware keys).
+ * It compares the DESIRED status message with the last one it applied and only
+ * then talks to Graph. That makes it idempotent, cheap to poke, and immune to
+ * the "stop happened via entries:update" class of blind spots an event hook
+ * would have.
+ *
+ * Ownership rule: this module only ever clears a message it set itself. A
+ * manually set Teams status is never touched, and switching the feature off
+ * clears at most our own last message.
+ *
+ * Failures are logged and swallowed — presence must never affect the timer.
+ * The applied state is only updated on success, so the next poke retries.
+ *
+ * Docs (verified 2026-07-29): POST /users/{id}/presence/setStatusMessage,
+ * delegated scope Presence.ReadWrite, v1.0; personal Microsoft accounts are
+ * "Not supported."; the only documented request form is /users/{id}/… — the
+ * signed-in user's GUID is resolved once per run via GET /me?$select=id.
+ * Clearing via empty content is community-established but undocumented.
+ */
+import type { RunningStatus } from './mcpBridgeCore'
+
+export interface PresenceAccountView {
+  connected: boolean
+  personalAccount: boolean
+  grantedScopes: string[]
+}
+
+export interface PresenceDeps {
+  getSetting: (key: string) => string | undefined
+  getAccountStatus: () => PresenceAccountView
+  getAccessToken: () => Promise<string | null>
+  /** The effective app client id — doubles as the presence session id. */
+  getClientId: () => string
+  fetchFn?: typeof fetch
+  now?: () => number
+  log?: (message: string) => void
+}
+
+const GRAPH_BASE = 'https://graph.microsoft.com/v1.0'
+const REQUEST_TIMEOUT_MS = 15_000
+/** Safety net: a crashed app must not leave "Fokus" standing forever. */
+const EXPIRY_MS = 12 * 60 * 60 * 1000
+/**
+ * Presence sessions expire (PT5M–PT4H); we request PT1H and re-apply the
+ * unchanged state every ~25 minutes. The 30-second heartbeat pokes make this
+ * renewal reliable while a timer runs.
+ */
+const SESSION_DURATION = 'PT1H'
+const REFRESH_AFTER_MS = 25 * 60 * 1000
+
+interface AppliedState {
+  /** The message content last successfully applied; '' after a clear; null = never touched. */
+  message: string | null
+  at: number
+  userId: string | null
+}
+
+const state: AppliedState = { message: null, at: 0, userId: null }
+
+/** Test-only: forget everything this module has applied. */
+export function resetPresenceStateForTests(): void {
+  state.message = null
+  state.at = 0
+  state.userId = null
+}
+
+function scopeGranted(view: PresenceAccountView): boolean {
+  return view.grantedScopes.some((s) => s.toLowerCase() === 'presence.readwrite')
+}
+
+/** The status message the current state calls for; '' means "clear". */
+export function desiredMessage(
+  running: Pick<RunningStatus, 'client_name' | 'project_name'> | null,
+  showClient: boolean,
+  language: string
+): string {
+  if (!running) return ''
+  const focus = language === 'en' ? 'Focus' : 'Fokus'
+  if (!showClient) return `🔴 ${focus}`
+  const project = running.project_name ? ` — ${running.project_name}` : ''
+  return `🔴 ${focus}: ${running.client_name}${project}`
+}
+
+/** UTC dateTimeTimeZone for Graph ("dateTime shouldn't include time zone"). */
+function expiryAt(nowMs: number): { dateTime: string; timeZone: string } {
+  return { dateTime: new Date(nowMs + EXPIRY_MS).toISOString().replace('Z', ''), timeZone: 'UTC' }
+}
+
+async function resolveUserId(
+  fetchFn: typeof fetch,
+  token: string,
+  log: (m: string) => void
+): Promise<string | null> {
+  if (state.userId) return state.userId
+  try {
+    const res = await fetchFn(`${GRAPH_BASE}/me?$select=id`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+    })
+    if (!res.ok) {
+      log(`presence: /me lookup failed with HTTP ${res.status}`)
+      return null
+    }
+    const body = (await res.json()) as { id?: unknown }
+    state.userId = typeof body.id === 'string' ? body.id : null
+    return state.userId
+  } catch (err) {
+    log(`presence: /me lookup failed (${err instanceof Error ? err.name : 'error'})`)
+    return null
+  }
+}
+
+/**
+ * Bring the Teams status message in line with the current timer state.
+ * Safe to call often; talks to Graph only when something actually changed.
+ */
+export async function reconcilePresence(
+  deps: PresenceDeps,
+  running: RunningStatus | null
+): Promise<void> {
+  const log = deps.log ?? ((): void => {})
+  const now = deps.now?.() ?? Date.now()
+  const enabled = deps.getSetting('presence_enabled') === '1'
+
+  // Feature off: leave Teams alone — except to withdraw our own last message.
+  const wantsClear = !enabled || running === null
+  if (wantsClear && (state.message === null || state.message === '')) return
+
+  const view = deps.getAccountStatus()
+  if (!view.connected || view.personalAccount) return
+  if (!scopeGranted(view)) {
+    log('presence: Presence.ReadWrite not granted — reconnect required')
+    return
+  }
+
+  const message = wantsClear
+    ? ''
+    : desiredMessage(
+        running,
+        deps.getSetting('presence_show_client') === '1',
+        deps.getSetting('language') ?? 'de'
+      )
+  const unchanged = state.message === message
+  const fresh = now - state.at < REFRESH_AFTER_MS
+  if (unchanged && (message === '' || fresh)) return
+
+  const fetchFn = deps.fetchFn ?? fetch
+  const token = await deps.getAccessToken()
+  if (!token) return
+  const userId = await resolveUserId(fetchFn, token, log)
+  if (!userId) return
+
+  const post = async (action: string, payload: unknown): Promise<boolean> => {
+    try {
+      const res = await fetchFn(
+        `${GRAPH_BASE}/users/${encodeURIComponent(userId)}/presence/${action}`,
+        {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+          signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+        }
+      )
+      // clearPresence answers 404 when no session exists — nothing to clear
+      // counts as cleared.
+      if (res.ok || (action === 'clearPresence' && res.status === 404)) return true
+      log(`presence: ${action} failed with HTTP ${res.status}`)
+      return false
+    } catch (err) {
+      log(`presence: ${action} failed (${err instanceof Error ? err.name : 'error'})`)
+      return false
+    }
+  }
+
+  const sessionId = deps.getClientId()
+  let ok: boolean
+  if (message === '') {
+    ok =
+      (await post('setStatusMessage', {
+        statusMessage: { message: { content: '', contentType: 'text' } }
+      })) && (await post('clearPresence', { sessionId }))
+  } else {
+    // Busy/InACall is the only plain-"red" combination setPresence accepts;
+    // DoNotDisturb/Presenting would suppress the user's notifications.
+    ok =
+      (await post('setStatusMessage', {
+        statusMessage: {
+          message: { content: message, contentType: 'text' },
+          expiryDateTime: expiryAt(now)
+        }
+      })) &&
+      (await post('setPresence', {
+        sessionId,
+        availability: 'Busy',
+        activity: 'InACall',
+        expirationDuration: SESSION_DURATION
+      }))
+  }
+  if (!ok) return
+  state.message = message
+  state.at = now
+  log(message === '' ? 'presence: cleared (message + session)' : 'presence: set (message + Busy)')
+  await readBack(fetchFn, token, userId, log)
+}
+
+/**
+ * Read the presence back after a write and log what Graph ACTUALLY stored.
+ * A 200 on setStatusMessage alone proves nothing — this makes a silent
+ * no-op visible in the log instead of looking like success.
+ */
+async function readBack(
+  fetchFn: typeof fetch,
+  token: string,
+  userId: string,
+  log: (m: string) => void
+): Promise<void> {
+  try {
+    const res = await fetchFn(`${GRAPH_BASE}/users/${encodeURIComponent(userId)}/presence`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+    })
+    if (!res.ok) {
+      log(`presence: read-back failed with HTTP ${res.status}`)
+      return
+    }
+    const body = (await res.json()) as {
+      availability?: unknown
+      statusMessage?: { message?: { content?: unknown } } | null
+    }
+    const content = body.statusMessage?.message?.content
+    log(
+      `presence: read-back availability=${String(body.availability)} statusMessage=` +
+        (typeof content === 'string' ? JSON.stringify(content) : 'none')
+    )
+  } catch (err) {
+    log(`presence: read-back failed (${err instanceof Error ? err.name : 'error'})`)
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -28,6 +28,10 @@ import {
   type BridgeDeps
 } from './mcpBridge'
 import { initAutoUpdater } from './updater'
+import { readRunning } from './mcpBridgeCore'
+import { reconcilePresence, type PresenceDeps } from './graphPresence'
+import { graphAccountDepsFor } from './graphHandlers'
+import { effectiveClientId, getAccessToken, getStatus } from './graphAccount'
 import { applyMiniEnabled, destroyMini, pushMiniState, toggleMini } from './miniWindow'
 import {
   configureIdleWatcher,
@@ -354,6 +358,36 @@ function createWindow(): void {
   }
 }
 
+/**
+ * Teams presence mirroring (#132): poked from the `tray:update` choke point,
+ * which fires on every timer state change from every source (UI, tray, hotkey,
+ * mini-widget, idle handlers — and external writes via the renderer resync).
+ * Fire-and-forget by contract; the reconciler swallows and logs failures.
+ */
+function pokePresence(): void {
+  try {
+    const db = getDb()
+    const account = graphAccountDepsFor(db)
+    const deps: PresenceDeps = {
+      getSetting: account.getSetting,
+      getAccountStatus: () => {
+        const s = getStatus(account)
+        return {
+          connected: s.connected,
+          personalAccount: s.personalAccount,
+          grantedScopes: s.grantedScopes
+        }
+      },
+      getAccessToken: () => getAccessToken(account),
+      getClientId: () => effectiveClientId(account),
+      log: (m) => log.info(m)
+    }
+    void reconcilePresence(deps, readRunning(db))
+  } catch (err) {
+    log.warn('[presence] poke failed', err)
+  }
+}
+
 /** Dependencies handed to the MCP write bridge (all resolved lazily at call time). */
 function mcpBridgeDeps(): BridgeDeps {
   return {
@@ -533,7 +567,8 @@ app.whenReady().then(async () => {
         clearControllerToken()
         if (mcpBridgeDeps().getSetting('mcp_write_enabled') !== '1') stopMcpBridge()
       }
-    }
+    },
+    pokePresence
   })
   createWindow()
 
@@ -582,6 +617,7 @@ app.whenReady().then(async () => {
       pushMiniState({ running, label, startedAt })
       if (running) startIdleWatcher()
       else stopIdleWatcher()
+      pokePresence()
     }
   )
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -50,6 +50,8 @@ export interface IpcHooks {
   setMiniHotkey(accelerator: string): boolean
   setMcpWriteEnabled(enabled: boolean): void
   setControllerEnabled(enabled: boolean): void
+  /** Re-run the presence reconciler (#132) after a relevant settings change. */
+  pokePresence(): void
 }
 
 function ok<T>(data: T): IpcResult<T> {
@@ -659,6 +661,14 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
         hooks.setMcpWriteEnabled(value === '1')
       } else if (key === 'controller_enabled') {
         hooks.setControllerEnabled(value === '1')
+      } else if (
+        key === 'presence_enabled' ||
+        key === 'presence_show_client' ||
+        key === 'language'
+      ) {
+        // Toggling mirroring off clears our own status message; the language
+        // and privacy switches re-render it while a timer runs.
+        hooks.pokePresence()
       }
       return ok(undefined)
     } catch (e) {

--- a/src/main/mcpBridgeCore.ts
+++ b/src/main/mcpBridgeCore.ts
@@ -283,7 +283,7 @@ function planOp(db: Db, op: WriteOp, args: Record<string, unknown>): Plan | { er
 
 // ── controller scope (#133) ─────────────────────────────────────────────────
 
-interface RunningStatus {
+export interface RunningStatus {
   id: number
   client_id: number
   project_id: number | null
@@ -293,8 +293,9 @@ interface RunningStatus {
   project_name: string | null
 }
 
-/** Current running timer with client/project names, or null. */
-function readRunning(db: Db): RunningStatus | null {
+/** Current running timer with client/project names, or null.
+ *  Exported for the presence reconciler (#132), which needs the same shape. */
+export function readRunning(db: Db): RunningStatus | null {
   const row = db
     .prepare(
       `SELECT e.id, e.client_id, e.project_id, e.description, e.started_at,

--- a/src/main/migrations/024-v117-presence.ts
+++ b/src/main/migrations/024-v117-presence.ts
@@ -1,0 +1,22 @@
+import type { Migration } from './index'
+
+/**
+ * v1.17 #132 — Teams presence mirroring settings.
+ *
+ * `presence_enabled` gates the feature (work/school accounts only — personal
+ * Microsoft accounts have no presence API). `presence_show_client` decides
+ * whether the status message names the client or stays generic ("Fokus") —
+ * generic by default so no client name leaves the machine without an explicit
+ * opt-in.
+ *
+ * `INSERT OR IGNORE` keeps it idempotent and never overwrites a user choice.
+ */
+export const migration024: Migration = {
+  version: 24,
+  name: 'v1.17-presence',
+  up: `
+    INSERT OR IGNORE INTO settings (key, value) VALUES
+      ('presence_enabled', '0'),
+      ('presence_show_client', '0');
+  `
+}

--- a/src/main/migrations/index.ts
+++ b/src/main/migrations/index.ts
@@ -21,6 +21,7 @@ import { migration020 } from './020-v115-webhooks'
 import { migration021 } from './021-v116-graph-import'
 import { migration022 } from './022-v117-domain-project'
 import { migration023 } from './023-v117-hardware-keys'
+import { migration024 } from './024-v117-presence'
 
 export interface Migration {
   /** Monotonically increasing integer. Never reused, never reordered. */
@@ -58,5 +59,6 @@ export const migrations: Migration[] = [
   migration020,
   migration021,
   migration022,
-  migration023
+  migration023,
+  migration024
 ].sort((a, b) => a.version - b.version)

--- a/src/main/migrations/migrations.test.ts
+++ b/src/main/migrations/migrations.test.ts
@@ -123,6 +123,9 @@ describe('migration SQL execution', () => {
       { key: 'pdf_round_minutes', value: '0' },
       { key: 'pdf_sender_address', value: '' },
       { key: 'pdf_tax_id', value: '' },
+      // Migration 024 — Teams presence mirroring (v1.17 #132)
+      { key: 'presence_enabled', value: '0' },
+      { key: 'presence_show_client', value: '0' },
       // Migration 011 — Light/Dark/System theme (v1.8 #76)
       { key: 'theme_mode', value: 'system' },
       // Migration 020 — Outbound-Webhooks (v1.15 #134)

--- a/src/renderer/src/components/GraphAccountSection.tsx
+++ b/src/renderer/src/components/GraphAccountSection.tsx
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useState } from 'react'
 import { useT } from '../contexts/I18nContext'
+import { Toggle } from './Toggle'
 import type { AccountStatus } from '../../../main/graphAccount'
+
+/** Delegated scope required for presence mirroring (#132); must match shared/graphAuth. */
+const PRESENCE_SCOPE = 'Presence.ReadWrite'
 
 /**
  * "Connect a Microsoft account" (#130).
@@ -26,6 +30,8 @@ export function GraphAccountSection(): React.JSX.Element {
   const [clientIdSaved, setClientIdSaved] = useState(false)
   const [verifying, setVerifying] = useState(false)
   const [verifyMsg, setVerifyMsg] = useState<string | null>(null)
+  const [presenceEnabled, setPresenceEnabled] = useState(false)
+  const [presenceShowClient, setPresenceShowClient] = useState(false)
 
   const refresh = useCallback(async () => {
     const res = await window.api.graph.status()
@@ -37,9 +43,23 @@ export function GraphAccountSection(): React.JSX.Element {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- #130: dauerhaft — asynchroner IPC-Abruf des Verbindungsstatus beim Mount, kein dedizierter Store
     void refresh()
     void window.api.settings.getAll().then((res) => {
-      if (res.ok) setClientId(res.data.graph_client_id ?? '')
+      if (res.ok) {
+        setClientId(res.data.graph_client_id ?? '')
+        setPresenceEnabled(res.data.presence_enabled === '1')
+        setPresenceShowClient(res.data.presence_show_client === '1')
+      }
     })
   }, [refresh])
+
+  async function onPresenceEnabled(v: boolean): Promise<void> {
+    setPresenceEnabled(v)
+    await window.api.settings.set('presence_enabled', v ? '1' : '0')
+  }
+
+  async function onPresenceShowClient(v: boolean): Promise<void> {
+    setPresenceShowClient(v)
+    await window.api.settings.set('presence_show_client', v ? '1' : '0')
+  }
 
   async function onConnect(): Promise<void> {
     setBusy(true)
@@ -132,6 +152,62 @@ export function GraphAccountSection(): React.JSX.Element {
             <p className="text-xs" style={{ color: 'var(--text3)' }}>
               {t('settings.graph.personalAccountNote')}
             </p>
+          )}
+
+          {/* Teams presence mirroring (#132) — work/school accounts only. */}
+          {!status?.personalAccount && (
+            <div
+              className="flex flex-col gap-2 rounded-lg border p-3"
+              style={{ borderColor: 'var(--card-border)' }}
+            >
+              <div className="flex items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-sm" style={{ color: 'var(--text)' }}>
+                    {t('settings.presence.enable')}
+                  </p>
+                  <p className="text-xs" style={{ color: 'var(--text3)' }}>
+                    {t('settings.presence.enableHint')}
+                  </p>
+                </div>
+                <Toggle checked={presenceEnabled} onChange={(v) => void onPresenceEnabled(v)} />
+              </div>
+              {presenceEnabled && (
+                <>
+                  {!status?.grantedScopes.some(
+                    (s) => s.toLowerCase() === PRESENCE_SCOPE.toLowerCase()
+                  ) && (
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="text-xs text-amber-300">
+                        {t('settings.presence.reconnectHint')}
+                      </p>
+                      <button
+                        type="button"
+                        onClick={() => void onConnect()}
+                        disabled={busy}
+                        className="rounded-lg border px-3 py-1.5 text-xs font-medium hover:bg-white/10 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                        style={{ borderColor: 'var(--card-border)', color: 'var(--text)' }}
+                      >
+                        {busy ? t('settings.graph.connecting') : t('settings.presence.reconnect')}
+                      </button>
+                    </div>
+                  )}
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="text-sm" style={{ color: 'var(--text)' }}>
+                        {t('settings.presence.showClient')}
+                      </p>
+                      <p className="text-xs" style={{ color: 'var(--text3)' }}>
+                        {t('settings.presence.showClientHint')}
+                      </p>
+                    </div>
+                    <Toggle
+                      checked={presenceShowClient}
+                      onChange={(v) => void onPresenceShowClient(v)}
+                    />
+                  </div>
+                </>
+              )}
+            </div>
           )}
 
           <div className="flex flex-wrap items-center gap-2">

--- a/src/shared/graphAuth.ts
+++ b/src/shared/graphAuth.ts
@@ -65,6 +65,13 @@ export const DEFAULT_CLIENT_ID = '734cb982-f7b7-4dbf-91b1-cf95470bcd2a'
  */
 export const CALENDAR_SCOPES = ['offline_access', 'openid', 'profile', 'Calendars.Read'] as const
 
+/**
+ * Delegated scope for Teams presence mirroring (#132). Requested only when the
+ * feature is enabled — scopes stay minimal per feature, so enabling presence
+ * on an existing connection requires reconnecting once for the extra consent.
+ */
+export const PRESENCE_SCOPE = 'Presence.ReadWrite'
+
 export function authorityBase(tenant: GraphTenant): string {
   return `https://login.microsoftonline.com/${encodeURIComponent(tenant)}`
 }

--- a/src/shared/locales/de.ts
+++ b/src/shared/locales/de.ts
@@ -638,6 +638,16 @@ export const de = {
   'settings.mcp.auditLogHint':
     'Jede ausgeführte Schreibaktion wird in mcp-writes.log protokolliert.',
   'settings.mcp.openAuditLog': 'Log-Ordner öffnen',
+  // v1.17 #132 — Teams-Presence spiegeln
+  'settings.presence.enable': 'Teams-Status spiegeln',
+  'settings.presence.enableHint':
+    'Setzt dich bei laufendem Timer in Teams auf Beschäftigt (rot) und hinterlegt eine Statusmeldung („🔴 Fokus …") — beim Stoppen wird beides entfernt. Ein manuell gesetzter Status hat Vorrang. Nur mit Arbeits-/Schulkonto; Fehler beeinflussen den Timer nie.',
+  'settings.presence.showClient': 'Kundennamen im Status anzeigen',
+  'settings.presence.showClientHint':
+    'Aus: nur „🔴 Fokus". An: „🔴 Fokus: Kunde — Projekt". Der Text ist für Kolleg:innen sichtbar.',
+  'settings.presence.reconnectHint':
+    'Für den Teams-Status fehlt noch die Berechtigung (Presence.ReadWrite) — einmal neu verbinden.',
+  'settings.presence.reconnect': 'Erneut verbinden',
   // v1.17 #133 — Hardware-Tasten (Stream Deck & Co.)
   'settings.controller.title': 'Hardware-Tasten',
   'settings.controller.enable': 'Hardware-Tasten erlauben',

--- a/src/shared/locales/en.ts
+++ b/src/shared/locales/en.ts
@@ -629,6 +629,16 @@ export const en: Record<TranslationKey, string> = {
   'settings.mcp.auditLog': 'Audit log',
   'settings.mcp.auditLogHint': 'Every executed write action is logged to mcp-writes.log.',
   'settings.mcp.openAuditLog': 'Open log folder',
+  // v1.17 #132 — Teams presence mirroring
+  'settings.presence.enable': 'Mirror Teams status',
+  'settings.presence.enableHint':
+    'Sets you to Busy (red) in Teams while a timer runs and adds a status message ("🔴 Focus …") — both are removed on stop. A manually set status takes precedence. Work/school accounts only; failures never affect the timer.',
+  'settings.presence.showClient': 'Show client name in the status',
+  'settings.presence.showClientHint':
+    'Off: just "🔴 Focus". On: "🔴 Focus: client — project". The text is visible to colleagues.',
+  'settings.presence.reconnectHint':
+    'The Teams status still needs its permission (Presence.ReadWrite) — reconnect once.',
+  'settings.presence.reconnect': 'Reconnect',
   // v1.17 #133 — hardware keys (Stream Deck & co.)
   'settings.controller.title': 'Hardware keys',
   'settings.controller.enable': 'Allow hardware keys',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -208,6 +208,11 @@ export interface Settings {
   // migration 023. Gates the controller ops on the local write bridge; the
   // controller token file is separate from the MCP write token.
   controller_enabled?: string
+  // v1.17 #132 — Teams presence mirroring (migration 024). Work/school
+  // accounts only; presence_show_client gates whether the status message
+  // names the client (default generic).
+  presence_enabled?: string
+  presence_show_client?: string
 }
 
 export interface CreateClientInput {


### PR DESCRIPTION
## Summary

Teams presence mirroring (closes #132): while a timer runs, the user shows as
**Busy (red)** in Teams with a status message ("🔴 Fokus" or, opt-in,
"🔴 Fokus: client — project"); both are removed when the timer stops.
Work/school accounts only — Microsoft Graph's presence APIs are
"Not supported." for personal accounts.

### State-driven reconciler, not event hooks

`src/main/graphPresence.ts` reconciles the desired Teams state with the last
state it applied, and is poked from the `tray:update` choke point — which
fires on every timer change from every source (UI, tray, hotkey, mini-widget,
idle handlers, and external writes via the renderer resync from #180). An
event-hook design would have missed timer stops that happen through
`entries:update` (the idle handlers) — the reconciler cannot, because it
derives everything from the current running entry.

Properties:

- **Ownership rule:** it only ever clears a message it set itself. A manually
  set Teams status is never touched; disabling the feature withdraws at most
  our own message. Teams' own aggregation adds a second guarantee: a
  user-preferred state always beats app sessions.
- **Idempotent and retrying:** unchanged state → no Graph call; failed calls
  are not marked applied, so the next poke retries. Failures are logged and
  swallowed — presence can never affect the timer.
- **Two Graph primitives** (verified against the live v1.0 docs): a
  `setStatusMessage` for the text and a `setPresence` session
  (`Busy/InACall`, the only plain-"red" combination the API accepts —
  `DoNotDisturb/Presenting` would suppress the user's notifications). The
  session runs on the app's client id, expires after 1 h and is renewed every
  ~25 min by the existing 30-second heartbeat pokes. Stop clears both
  (`clearPresence` 404 = already gone, counts as cleared).
- **Safety nets:** the message carries a 12 h expiry and the session 1 h — a
  killed app cannot leave a stale "Fokus" standing.
- **Read-back verification:** after every write the reconciler reads the
  presence back and logs what Graph actually stored — a 200 OK alone is a
  claim, not evidence. (This turned out to matter: clearing via empty content
  is community practice, not documented contract; the read-back plus the
  hand-test proved it works.)

### Minimal scopes

`Presence.ReadWrite` is only requested once mirroring is enabled — a
calendar-only user keeps consenting to nothing but `Calendars.Read`. Enabling
the feature on an existing connection shows a reconnect hint in the settings;
one re-consent later the toggle works.

### Settings & UI

`presence_enabled` and `presence_show_client` (migration 024, both off — no
client name leaves the machine without an explicit opt-in). The controls live
inside the Microsoft-account block (Settings → Integrations) and only render
for connected work/school accounts.

## Verification

- 13 new unit tests on the reconciler (idempotence, ownership/clear-once
  semantics, Busy session shape, 25-minute renewal, 404-tolerant clear,
  account/scope gates, retry after failure, privacy switch, never-throws);
  suite total 896 passed / 0 skipped.
- Settings UI hand-tested in both states (disconnected: block hidden;
  connected work account: block visible) via CDP against the built app.
- Live hand-test by the owner: dot turns red on start, status message
  appears, both revert on stop — confirmed visually in Teams and by the
  read-back log (`availability=Busy statusMessage="🔴 Fokus"` →
  `availability=Available statusMessage=""`).

## Known limitations

- Teams aggregates presence sessions: the app's Busy only wins against
  "weaker" states (DoNotDisturb > Busy > Available > Away). A manually set
  status always has precedence — by design.
- If the app is killed mid-timer, the red state survives up to the session
  expiry (≤ 1 h) and the message up to 12 h; a normal stop clears both
  immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
