### PR TITLE
feat(#186): timer dial — encoder action for the Stream Deck +

### DIFF
--- a/src/main/dashboardTotals.test.ts
+++ b/src/main/dashboardTotals.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for the shared today/week totals (#186).
+ *
+ * Two jobs: pin the window semantics (running entry counts, entries outside
+ * the window do not), and pin the numbers against the *other* copy of the same
+ * definition — `getDashboard()` in the read-only MCP layer. Both are read by
+ * different surfaces; if one is ever changed alone, this goes red instead of
+ * the dial quietly disagreeing with the app.
+ */
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import type Database from 'better-sqlite3'
+import { applyMigrations, loadSqlite, type DatabaseCtor } from '../test/sqlite'
+import { readRoundMinutes, readTotals } from './dashboardTotals'
+import { getDashboard, type SqliteDb } from '../mcp/queries'
+
+let DatabaseImpl: DatabaseCtor
+
+beforeAll(async () => {
+  DatabaseImpl = await loadSqlite()
+})
+
+function iso(msFromNow: number): string {
+  return new Date(Date.now() + msFromNow).toISOString()
+}
+
+/** Local-midnight-safe: a date N days back at 10:00 local time. */
+function daysAgoAt10(days: number): Date {
+  const d = new Date()
+  d.setDate(d.getDate() - days)
+  d.setHours(10, 0, 0, 0)
+  return d
+}
+
+function addClosed(db: Database.Database, startedAt: string, minutes: number): void {
+  db.prepare(
+    `INSERT INTO entries (client_id, description, started_at, stopped_at, billable)
+     VALUES (1, 'x', ?, ?, 1)`
+  ).run(startedAt, new Date(Date.parse(startedAt) + minutes * 60_000).toISOString())
+}
+
+describe('readTotals', () => {
+  let db: Database.Database
+
+  beforeEach(() => {
+    db = new DatabaseImpl(':memory:')
+    db.pragma('foreign_keys = ON')
+    applyMigrations(db)
+    db.prepare(
+      `INSERT INTO clients (id, name, color, active, rate_cent) VALUES (1,'Acme','#111',1,0)`
+    ).run()
+  })
+
+  it('is zero on an empty database', () => {
+    expect(readTotals(db)).toEqual({ today_seconds: 0, week_seconds: 0 })
+  })
+
+  it('sums closed entries of today into both windows', () => {
+    addClosed(db, iso(-3 * 3_600_000), 30)
+    addClosed(db, iso(-2 * 3_600_000), 15)
+    const t = readTotals(db)
+    expect(t.today_seconds).toBe(45 * 60)
+    expect(t.week_seconds).toBe(45 * 60)
+  })
+
+  it('counts a running entry up to now, in both windows', () => {
+    db.prepare(
+      `INSERT INTO entries (client_id, description, started_at, billable)
+       VALUES (1, 'running', ?, 1)`
+    ).run(iso(-600_000))
+    const t = readTotals(db)
+    expect(t.today_seconds).toBeGreaterThanOrEqual(600)
+    expect(t.today_seconds).toBeLessThan(660)
+    expect(t.week_seconds).toBe(t.today_seconds)
+  })
+
+  it('counts a running entry started before midnight — the cross-midnight case', () => {
+    const yesterdayEvening = daysAgoAt10(1)
+    yesterdayEvening.setHours(22, 0, 0, 0)
+    db.prepare(
+      `INSERT INTO entries (client_id, description, started_at, billable)
+       VALUES (1, 'overnight', ?, 1)`
+    ).run(yesterdayEvening.toISOString())
+    // `OR stopped_at IS NULL` puts it in today's window even though it started
+    // yesterday — the app, the tray and the dial all show it that way.
+    expect(readTotals(db).today_seconds).toBeGreaterThan(8 * 3600)
+  })
+
+  it('excludes deleted entries and entries older than the week window', () => {
+    addClosed(db, daysAgoAt10(0).toISOString(), 60)
+    addClosed(db, daysAgoAt10(30).toISOString(), 120)
+    db.prepare(
+      `INSERT INTO entries (client_id, description, started_at, stopped_at, billable, deleted_at)
+       VALUES (1, 'trash', ?, ?, 1, ?)`
+    ).run(iso(-7_200_000), iso(-3_600_000), iso(0))
+
+    const t = readTotals(db)
+    expect(t.today_seconds).toBe(60 * 60)
+    expect(t.week_seconds).toBe(60 * 60)
+  })
+
+  it('week ≥ today whenever both windows are populated', () => {
+    addClosed(db, daysAgoAt10(0).toISOString(), 45)
+    // Two days back is inside the window on most weekdays; either way the
+    // invariant week ≥ today must hold.
+    addClosed(db, daysAgoAt10(2).toISOString(), 90)
+    const t = readTotals(db)
+    expect(t.week_seconds).toBeGreaterThanOrEqual(t.today_seconds)
+  })
+
+  it('readRoundMinutes: off unless the setting holds a positive number', () => {
+    const set = (v: string): void => {
+      db.prepare(
+        `INSERT OR REPLACE INTO settings (key, value) VALUES ('pdf_round_minutes', ?)`
+      ).run(v)
+    }
+    // Unset ⇒ no rounding.
+    expect(readRoundMinutes(db)).toBe(0)
+    set('15')
+    expect(readRoundMinutes(db)).toBe(15)
+    set('0')
+    expect(readRoundMinutes(db)).toBe(0)
+    // Garbage must not switch rounding on — same tolerance as the renderer's
+    // parseInt in RoundingContext.
+    set('abc')
+    expect(readRoundMinutes(db)).toBe(0)
+    set('-5')
+    expect(readRoundMinutes(db)).toBe(0)
+  })
+
+  it('agrees with getDashboard() — the second copy of the same definition', () => {
+    addClosed(db, daysAgoAt10(0).toISOString(), 45)
+    addClosed(db, daysAgoAt10(2).toISOString(), 90)
+    addClosed(db, daysAgoAt10(20).toISOString(), 30)
+    db.prepare(
+      `INSERT INTO entries (client_id, description, started_at, billable)
+       VALUES (1, 'running', ?, 1)`
+    ).run(iso(-120_000))
+
+    const mine = readTotals(db)
+    const theirs = getDashboard(
+      db as unknown as SqliteDb,
+      { exposeRates: false, exposePrivateNotes: false },
+      Date.now()
+    )
+    expect(mine.today_seconds).toBe(theirs.today_seconds)
+    expect(mine.week_seconds).toBe(theirs.week_seconds)
+  })
+})

--- a/src/main/dashboardTotals.ts
+++ b/src/main/dashboardTotals.ts
@@ -1,0 +1,85 @@
+/**
+ * Hours today / this week — the two numbers the "Heute" view shows as stat
+ * cards, and the same two the Stream Deck dial shows on its ambient face
+ * (#186).
+ *
+ * Electron-free and DB-injected, so both callers read from ONE definition:
+ * the `dashboard:summary` IPC handler (app window) and the controller scope of
+ * the write bridge (`get_summary`). "The dial shows what the main page shows"
+ * is then true by construction instead of by assertion.
+ */
+import type Database from 'better-sqlite3'
+
+type Db = Database.Database
+
+/** Seconds of an entry; a running one counts up to now. */
+const SECONDS = `CASE
+       WHEN stopped_at IS NULL
+         THEN CAST(strftime('%s', 'now') AS INTEGER) - CAST(strftime('%s', started_at) AS INTEGER)
+       ELSE CAST(strftime('%s', stopped_at) AS INTEGER) - CAST(strftime('%s', started_at) AS INTEGER)
+     END`
+
+/**
+ * Start of the week window, carried over verbatim from the IPC handler.
+ *
+ * NB: `weekday 0` advances to the *coming* Sunday, so minus seven days lands
+ * on the most recent Sunday — the window therefore starts on SUNDAY, despite
+ * the "ISO week — Monday as first day" comment that used to sit above it.
+ * Kept unchanged on purpose: correcting it would move a number the app has
+ * shown since v1.2, which is a product decision, not a refactor.
+ */
+const WEEK_START = `DATE('now', 'localtime', 'weekday 0', '-7 days')`
+
+export interface DayWeekTotals {
+  today_seconds: number
+  week_seconds: number
+}
+
+/**
+ * The rounding step the app applies before *showing* a duration
+ * (`pdf_round_minutes`, ceiling arithmetic — see `roundDuration`). 0 = off.
+ *
+ * The stat cards on the "Heute" page round; the raw seconds stay in the
+ * payload. Any surface that wants to show the same number as the app has to
+ * round the same way, which is what tripped up the first version of the dial:
+ * 6:24 raw against 6:30 on screen at a 15-minute step.
+ */
+export function readRoundMinutes(db: Db): number {
+  const row = db.prepare(`SELECT value FROM settings WHERE key = 'pdf_round_minutes'`).get() as
+    | { value: string }
+    | undefined
+  const n = parseInt(row?.value ?? '0', 10)
+  return Number.isFinite(n) && n > 0 ? n : 0
+}
+
+/**
+ * Both totals in one read. A running entry is always included in both windows
+ * (`OR stopped_at IS NULL`) even when it was started before midnight — that is
+ * what makes the tray, the stat cards and the dial agree while a timer runs.
+ */
+export function readTotals(db: Db): DayWeekTotals {
+  const today = db
+    .prepare(
+      `SELECT COALESCE(SUM(${SECONDS}), 0) AS seconds
+         FROM entries
+        WHERE deleted_at IS NULL
+          AND (DATE(started_at, 'localtime') = DATE('now', 'localtime')
+               OR stopped_at IS NULL)`
+    )
+    .get() as { seconds: number }
+
+  const week = db
+    .prepare(
+      `SELECT COALESCE(SUM(${SECONDS}), 0) AS seconds
+         FROM entries
+        WHERE deleted_at IS NULL
+          AND (DATE(started_at, 'localtime') >= ${WEEK_START}
+               OR stopped_at IS NULL)`
+    )
+    .get() as { seconds: number }
+
+  return {
+    today_seconds: Math.max(0, Math.floor(today.seconds ?? 0)),
+    week_seconds: Math.max(0, Math.floor(week.seconds ?? 0))
+  }
+}

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -23,6 +23,7 @@ import { registerTagHandlers } from './tagHandlers'
 import { registerGraphHandlers } from './graphHandlers'
 import { feedUrl, generateFeedToken } from './icalFeed'
 import { buildMcpRegistration, type McpRegistration } from './mcpLaunch'
+import { readTotals } from './dashboardTotals'
 import type {
   Client,
   Entry,
@@ -537,43 +538,9 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
   ipcMain.handle('dashboard:summary', (): IpcResult<DashboardSummary> => {
     try {
       const tx = db.transaction((): DashboardSummary => {
-        const today = db
-          .prepare(
-            `SELECT COALESCE(SUM(
-               CASE
-                 WHEN stopped_at IS NULL
-                   THEN CAST(strftime('%s', 'now') AS INTEGER) - CAST(strftime('%s', started_at) AS INTEGER)
-                 ELSE CAST(strftime('%s', stopped_at) AS INTEGER) - CAST(strftime('%s', started_at) AS INTEGER)
-               END
-             ), 0) AS seconds
-             FROM entries
-             WHERE deleted_at IS NULL
-               AND (DATE(started_at, 'localtime') = DATE('now', 'localtime')
-                    OR stopped_at IS NULL)`
-          )
-          .get() as { seconds: number }
-
-        // ISO week — Monday as first day. SQLite's strftime('%w') returns
-        // 0=Sunday, so we shift to start the window from the most recent
-        // Monday at local midnight.
-        const week = db
-          .prepare(
-            `SELECT COALESCE(SUM(
-               CASE
-                 WHEN stopped_at IS NULL
-                   THEN CAST(strftime('%s', 'now') AS INTEGER) - CAST(strftime('%s', started_at) AS INTEGER)
-                 ELSE CAST(strftime('%s', stopped_at) AS INTEGER) - CAST(strftime('%s', started_at) AS INTEGER)
-               END
-             ), 0) AS seconds
-             FROM entries
-             WHERE deleted_at IS NULL
-               AND (
-                 DATE(started_at, 'localtime')
-                   >= DATE('now', 'localtime', 'weekday 0', '-7 days')
-                 OR stopped_at IS NULL
-               )`
-          )
-          .get() as { seconds: number }
+        // Today/week come from readTotals() so the stat cards, the tray and
+        // the Stream Deck dial can never drift apart (#186).
+        const totals = readTotals(db)
 
         const recentEntries = db
           .prepare(
@@ -615,8 +582,8 @@ export function registerIpcHandlers(hooks: IpcHooks): void {
         }>
 
         return {
-          todaySeconds: Math.max(0, Math.floor(today.seconds ?? 0)),
-          weekSeconds: Math.max(0, Math.floor(week.seconds ?? 0)),
+          todaySeconds: totals.today_seconds,
+          weekSeconds: totals.week_seconds,
           recentEntries,
           topClients30d: topClients30d.map((r) => ({
             ...r,

--- a/src/main/mcpBridgeCore.test.ts
+++ b/src/main/mcpBridgeCore.test.ts
@@ -340,6 +340,98 @@ describe('handleRequest — controller scope', () => {
     }
   })
 
+  it('get_summary: running timer plus today/week totals in one answer (#186)', async () => {
+    const { ctx } = makeCtx(db)
+    const idle = await handleRequest(ctx, ctl('get_summary'))
+    expect(idle.ok).toBe(true)
+    if (idle.ok) {
+      expect(idle.data).toEqual({
+        running: null,
+        today_seconds: 0,
+        week_seconds: 0,
+        round_minutes: 0,
+        today_display_seconds: 0,
+        week_display_seconds: 0
+      })
+    }
+
+    // One closed 30-minute entry today, then a running one.
+    const now = Date.now()
+    db.prepare(
+      `INSERT INTO entries (client_id, description, started_at, stopped_at, billable)
+       VALUES (1, 'closed', ?, ?, 1)`
+    ).run(new Date(now - 3_600_000).toISOString(), new Date(now - 1_800_000).toISOString())
+    await handleRequest(ctx, ctl('toggle_timer', { client_id: 1, project_id: 10 }))
+
+    const busy = await handleRequest(ctx, ctl('get_summary'))
+    expect(busy.ok).toBe(true)
+    if (busy.ok) {
+      const data = busy.data as {
+        running: { client_id: number } | null
+        today_seconds: number
+        week_seconds: number
+      }
+      expect(data.running).toMatchObject({ client_id: 1, project_id: 10 })
+      // 30 min closed; the running entry adds ~0 s so far.
+      expect(data.today_seconds).toBeGreaterThanOrEqual(1800)
+      expect(data.today_seconds).toBeLessThan(1830)
+      expect(data.week_seconds).toBeGreaterThanOrEqual(data.today_seconds)
+    }
+  })
+
+  it('get_summary rounds the display seconds exactly like the app page', async () => {
+    // 6:24 of work at a 15-minute step is 6:30 on screen — the mismatch the
+    // dial showed on its first hardware run.
+    db.prepare(
+      `INSERT OR REPLACE INTO settings (key, value) VALUES ('pdf_round_minutes','15')`
+    ).run()
+    const started = new Date(Date.now() - (6 * 3600 + 24 * 60) * 1000).toISOString()
+    db.prepare(
+      `INSERT INTO entries (client_id, description, started_at, stopped_at, billable)
+       VALUES (1, 'x', ?, ?, 1)`
+    ).run(started, new Date().toISOString())
+
+    const { ctx } = makeCtx(db)
+    const res = await handleRequest(ctx, ctl('get_summary'))
+    expect(res.ok).toBe(true)
+    if (!res.ok) return
+    const data = res.data as {
+      today_seconds: number
+      today_display_seconds: number
+      week_display_seconds: number
+      round_minutes: number
+    }
+    expect(data.round_minutes).toBe(15)
+    expect(data.today_seconds).toBeGreaterThanOrEqual(6 * 3600 + 24 * 60)
+    expect(data.today_seconds).toBeLessThan(6 * 3600 + 25 * 60)
+    expect(data.today_display_seconds).toBe(6 * 3600 + 30 * 60)
+    expect(data.week_display_seconds).toBe(6 * 3600 + 30 * 60)
+  })
+
+  it('get_summary passes the raw seconds through when rounding is off', async () => {
+    const started = new Date(Date.now() - 3_600_000).toISOString()
+    db.prepare(
+      `INSERT INTO entries (client_id, description, started_at, stopped_at, billable)
+       VALUES (1, 'x', ?, ?, 1)`
+    ).run(started, new Date().toISOString())
+
+    const { ctx } = makeCtx(db)
+    const res = await handleRequest(ctx, ctl('get_summary'))
+    expect(res.ok).toBe(true)
+    if (!res.ok) return
+    const data = res.data as { today_seconds: number; today_display_seconds: number }
+    expect(data.today_display_seconds).toBe(data.today_seconds)
+  })
+
+  it('get_summary is read-only — no backup, no audit, no broadcast', async () => {
+    const { ctx, spies } = makeCtx(db)
+    await handleRequest(ctx, ctl('get_summary'))
+    expect(spies.backupCalls).toBe(0)
+    expect(spies.auditCalls).toBe(0)
+    expect(spies.changeCalls).toBe(0)
+    expect(countEntries(db)).toBe(0)
+  })
+
   it('toggle: start → stop on the same target', async () => {
     const { ctx, spies } = makeCtx(db)
     const start = await handleRequest(ctx, ctl('toggle_timer', { client_id: 1, project_id: 10 }))

--- a/src/main/mcpBridgeCore.ts
+++ b/src/main/mcpBridgeCore.ts
@@ -23,6 +23,8 @@ import type {
   CreateEntryInput
 } from '../shared/types'
 import type { McpAuditEntry } from './mcpAudit'
+import { readRoundMinutes, readTotals } from './dashboardTotals'
+import { roundDuration } from '../shared/duration'
 
 type Db = Database.Database
 
@@ -41,7 +43,12 @@ export type WriteOp = (typeof WRITE_OPS)[number]
  * confirmation, but an AI agent must never get that shortcut), and the
  * controller token cannot call the MCP write ops.
  */
-export const CONTROLLER_OPS = ['toggle_timer', 'get_timer_status', 'list_targets'] as const
+export const CONTROLLER_OPS = [
+  'toggle_timer',
+  'get_timer_status',
+  'list_targets',
+  'get_summary'
+] as const
 export type ControllerOp = (typeof CONTROLLER_OPS)[number]
 
 export interface BridgeRequest {
@@ -332,6 +339,30 @@ async function handleControllerRequest(
 
   if (op === 'get_timer_status') {
     return { ok: true, data: { running: readRunning(db) } }
+  }
+
+  // get_summary — everything the Stream Deck dial polls for its ambient face
+  // (#186) in ONE round trip: the running timer plus the two totals the app's
+  // "Heute" page shows. Superset of get_timer_status; that op stays for the
+  // key action, which does not need the totals.
+  //
+  // Raw *and* display seconds: the page shows the rounded value
+  // (`pdf_round_minutes`, ceiling), so a surface that renders the raw number
+  // disagrees with the app by up to one rounding step. Rounding here rather
+  // than in the plugin keeps the rule in one place.
+  if (op === 'get_summary') {
+    const totals = readTotals(db)
+    const round_minutes = readRoundMinutes(db)
+    return {
+      ok: true,
+      data: {
+        running: readRunning(db),
+        ...totals,
+        round_minutes,
+        today_display_seconds: roundDuration(totals.today_seconds, round_minutes),
+        week_display_seconds: roundDuration(totals.week_seconds, round_minutes)
+      }
+    }
   }
 
   if (op === 'list_targets') {

--- a/streamdeck-plugin/README.md
+++ b/streamdeck-plugin/README.md
@@ -1,8 +1,32 @@
-# TimeTrack Stream Deck plugin (#133)
+# TimeTrack Stream Deck plugin
 
-One key = one timer target. Each key is configured with a client (and optionally
-one of its projects) and toggles the TimeTrack timer for exactly that target.
-The key face shows the live timer state (polled every 2 s while visible).
+Two actions:
+
+**Toggle timer** (keypad, #133) — one key = one timer target. Each key is
+configured with a client (and optionally one of its projects) and toggles the
+TimeTrack timer for exactly that target. The key face shows the live timer
+state (polled every 2 s while visible).
+
+**Timer dial** (encoder, Stream Deck +, #186) — one dial reaches every target,
+no configuration at all:
+
+| Gesture | Effect |
+| --- | --- |
+| idle | today + this week, exactly the numbers the app's *Heute* page shows, plus the entry a press would start |
+| turn | walk the list of projects, and of clients that have none |
+| press (on release) | start the shown target — or stop it, if it is the one running |
+| press and hold (0.5 s) | start the same **client without a project** |
+| tap / long-tap the strip | same as short / long press |
+| while a timer runs | client, project, elapsed time, the minute ring and the pulse — the running face of the keys, on the strip |
+
+A client that has projects does **not** appear on its own in the list: its
+project-less timer is what the long press is for. That keeps the list as short
+as the number of things you actually book on.
+
+After a rotation the selection stays on screen for 4 s, then the ambient face
+comes back. The selection itself is remembered per dial (anchored by client and
+project id, not by position, so adding or archiving a project elsewhere does
+not move it).
 
 The plugin talks to the running TimeTrack app through the local control bridge
 (named pipe on Windows, unix socket on macOS) using the **controller token** —
@@ -41,8 +65,37 @@ the key surface while the plugin runs in the desktop app.
   `\\.\pipe\timetrack-mcp` (Windows) or `<userData>/mcp.sock` (macOS), token
   `<userData>/controller.token`, userData dir `time-tracking` (the Electron
   `app.getName()`, NOT `TimeTrack`).
-- Controller ops (`toggle_timer`, `get_timer_status`, `list_targets`) are
-  token-scoped separately from the MCP write ops — see
+- Controller ops (`toggle_timer`, `get_timer_status`, `list_targets`,
+  `get_summary`) are token-scoped separately from the MCP write ops — see
   `src/main/mcpBridgeCore.ts` in the app repo.
 - Timer labels are rendered into the SVG key image, not via `setTitle`: a
   user-defined title always beats a runtime title.
+- The dial's today/week numbers come from `readTotals()` in
+  `src/main/dashboardTotals.ts` — the same function the app's `dashboard:summary`
+  IPC handler uses, so the strip cannot drift away from the app window.
+  `get_summary` sends the raw seconds **and** the display seconds (raw rounded
+  up to `pdf_round_minutes`, the same rounding the stat cards apply). The strip
+  shows the display ones; showing the raw ones is what made the first hardware
+  run read 6:24 against the app's 6:30. An app older than that answers without
+  those fields — `displayTotals()` then falls back to raw, because plugin and
+  app are installed separately and can be out of step.
+- The touch strip is one full-bleed SVG in the layout's single `canvas` pixmap,
+  not a set of text items: the faces place their text differently per state and
+  a layout cannot switch geometry. Feedback keys are a contract with
+  `layouts/dial.json` — a key the layout does not know is dropped **silently**,
+  which on the device is indistinguishable from a broken plugin, so
+  `dialImage.test.ts` checks both sides against each other.
+- Hardware rules are the same on both surfaces: one static frame per render, no
+  SMIL, no `pathLength`. The ring and the pulse are advanced frame-by-frame by a
+  1 Hz tick, and `setFeedback`/`setImage` only run when the rendered frame
+  actually changed.
+
+## Tests
+
+The pure modules (`dialModel.ts`, `dialImage.ts` and the layout contract) run in
+the app repo's suite as the `streamdeck` project:
+
+```
+pnpm test                          # in the repo root — includes this project
+pnpm test -- --project streamdeck  # only these
+```

--- a/streamdeck-plugin/com.timetrack.streamdeck.sdPlugin/layouts/dial.json
+++ b/streamdeck-plugin/com.timetrack.streamdeck.sdPlugin/layouts/dial.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://schemas.elgato.com/streamdeck/plugins/layout.json",
+  "id": "dial",
+  "items": [
+    {
+      "key": "canvas",
+      "type": "pixmap",
+      "rect": [0, 0, 200, 100],
+      "zOrder": 0,
+      "value": ""
+    }
+  ]
+}

--- a/streamdeck-plugin/com.timetrack.streamdeck.sdPlugin/manifest.json
+++ b/streamdeck-plugin/com.timetrack.streamdeck.sdPlugin/manifest.json
@@ -2,9 +2,9 @@
   "$schema": "https://schemas.elgato.com/streamdeck/plugins/manifest.json",
   "UUID": "com.timetrack.streamdeck",
   "Name": "TimeTrack",
-  "Version": "0.1.0.0",
+  "Version": "0.2.0.0",
   "Author": "wald-it",
-  "Description": "Start and stop TimeTrack timers per client and project with one key. Requires the TimeTrack app with hardware keys enabled (Settings → Integrations).",
+  "Description": "Start and stop TimeTrack timers per client and project — with a key, or with the Stream Deck + dial. Requires the TimeTrack app with hardware keys enabled (Settings → Integrations).",
   "Category": "TimeTrack",
   "CategoryIcon": "imgs/plugin",
   "Icon": "imgs/plugin",
@@ -27,6 +27,25 @@
       "Tooltip": "Toggle the TimeTrack timer for a client (and project).",
       "Icon": "imgs/toggle",
       "PropertyInspectorPath": "ui/toggle-timer.html",
+      "Controllers": ["Keypad"],
+      "UserTitleEnabled": false,
+      "States": [{ "Image": "imgs/toggle" }]
+    },
+    {
+      "UUID": "com.timetrack.streamdeck.dial",
+      "Name": "Timer dial",
+      "Tooltip": "Turn to pick a client or project, press to start or stop the timer.",
+      "Icon": "imgs/toggle",
+      "Controllers": ["Encoder"],
+      "Encoder": {
+        "layout": "layouts/dial.json",
+        "TriggerDescription": {
+          "Rotate": "Pick a client or project",
+          "Push": "short: start / stop · long: client without project",
+          "Touch": "Start / stop",
+          "LongTouch": "Client without project"
+        }
+      },
       "UserTitleEnabled": false,
       "States": [{ "Image": "imgs/toggle" }]
     }

--- a/streamdeck-plugin/src/actions/timer-dial.ts
+++ b/streamdeck-plugin/src/actions/timer-dial.ts
@@ -1,0 +1,360 @@
+/**
+ * "Timer dial" encoder action (#186) — Stream Deck + wheel and touch strip.
+ *
+ * Idle the slot shows the two numbers from TimeTrack's "Heute" page; turning
+ * the wheel walks the client/project list; a press starts (or stops) the
+ * shown target; a long press starts the same client *without* a project,
+ * which is why clients that have projects do not appear on their own.
+ *
+ * All state comes from the app's local bridge — the plugin never reads the
+ * database. Polling, not pushing: the bridge is request/response.
+ */
+import { action, SingletonAction } from '@elgato/streamdeck'
+import streamDeck from '@elgato/streamdeck'
+import type {
+  DialAction,
+  DialDownEvent,
+  DialRotateEvent,
+  DialUpEvent,
+  TouchTapEvent,
+  WillAppearEvent,
+  WillDisappearEvent
+} from '@elgato/streamdeck'
+import { getSummary, listTargets, toggleTimer, type Summary } from '../bridge'
+import { dialImage, FEEDBACK_KEY, type DialFace, type DialLabel } from '../dialImage'
+import {
+  buildTargets,
+  clientOnly,
+  createPressGesture,
+  displayTotals,
+  elapsedSeconds,
+  indexOfKey,
+  isRunning,
+  step,
+  type DialTarget,
+  type PressGesture
+} from '../dialModel'
+
+export type DialSettings = {
+  /** Selected entry, anchored by key so the list can change underneath it. */
+  selected?: string
+  [key: string]: string | number | null | undefined
+}
+
+/** Bridge poll for the running timer and the totals. */
+const POLL_MS = 2000
+/** The list of clients/projects changes rarely; no reason to poll it as often. */
+const TARGETS_MS = 30_000
+/** Render tick — advances the ring and the elapsed time between polls. */
+const RENDER_TICK_MS = 1000
+/** How long the wheel stays on the selection before falling back to the stats. */
+const BROWSE_MS = 4000
+/** Held longer than this ⇒ start the client without a project. */
+const LONG_PRESS_MS = 500
+/** Rotations arrive in bursts; do not write settings on every tick. */
+const SAVE_DELAY_MS = 400
+
+interface DialState {
+  index: number
+  /** Selection is shown until this timestamp, then the stats come back. */
+  browseUntil: number
+  gesture: PressGesture
+  saveTimer: NodeJS.Timeout | null
+  /** Current selection; null until the wheel was turned (then settings rule). */
+  selectedKey: string | null
+  /** Selection key waiting to be written; flushed if the dial disappears. */
+  pending: string | null
+  /**
+   * The dial instance, kept for the flush on disappear: `willDisappear` hands
+   * out an ActionContext, which cannot write settings.
+   */
+  dial: DialAction<DialSettings> | null
+  lastRenderKey: string
+}
+
+@action({ UUID: 'com.timetrack.streamdeck.dial' })
+export class TimerDial extends SingletonAction<DialSettings> {
+  private pollTimer: NodeJS.Timeout | null = null
+  private targetsTimer: NodeJS.Timeout | null = null
+  private renderTimer: NodeJS.Timeout | null = null
+  /** Shared across dials — one bridge answer feeds every visible slot. */
+  private summary: Summary | 'unavailable' = 'unavailable'
+  private targets: DialTarget[] = []
+  private states = new Map<string, DialState>()
+
+  override async onWillAppear(ev: WillAppearEvent<DialSettings>): Promise<void> {
+    if (!ev.action.isDial()) return
+    this.ensureState(ev.action.id, ev.action)
+    this.ensureTimers()
+    await this.refreshTargets()
+    await this.refreshSummary()
+  }
+
+  override async onWillDisappear(ev: WillDisappearEvent<DialSettings>): Promise<void> {
+    const state = this.states.get(ev.action.id)
+    if (state) {
+      // Send the debounced write NOW instead of dropping it: turning the wheel
+      // and immediately switching profile would otherwise lose the selection.
+      // The action is gone from `this.actions`, but settings are addressed by
+      // context, and Stream Deck stores them for an invisible instance too.
+      if (state.saveTimer) {
+        clearTimeout(state.saveTimer)
+        state.saveTimer = null
+        if (state.pending && state.dial) await state.dial.setSettings({ selected: state.pending })
+      }
+      state.gesture.cancel()
+      this.states.delete(ev.action.id)
+    }
+    // Enumerable has no cheap "size"; stop the timers when nothing is left.
+    let any = false
+    for (const _ of this.actions) {
+      any = true
+      break
+    }
+    if (!any) this.stopTimers()
+  }
+
+  override async onDialRotate(ev: DialRotateEvent<DialSettings>): Promise<void> {
+    const state = this.ensureState(ev.action.id, ev.action)
+    // Turning while pressed is a different gesture — nothing may start when
+    // the wheel is released.
+    state.gesture.cancel()
+    if (this.targets.length === 0) {
+      await this.render(ev.action, state)
+      return
+    }
+    state.index = step(state.index, ev.payload.ticks, this.targets.length)
+    state.browseUntil = Date.now() + BROWSE_MS
+    this.persist(ev.action, state)
+    await this.render(ev.action, state)
+  }
+
+  override onDialDown(ev: DialDownEvent<DialSettings>): void {
+    const state = this.ensureState(ev.action.id, ev.action)
+    state.gesture.down()
+  }
+
+  override async onDialUp(ev: DialUpEvent<DialSettings>): Promise<void> {
+    const state = this.ensureState(ev.action.id, ev.action)
+    if (state.gesture.up()) await this.toggle(ev.action, state, false)
+  }
+
+  override async onTouchTap(ev: TouchTapEvent<DialSettings>): Promise<void> {
+    const state = this.ensureState(ev.action.id, ev.action)
+    // The touch strip reports the hold itself, so the strip needs no timer of
+    // its own — but it means the same thing as on the wheel.
+    await this.toggle(ev.action, state, ev.payload.hold === true)
+  }
+
+  // ── actions ──────────────────────────────────────────────────────────────
+
+  /**
+   * Toggle the selected target, or — on a long press — the same client
+   * without a project. Toggle, not start: pressing the entry that is already
+   * running stops it, exactly like the keys.
+   */
+  private async toggle(
+    dial: DialAction<DialSettings>,
+    state: DialState,
+    long: boolean
+  ): Promise<void> {
+    const selected = this.targets[state.index]
+    if (!selected) {
+      await dial.showAlert()
+      return
+    }
+    const target = long ? clientOnly(selected) : selected
+    const res = await toggleTimer(target.clientId, target.projectId)
+    if (!res.ok) {
+      streamDeck.logger.warn(`dial toggle failed: ${res.error}`)
+      await dial.showAlert()
+      return
+    }
+    // Straight back to the ambient face: after a press the interesting thing
+    // is the running timer, not the list position.
+    state.browseUntil = 0
+    await this.refreshSummary()
+  }
+
+  // ── polling ──────────────────────────────────────────────────────────────
+
+  private ensureTimers(): void {
+    if (!this.pollTimer) this.pollTimer = setInterval(() => void this.refreshSummary(), POLL_MS)
+    if (!this.targetsTimer) {
+      this.targetsTimer = setInterval(() => void this.refreshTargets(), TARGETS_MS)
+    }
+    if (!this.renderTimer) {
+      this.renderTimer = setInterval(() => void this.renderAll(), RENDER_TICK_MS)
+    }
+  }
+
+  private stopTimers(): void {
+    for (const t of [this.pollTimer, this.targetsTimer, this.renderTimer]) {
+      if (t) clearInterval(t)
+    }
+    this.pollTimer = null
+    this.targetsTimer = null
+    this.renderTimer = null
+  }
+
+  private async refreshSummary(): Promise<void> {
+    this.summary = await getSummary()
+    await this.renderAll()
+  }
+
+  private async refreshTargets(): Promise<void> {
+    const clients = await listTargets()
+    // A failed call keeps the previous list: the offline face is driven by the
+    // summary poll, and dropping the list would also drop the selection.
+    if (clients === null) return
+    this.targets = buildTargets(clients)
+    // Re-anchor every dial on its key — a project added or archived above the
+    // selection must not slide it onto a neighbour.
+    for (const a of this.actions) {
+      if (!a.isDial()) continue
+      const state = this.ensureState(a.id, a)
+      // Live selection first, stored one only until the wheel has been turned:
+      // reading settings here would otherwise undo a rotation whose debounced
+      // write has not landed yet.
+      const key = state.selectedKey ?? (await a.getSettings()).selected
+      state.index = indexOfKey(this.targets, key)
+    }
+  }
+
+  // ── rendering ────────────────────────────────────────────────────────────
+
+  private async renderAll(): Promise<void> {
+    for (const a of this.actions) {
+      if (!a.isDial()) continue
+      await this.render(a, this.ensureState(a.id))
+    }
+  }
+
+  private async render(dial: DialAction<DialSettings>, state: DialState): Promise<void> {
+    const face = this.faceFor(state)
+    // setFeedback only on change — an idle slot costs nothing per tick.
+    const key = renderKey(face)
+    if (state.lastRenderKey === key) return
+    state.lastRenderKey = key
+    await dial.setFeedback({ [FEEDBACK_KEY]: dialImage(face) })
+  }
+
+  private faceFor(state: DialState): DialFace {
+    if (this.summary === 'unavailable') return { state: 'offline' }
+    const selected = this.targets[state.index]
+    const running = this.summary.running
+    const browsing = Date.now() < state.browseUntil
+
+    if (browsing && selected) {
+      return {
+        state: 'browse',
+        label: labelOf(selected),
+        position: `${state.index + 1}/${this.targets.length}`,
+        progress: this.targets.length < 2 ? 1 : state.index / (this.targets.length - 1),
+        color: selected.color,
+        running: isRunning(selected, running)
+      }
+    }
+
+    if (running) {
+      return {
+        state: 'running',
+        label: { client: running.client_name, project: running.project_name },
+        elapsedSec: elapsedSeconds(running.started_at, Date.now()),
+        // The running timer may point somewhere the wheel is not on; take the
+        // colour from the matching entry, not from the selection.
+        color: this.colorForRunning(running.client_id)
+      }
+    }
+
+    if (!selected) return { state: 'empty' }
+
+    // Display seconds, not raw: the stat cards in the app are rounded.
+    const totals = displayTotals(this.summary)
+    return {
+      state: 'stats',
+      todaySeconds: totals.today,
+      weekSeconds: totals.week,
+      label: labelOf(selected),
+      position: `${state.index + 1}/${this.targets.length}`,
+      color: selected.color
+    }
+  }
+
+  private colorForRunning(clientId: number): string | undefined {
+    return this.targets.find((t) => t.clientId === clientId)?.color
+  }
+
+  // ── plumbing ─────────────────────────────────────────────────────────────
+
+  private ensureState(id: string, dial?: DialAction<DialSettings>): DialState {
+    let state = this.states.get(id)
+    if (state) {
+      if (dial) state.dial = dial
+      return state
+    }
+    state = {
+      index: 0,
+      browseUntil: 0,
+      dial: dial ?? null,
+      // The long action fires on reaching the threshold, not on release —
+      // the timer starts in the moment you have held long enough, which is
+      // the only feedback that the gesture registered.
+      gesture: createPressGesture(() => void this.onLongPress(id), LONG_PRESS_MS),
+      saveTimer: null,
+      selectedKey: null,
+      pending: null,
+      lastRenderKey: ''
+    }
+    this.states.set(id, state)
+    return state
+  }
+
+  /** Resolved late: the dial instance is not known when the state is built. */
+  private async onLongPress(id: string): Promise<void> {
+    for (const a of this.actions) {
+      if (a.id !== id || !a.isDial()) continue
+      await this.toggle(a, this.ensureState(id), true)
+      return
+    }
+  }
+
+  /** Rotations arrive in bursts — one write per burst, not one per tick. */
+  private persist(dial: DialAction<DialSettings>, state: DialState): void {
+    const target = this.targets[state.index]
+    if (!target) return
+    state.selectedKey = target.key
+    state.pending = target.key
+    if (state.saveTimer) clearTimeout(state.saveTimer)
+    state.saveTimer = setTimeout(() => {
+      state.saveTimer = null
+      const key = state.pending
+      state.pending = null
+      if (key) void dial.setSettings({ selected: key })
+    }, SAVE_DELAY_MS)
+  }
+}
+
+function labelOf(t: DialTarget): DialLabel {
+  return { client: t.clientName, project: t.projectName }
+}
+
+/**
+ * Identity of a rendered frame. Everything the face draws has to appear here —
+ * a value that changes without changing the key would freeze on the strip.
+ */
+export function renderKey(face: DialFace): string {
+  switch (face.state) {
+    case 'offline':
+      return 'offline'
+    case 'empty':
+      return 'empty'
+    case 'running':
+      // Per second: the ring advances and the pulse breathes.
+      return `running|${Math.floor(face.elapsedSec)}|${face.label.client}|${face.label.project ?? ''}|${face.color ?? ''}`
+    case 'browse':
+      return `browse|${face.position}|${face.label.client}|${face.label.project ?? ''}|${face.color ?? ''}|${face.running}`
+    default:
+      return `stats|${face.todaySeconds}|${face.weekSeconds}|${face.position}|${face.label?.client ?? ''}|${face.label?.project ?? ''}|${face.color ?? ''}`
+  }
+}

--- a/streamdeck-plugin/src/bridge.ts
+++ b/streamdeck-plugin/src/bridge.ts
@@ -127,6 +127,37 @@ export async function getTimerStatus(): Promise<RunningTimer | null | 'unavailab
   return (res.data as { running: RunningTimer | null }).running
 }
 
+/**
+ * One round trip for everything the dial's ambient face needs (#186): the
+ * running timer plus the two totals the app's "Heute" page shows. Both come
+ * from one read so they can never describe different moments.
+ */
+export interface Summary {
+  running: RunningTimer | null
+  /** Raw seconds. */
+  today_seconds: number
+  week_seconds: number
+  /**
+   * Rounding step the app applies before showing a duration; 0 = off.
+   * Optional: an app older than #186's fix does not send these fields — see
+   * `displayTotals()` for the fallback.
+   */
+  round_minutes?: number
+  /**
+   * What the app's "Heute" page puts on screen: raw, rounded up to
+   * `round_minutes`. The dial shows these — rendering the raw seconds made it
+   * disagree with the app by up to one rounding step (6:24 vs. 6:30).
+   */
+  today_display_seconds?: number
+  week_display_seconds?: number
+}
+
+export async function getSummary(): Promise<Summary | 'unavailable'> {
+  const res = await sendRequest('get_summary')
+  if (!res.ok) return 'unavailable'
+  return res.data as Summary
+}
+
 export async function listTargets(): Promise<TargetClient[] | null> {
   const res = await sendRequest('list_targets')
   if (!res.ok) return null

--- a/streamdeck-plugin/src/dialImage.test.ts
+++ b/streamdeck-plugin/src/dialImage.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Tests for the touch-strip faces (#186).
+ *
+ * The device rasterizes what it gets and reports nothing back, so the checks
+ * here are the ones that would otherwise only fail silently on the hardware:
+ * the layout contract, well-formed SVG, and that every value the face draws
+ * actually reaches the image.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { dialImage, fit, wrapTwo, FEEDBACK_KEY, type DialFace } from './dialImage'
+
+const LABEL = { client: 'Acme', project: 'Rollout' }
+
+function svgOf(face: DialFace): string {
+  const url = dialImage(face)
+  expect(url.startsWith('data:image/svg+xml;base64,')).toBe(true)
+  return Buffer.from(url.slice('data:image/svg+xml;base64,'.length), 'base64').toString('utf8')
+}
+
+describe('layout contract', () => {
+  it('the key setFeedback writes is declared in layouts/dial.json', () => {
+    const layout = JSON.parse(
+      readFileSync(
+        join(__dirname, '..', 'com.timetrack.streamdeck.sdPlugin', 'layouts', 'dial.json'),
+        'utf8'
+      )
+    ) as { items: Array<{ key: string; type: string; rect: number[] }> }
+    const item = layout.items.find((i) => i.key === FEEDBACK_KEY)
+    // A key the layout does not know is dropped in silence — on the device
+    // that looks exactly like a broken plugin.
+    expect(item, `layout has no item "${FEEDBACK_KEY}"`).toBeDefined()
+    expect(item?.type).toBe('pixmap')
+    // Full-bleed: the faces are drawn for exactly this canvas.
+    expect(item?.rect).toEqual([0, 0, 200, 100])
+  })
+})
+
+describe('dialImage', () => {
+  const faces: DialFace[] = [
+    { state: 'offline' },
+    { state: 'empty' },
+    {
+      state: 'stats',
+      todaySeconds: 3600,
+      weekSeconds: 7200,
+      label: LABEL,
+      position: '1/4',
+      color: '#ff8800'
+    },
+    {
+      state: 'browse',
+      label: LABEL,
+      position: '2/4',
+      progress: 0.5,
+      color: '#ff8800',
+      running: false
+    },
+    { state: 'running', label: LABEL, elapsedSec: 125, color: '#ff8800' }
+  ]
+
+  it('every face is a 200x100 SVG', () => {
+    for (const face of faces) {
+      const svg = svgOf(face)
+      expect(svg.startsWith('<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100"')).toBe(
+        true
+      )
+      expect(svg.endsWith('</svg>')).toBe(true)
+    }
+  })
+
+  it('uses no SVG feature the deck ignores (SMIL, pathLength)', () => {
+    for (const face of faces) {
+      const svg = svgOf(face)
+      expect(svg).not.toContain('<animate')
+      expect(svg).not.toContain('pathLength')
+    }
+  })
+
+  it('stats face shows both totals, the selection and the position', () => {
+    const svg = svgOf({
+      state: 'stats',
+      todaySeconds: 3 * 3600 + 25 * 60,
+      weekSeconds: 21 * 3600,
+      label: LABEL,
+      position: '2/17',
+      color: '#ff8800'
+    })
+    expect(svg).toContain('>TODAY<')
+    expect(svg).toContain('>WEEK<')
+    expect(svg).toContain('>3:25<')
+    expect(svg).toContain('>21:00<')
+    expect(svg).toContain('Acme · Rollout')
+    expect(svg).toContain('>2/17<')
+  })
+
+  it('running face shows client, project and elapsed time', () => {
+    const svg = svgOf({ state: 'running', label: LABEL, elapsedSec: 3 * 3600 + 7 * 60, color: '#ff8800' })
+    expect(svg).toContain('>Acme<')
+    expect(svg).toContain('>Rollout<')
+    expect(svg).toContain('>3:07<')
+  })
+
+  it('a client-only target shows the client as the main line, without a header', () => {
+    const svg = svgOf({
+      state: 'running',
+      label: { client: 'Beta', project: null },
+      elapsedSec: 60,
+      color: '#00aa55'
+    })
+    // Exactly once — as the main line, not additionally as a header.
+    expect(svg.match(/>Beta</g)).toHaveLength(1)
+  })
+
+  it('the ring advances with the minute and stays inside its own length', () => {
+    const at0 = svgOf({ state: 'running', label: LABEL, elapsedSec: 0 })
+    const at30 = svgOf({ state: 'running', label: LABEL, elapsedSec: 30 })
+    const at59 = svgOf({ state: 'running', label: LABEL, elapsedSec: 59 })
+    // No progress path at all in the first half second of a minute.
+    expect(at0).not.toContain('stroke-dasharray')
+    const dash = (svg: string): number => Number(/stroke-dasharray="([\d.]+) /.exec(svg)?.[1])
+    expect(dash(at30)).toBeGreaterThan(250)
+    expect(dash(at30)).toBeLessThan(280)
+    expect(dash(at59)).toBeGreaterThan(dash(at30))
+    // Ring length ≈ 547.4 — the dash must never exceed a full lap.
+    expect(dash(at59)).toBeLessThan(548)
+  })
+
+  it('the pulse breathes over four seconds and returns to its start', () => {
+    const opacity = (sec: number): string =>
+      /<circle cx="178" cy="74" r="5" fill="#ffffff" opacity="([\d.]+)"/.exec(
+        svgOf({ state: 'running', label: LABEL, elapsedSec: sec })
+      )?.[1] as string
+    expect(opacity(0)).toBe('1.00')
+    expect(opacity(2)).toBe('0.35')
+    expect(opacity(4)).toBe(opacity(0))
+  })
+
+  it('browse face marks a target that is already running', () => {
+    const idle = svgOf({
+      state: 'browse',
+      label: LABEL,
+      position: '1/2',
+      progress: 0,
+      running: false
+    })
+    const live = svgOf({
+      state: 'browse',
+      label: LABEL,
+      position: '1/2',
+      progress: 0,
+      running: true
+    })
+    expect(idle).not.toContain('#4ade80')
+    expect(live).toContain('#4ade80')
+  })
+
+  it('browse position bar grows with the progress and never leaves the track', () => {
+    // The filled bar is the rect whose fill has no opacity — the one below it
+    // is the track (fill-opacity 0.10) and is always the full width.
+    const width = (progress: number): number =>
+      Number(
+        /<rect x="16" y="88" width="(\d+)" height="4" rx="2" fill="#[0-9a-f]{6}"\/>/.exec(
+          svgOf({ state: 'browse', label: LABEL, position: 'x', progress, running: false })
+        )?.[1]
+      )
+    expect(width(0)).toBeLessThanOrEqual(8)
+    expect(width(1)).toBe(168)
+    expect(width(0.5)).toBe(84)
+    // Out-of-range values are clamped, not drawn past the track.
+    expect(width(4)).toBe(168)
+    expect(width(-1)).toBeLessThanOrEqual(8)
+  })
+
+  it('escapes names that would otherwise break the XML', () => {
+    const svg = svgOf({
+      state: 'browse',
+      label: { client: 'A & B', project: '<script>' },
+      position: '1/1',
+      progress: 1,
+      running: false
+    })
+    expect(svg).toContain('A &amp; B')
+    expect(svg).toContain('&lt;script&gt;')
+    expect(svg).not.toContain('<script>')
+  })
+
+  it('offline face names the switch the user has to flip', () => {
+    const svg = svgOf({ state: 'offline' })
+    expect(svg).toContain('TimeTrack offline')
+    expect(svg).toContain('Settings')
+  })
+})
+
+describe('text fitting', () => {
+  it('fit truncates with an ellipsis, short strings untouched', () => {
+    expect(fit('Rollout', 10)).toBe('Rollout')
+    expect(fit('Rollout Phase Two', 10)).toBe('Rollout P…')
+    expect(fit('Rollout Phase Two', 10).length).toBe(10)
+  })
+
+  it('wrapTwo breaks at a space and keeps at most two lines', () => {
+    expect(wrapTwo('Rollout', 17)).toEqual(['Rollout'])
+    expect(wrapTwo('Rollout Phase Two', 12)).toEqual(['Rollout', 'Phase Two'])
+    const many = wrapTwo('one two three four five six seven', 10)
+    expect(many).toHaveLength(2)
+    for (const line of many) expect(line.length).toBeLessThanOrEqual(10)
+  })
+
+  it('a single unbreakable word is truncated rather than dropped', () => {
+    expect(wrapTwo('Donaudampfschifffahrtsgesellschaft', 12)).toEqual(['Donaudampfs…'])
+  })
+})

--- a/streamdeck-plugin/src/dialImage.ts
+++ b/streamdeck-plugin/src/dialImage.ts
@@ -1,0 +1,343 @@
+/**
+ * TimeTrack Stream Deck — touch-strip faces for the timer dial (#186).
+ *
+ * Same design language as the keys (`keyImage.ts`), on the encoder's 200x100
+ * slot: dark glass while idle, the client colour lit up while a timer runs,
+ * the minute ring sweeping like a clock hand, and the breathing dot.
+ *
+ * The whole slot is ONE full-bleed SVG handed to the layout's `canvas` pixmap.
+ * Text as layout items would mean a fixed rect per string; the four faces here
+ * place their text differently, and a layout cannot switch geometry. Rendering
+ * everything into the image keeps the layout contract at a single key — which
+ * matters, because a key the layout does not know is dropped in silence.
+ *
+ * The same hardware rules as on the keys apply: one static frame, no SMIL, no
+ * `pathLength`. Motion is frame-by-frame, driven by the action's 1 Hz tick.
+ */
+import { FONT, MONO, escapeXml, normalizeKeyColor, scaleL } from './keyImage'
+import { formatHm } from './dialModel'
+
+const W = 200
+const H = 100
+
+/**
+ * The one key `setFeedback` writes to, and the one key `layouts/dial.json`
+ * declares. Feedback keys are a contract with the layout: a key the layout
+ * does not know is dropped without a word, which on the device is
+ * indistinguishable from a broken feature. `dialImage.test.ts` checks both
+ * sides against each other.
+ */
+export const FEEDBACK_KEY = 'canvas'
+
+// ── Bausteine ──────────────────────────────────────────────────────────────
+
+const SHELL = (fill: string): string =>
+  `<rect x="0" y="0" width="${W}" height="${H}" rx="14" fill="${fill}"/>`
+
+/** Innere 1-px-Kante — macht aus der Fläche eine Glasscheibe. */
+const HAIRLINE = (opacity = 0.12): string =>
+  `<rect x="0.75" y="0.75" width="${W - 1.5}" height="${H - 1.5}" rx="13.25" fill="none" stroke="#ffffff" stroke-opacity="${opacity}"/>`
+
+function dataUrl(inner: string): string {
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">` +
+    inner +
+    '</svg>'
+  // base64 rather than percent-encoding: the layout schema documents pixmap
+  // values as "base64 encoded string", and that is the form the app parses
+  // most reliably. Node's Buffer is available inside the plugin runtime.
+  return `data:image/svg+xml;base64,${Buffer.from(svg, 'utf8').toString('base64')}`
+}
+
+function text(
+  s: string,
+  o: {
+    x: number
+    y: number
+    size: number
+    fill: string
+    weight?: number
+    anchor?: 'start' | 'middle' | 'end'
+    mono?: boolean
+    opacity?: number
+    spacing?: number
+  }
+): string {
+  if (!s) return ''
+  const attrs = [
+    `x="${o.x}"`,
+    `y="${o.y}"`,
+    `font-family="${o.mono ? MONO : FONT}"`,
+    `font-size="${o.size}"`,
+    `font-weight="${o.weight ?? 500}"`,
+    `fill="${o.fill}"`,
+    `text-anchor="${o.anchor ?? 'start'}"`
+  ]
+  if (o.opacity != null) attrs.push(`opacity="${o.opacity}"`)
+  if (o.spacing != null) attrs.push(`letter-spacing="${o.spacing}"`)
+  return `<text ${attrs.join(' ')}>${escapeXml(s)}</text>`
+}
+
+/**
+ * Hard truncation with an ellipsis. No font metrics are available inside the
+ * deck's renderer, so the budgets are character counts calibrated per size —
+ * deliberately conservative: a clipped name is worse than a short one.
+ */
+export function fit(s: string, maxChars: number): string {
+  if (s.length <= maxChars) return s
+  return s.slice(0, Math.max(1, maxChars - 1)).trimEnd() + '…'
+}
+
+/** Break into at most two lines at a space, else truncate to one. */
+export function wrapTwo(s: string, maxChars: number): string[] {
+  if (s.length <= maxChars) return [s]
+  const words = s.split(/\s+/)
+  const lines: string[] = []
+  let line = ''
+  for (const w of words) {
+    if (line === '') line = w
+    else if ((line + ' ' + w).length <= maxChars) line += ' ' + w
+    else {
+      lines.push(line)
+      line = w
+    }
+  }
+  if (line) lines.push(line)
+  return lines.slice(0, 2).map((l) => fit(l, maxChars))
+}
+
+// ── Minutenring ────────────────────────────────────────────────────────────
+
+/**
+ * Rounded rect x/y 4, w 192, h 92, r 12 as an explicit path: starts at top
+ * centre (100, 4) and runs clockwise, like a clock hand. Dashes are in REAL
+ * user units — `pathLength` is ignored by the deck's renderer.
+ */
+const RING_PATH =
+  'M 100 4 H 184 A 12 12 0 0 1 196 16 V 84 A 12 12 0 0 1 184 96 H 16 ' +
+  'A 12 12 0 0 1 4 84 V 16 A 12 12 0 0 1 16 4 H 100'
+/** Straights 84+68+168+68+84 = 472, plus 4 quarter arcs (2π·12) ≈ 547.4. */
+const RING_LENGTH = 472 + 2 * Math.PI * 12
+
+function ring(elapsedSec: number): string {
+  const dash = ((Math.floor(elapsedSec) % 60) / 60) * RING_LENGTH
+  return (
+    `<rect x="4" y="4" width="192" height="92" rx="12" fill="none" stroke="#ffffff" stroke-opacity="0.22" stroke-width="2.5"/>` +
+    (dash > 0.5
+      ? `<path d="${RING_PATH}" fill="none" stroke="#ffffff" stroke-width="2.5" stroke-linecap="round" stroke-dasharray="${dash.toFixed(1)} ${Math.ceil(RING_LENGTH)}"/>`
+      : '')
+  )
+}
+
+/** Frame-by-frame pulse: a 4 s cosine sampled once per second. */
+function pulse(cx: number, cy: number, elapsedSec: number): string {
+  const o = 0.675 + 0.325 * Math.cos((2 * Math.PI * (Math.floor(elapsedSec) % 4)) / 4)
+  return `<circle cx="${cx}" cy="${cy}" r="5" fill="#ffffff" opacity="${o.toFixed(2)}"/>`
+}
+
+// ── Hintergründe ───────────────────────────────────────────────────────────
+
+/** Dunkles Glas mit Akzent-Schimmer von unten — wie die Idle-Taste. */
+function glassBackground(accent: string): string {
+  return (
+    `<defs><linearGradient id="b" x1="0" y1="0" x2="0" y2="1">` +
+    `<stop offset="0" stop-color="#242844"/><stop offset="1" stop-color="#0d1020"/></linearGradient>` +
+    `<radialGradient id="w" cx="0.5" cy="1" r="0.9">` +
+    `<stop offset="0" stop-color="${accent}" stop-opacity="0.30"/>` +
+    `<stop offset="1" stop-color="${accent}" stop-opacity="0"/></radialGradient>` +
+    `<linearGradient id="s" x1="0" y1="0" x2="0" y2="1">` +
+    `<stop offset="0" stop-color="#ffffff" stop-opacity="0.12"/>` +
+    `<stop offset="1" stop-color="#ffffff" stop-opacity="0"/></linearGradient></defs>` +
+    SHELL('url(#b)') +
+    SHELL('url(#w)') +
+    `<rect x="1" y="1" width="${W - 2}" height="40" rx="13" fill="url(#s)"/>` +
+    HAIRLINE()
+  )
+}
+
+// ── Flächen ────────────────────────────────────────────────────────────────
+
+export interface DialLabel {
+  /** Client name — the header when a project is shown, else the main line. */
+  client: string
+  /** Project name, or null for a client-only target. */
+  project: string | null
+}
+
+/**
+ * Idle: the two numbers from the app's "Heute" page, plus the entry a press
+ * would start. The footer is what keeps the press from being blind — without
+ * it you would have to rotate first to find out what you are about to start.
+ */
+function statsFace(o: {
+  todaySeconds: number
+  weekSeconds: number
+  label: DialLabel | null
+  position: string
+  color?: string
+}): string {
+  const accent = normalizeKeyColor(o.color)
+  const selection = o.label
+    ? o.label.project
+      ? `${o.label.client} · ${o.label.project}`
+      : o.label.client
+    : 'No clients'
+  return (
+    glassBackground(accent) +
+    text('TODAY', { x: 16, y: 24, size: 10, fill: '#8b93bc', weight: 600, spacing: 1.2 }) +
+    text('WEEK', { x: 110, y: 24, size: 10, fill: '#8b93bc', weight: 600, spacing: 1.2 }) +
+    text(formatHm(o.todaySeconds), {
+      x: 16,
+      y: 52,
+      size: 25,
+      fill: '#e8eaf6',
+      weight: 700,
+      mono: true,
+      spacing: -1
+    }) +
+    text(formatHm(o.weekSeconds), {
+      x: 110,
+      y: 52,
+      size: 25,
+      fill: '#8b93bc',
+      weight: 700,
+      mono: true,
+      spacing: -1
+    }) +
+    `<line x1="16" y1="64" x2="184" y2="64" stroke="#ffffff" stroke-opacity="0.10"/>` +
+    `<circle cx="20" cy="80" r="4" fill="${accent}"/>` +
+    text(fit(selection, 24), { x: 30, y: 84, size: 12, fill: '#8b93bc' }) +
+    text(o.position, { x: 184, y: 84, size: 11, fill: '#4a5270', anchor: 'end', mono: true })
+  )
+}
+
+/**
+ * Rotating: the entry under the wheel. The bar along the bottom is the
+ * position in the list — on a long list the counter alone does not convey
+ * "how far in" you are.
+ */
+function browseFace(o: {
+  label: DialLabel
+  position: string
+  progress: number
+  color?: string
+  running: boolean
+}): string {
+  const accent = normalizeKeyColor(o.color)
+  const main = o.label.project ?? o.label.client
+  const lines = wrapTwo(main, 17)
+  const header = o.label.project ? o.label.client : ''
+  const barW = Math.max(6, Math.round(168 * Math.min(1, Math.max(0, o.progress))))
+  return (
+    glassBackground(accent) +
+    `<circle cx="20" cy="21" r="4" fill="${accent}"/>` +
+    text(fit(header, 22), { x: 30, y: 25, size: 11, fill: '#8b93bc', weight: 600 }) +
+    text(o.position, { x: 184, y: 25, size: 11, fill: '#4a5270', anchor: 'end', mono: true }) +
+    (lines.length === 1
+      ? text(lines[0], { x: 16, y: 62, size: 20, fill: '#e8eaf6', weight: 600 })
+      : text(lines[0], { x: 16, y: 54, size: 19, fill: '#e8eaf6', weight: 600 }) +
+        text(lines[1], { x: 16, y: 74, size: 19, fill: '#e8eaf6', weight: 600 })) +
+    // Running target while browsing: the same green the app uses for a live
+    // timer, so the wheel says "this one is already going" before you press.
+    (o.running ? `<circle cx="184" cy="80" r="4.5" fill="#4ade80"/>` : '') +
+    `<rect x="16" y="88" width="168" height="4" rx="2" fill="#ffffff" fill-opacity="0.10"/>` +
+    `<rect x="16" y="88" width="${barW}" height="4" rx="2" fill="${accent}"/>`
+  )
+}
+
+/** Running: client colour lit up, elapsed time, ring and pulse. */
+function runningFace(o: { label: DialLabel; elapsedSec: number; color?: string }): string {
+  const base = normalizeKeyColor(o.color)
+  const top = scaleL(base, 1.18)
+  const bot = scaleL(base, 0.62)
+  const sec = Math.max(0, Math.floor(o.elapsedSec))
+  const header = o.label.project ? o.label.client : ''
+  const main = o.label.project ?? o.label.client
+  return (
+    `<defs><linearGradient id="b" x1="0" y1="0" x2="0.35" y2="1">` +
+    `<stop offset="0" stop-color="${top}"/><stop offset="0.55" stop-color="${base}"/>` +
+    `<stop offset="1" stop-color="${bot}"/></linearGradient>` +
+    `<linearGradient id="s" x1="0" y1="0" x2="0" y2="1">` +
+    `<stop offset="0" stop-color="#ffffff" stop-opacity="0.22"/>` +
+    `<stop offset="1" stop-color="#ffffff" stop-opacity="0"/></linearGradient></defs>` +
+    SHELL('url(#b)') +
+    `<rect x="1" y="1" width="${W - 2}" height="42" rx="13" fill="url(#s)"/>` +
+    ring(sec) +
+    (header
+      ? text(fit(header, 24), { x: 18, y: 27, size: 12, fill: '#ffffff', opacity: 0.8 }) +
+        text(fit(main, 20), { x: 18, y: 50, size: 17, fill: '#ffffff', weight: 600 })
+      : text(fit(main, 18), { x: 18, y: 40, size: 19, fill: '#ffffff', weight: 600 })) +
+    text(formatHm(sec), {
+      x: 18,
+      y: 84,
+      size: 30,
+      fill: '#ffffff',
+      weight: 700,
+      mono: true,
+      spacing: -1
+    }) +
+    pulse(178, 74, sec)
+  )
+}
+
+/** The app is not running, or hardware keys are switched off. */
+function offlineFace(): string {
+  return (
+    `<defs><linearGradient id="b" x1="0" y1="0" x2="0" y2="1">` +
+    `<stop offset="0" stop-color="#20222c"/><stop offset="1" stop-color="#0f1116"/></linearGradient></defs>` +
+    SHELL('url(#b)') +
+    HAIRLINE(0.07) +
+    // Clock glyph from imgs/plugin.svg, desaturated.
+    `<circle cx="30" cy="50" r="13" fill="none" stroke="#4a5270" stroke-width="2.5"/>` +
+    `<line x1="30" y1="43" x2="30" y2="51" stroke="#4a5270" stroke-width="2.5" stroke-linecap="round"/>` +
+    `<line x1="30" y1="51" x2="35" y2="54" stroke="#4a5270" stroke-width="2.5" stroke-linecap="round"/>` +
+    text('TimeTrack offline', { x: 54, y: 47, size: 15, fill: '#767c8e', weight: 600 }) +
+    text('Settings → Integrations', { x: 54, y: 66, size: 11, fill: '#5b6070' })
+  )
+}
+
+/** Bridge answers, but there is nothing to start yet. */
+function emptyFace(): string {
+  return (
+    glassBackground('#8b7cf8') +
+    text('No clients yet', { x: 100, y: 48, size: 16, fill: '#e8eaf6', weight: 600, anchor: 'middle' }) +
+    text('Add one in TimeTrack', { x: 100, y: 70, size: 11, fill: '#8b93bc', anchor: 'middle' })
+  )
+}
+
+export type DialFace =
+  | { state: 'offline' }
+  | { state: 'empty' }
+  | {
+      state: 'stats'
+      todaySeconds: number
+      weekSeconds: number
+      label: DialLabel | null
+      position: string
+      color?: string
+    }
+  | {
+      state: 'browse'
+      label: DialLabel
+      position: string
+      progress: number
+      color?: string
+      running: boolean
+    }
+  | { state: 'running'; label: DialLabel; elapsedSec: number; color?: string }
+
+/** 200x100 touch-strip face as a data: URL for the layout's `canvas` pixmap. */
+export function dialImage(face: DialFace): string {
+  switch (face.state) {
+    case 'offline':
+      return dataUrl(offlineFace())
+    case 'empty':
+      return dataUrl(emptyFace())
+    case 'running':
+      return dataUrl(runningFace(face))
+    case 'browse':
+      return dataUrl(browseFace(face))
+    default:
+      return dataUrl(statsFace(face))
+  }
+}

--- a/streamdeck-plugin/src/dialModel.test.ts
+++ b/streamdeck-plugin/src/dialModel.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Tests for the timer dial's model (#186) — the part that decides what the
+ * wheel lands on and what a press starts. No SDK, no bridge, no device.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import type { TargetClient } from './bridge'
+import {
+  buildTargets,
+  clientOnly,
+  createPressGesture,
+  displayTotals,
+  elapsedSeconds,
+  formatHm,
+  indexOfKey,
+  isRunning,
+  step,
+  targetKey
+} from './dialModel'
+
+const CLIENTS: TargetClient[] = [
+  {
+    id: 1,
+    name: 'Acme',
+    color: '#ff0000',
+    projects: [
+      { id: 10, name: 'Rollout' },
+      { id: 11, name: 'Support' }
+    ]
+  },
+  { id: 2, name: 'Beta', color: '#00ff00', projects: [] },
+  { id: 3, name: 'Gamma', color: '#0000ff', projects: [{ id: 30, name: 'Audit' }] }
+]
+
+describe('buildTargets', () => {
+  it('lists projects, and clients only when they have none', () => {
+    const targets = buildTargets(CLIENTS)
+    expect(targets.map((t) => `${t.clientName}/${t.projectName ?? '—'}`)).toEqual([
+      'Acme/Rollout',
+      'Acme/Support',
+      'Beta/—',
+      'Gamma/Audit'
+    ])
+    // Acme has projects, so it must NOT also appear on its own — that entry
+    // is what the long press is for.
+    expect(targets.filter((t) => t.clientId === 1 && t.projectId === null)).toEqual([])
+  })
+
+  it('keeps the bridge order and carries the client colour', () => {
+    const targets = buildTargets(CLIENTS)
+    expect(targets[0].color).toBe('#ff0000')
+    expect(targets[2].color).toBe('#00ff00')
+  })
+
+  it('is empty for an empty client list', () => {
+    expect(buildTargets([])).toEqual([])
+  })
+})
+
+describe('clientOnly', () => {
+  it('drops the project — what a long press starts', () => {
+    const [rollout] = buildTargets(CLIENTS)
+    const bare = clientOnly(rollout)
+    expect(bare).toMatchObject({ clientId: 1, projectId: null, clientName: 'Acme' })
+    expect(bare.key).toBe(targetKey(1, null))
+  })
+
+  it('is the identity on a client that has no projects', () => {
+    const beta = buildTargets(CLIENTS)[2]
+    expect(clientOnly(beta)).toBe(beta)
+  })
+})
+
+describe('indexOfKey', () => {
+  it('re-finds the selection after the list changed above it', () => {
+    const before = buildTargets(CLIENTS)
+    const selected = before[2].key // Beta
+    // A new project appears on Acme, pushing everything down by one.
+    const after = buildTargets([
+      {
+        ...CLIENTS[0],
+        projects: [{ id: 9, name: 'Aufmass' }, ...CLIENTS[0].projects]
+      },
+      CLIENTS[1],
+      CLIENTS[2]
+    ])
+    expect(indexOfKey(before, selected)).toBe(2)
+    expect(indexOfKey(after, selected)).toBe(3)
+    expect(after[3].clientName).toBe('Beta')
+  })
+
+  it('falls back to the top for an unknown or missing key', () => {
+    const targets = buildTargets(CLIENTS)
+    expect(indexOfKey(targets, '999:')).toBe(0)
+    expect(indexOfKey(targets, undefined)).toBe(0)
+  })
+})
+
+describe('step', () => {
+  it('wraps in both directions', () => {
+    expect(step(0, 1, 4)).toBe(1)
+    expect(step(3, 1, 4)).toBe(0)
+    expect(step(0, -1, 4)).toBe(3)
+    expect(step(0, -6, 4)).toBe(2)
+    expect(step(1, 9, 4)).toBe(2)
+  })
+
+  it('stays at 0 without entries', () => {
+    expect(step(0, 3, 0)).toBe(0)
+  })
+})
+
+describe('isRunning', () => {
+  const [rollout, , beta] = buildTargets(CLIENTS)
+  const running = {
+    id: 1,
+    client_id: 1,
+    project_id: 10,
+    description: '',
+    started_at: '2026-08-02T09:00:00.000Z',
+    client_name: 'Acme',
+    project_name: 'Rollout'
+  }
+
+  it('matches on client AND project', () => {
+    expect(isRunning(rollout, running)).toBe(true)
+    expect(isRunning(beta, running)).toBe(false)
+    expect(isRunning(rollout, null)).toBe(false)
+  })
+
+  it('does not confuse "client without project" with "client with project"', () => {
+    expect(isRunning(clientOnly(rollout), running)).toBe(false)
+    expect(isRunning(clientOnly(rollout), { ...running, project_id: null })).toBe(true)
+  })
+})
+
+describe('formatHm / elapsedSeconds', () => {
+  it('formats h:mm and never goes negative', () => {
+    expect(formatHm(0)).toBe('0:00')
+    expect(formatHm(59)).toBe('0:00')
+    expect(formatHm(3599)).toBe('0:59')
+    expect(formatHm(3600)).toBe('1:00')
+    expect(formatHm(45296)).toBe('12:34')
+    expect(formatHm(-5)).toBe('0:00')
+  })
+
+  it('measures from started_at, clamps a clock that ran backwards', () => {
+    const now = Date.parse('2026-08-02T10:00:00.000Z')
+    expect(elapsedSeconds('2026-08-02T09:30:00.000Z', now)).toBe(1800)
+    expect(elapsedSeconds('2026-08-02T10:30:00.000Z', now)).toBe(0)
+    expect(elapsedSeconds('not a date', now)).toBe(0)
+  })
+})
+
+describe('displayTotals', () => {
+  it('prefers the rounded seconds the app shows', () => {
+    // The hardware run that found this: 6:24 raw, 6:30 in the app window.
+    expect(
+      displayTotals({
+        today_seconds: 0,
+        week_seconds: 23051,
+        today_display_seconds: 0,
+        week_display_seconds: 23400
+      })
+    ).toEqual({ today: 0, week: 23400 })
+  })
+
+  it('falls back to raw against an app that does not send them yet', () => {
+    // Plugin and app ship separately — an older app answers get_summary
+    // without the display fields, and "slightly off" beats "NaN:NaN".
+    expect(displayTotals({ today_seconds: 120, week_seconds: 23051 })).toEqual({
+      today: 120,
+      week: 23051
+    })
+  })
+
+  it('survives a garbage payload', () => {
+    expect(
+      displayTotals({
+        today_seconds: NaN,
+        week_seconds: 60,
+        week_display_seconds: NaN
+      } as unknown as Parameters<typeof displayTotals>[0])
+    ).toEqual({ today: 0, week: 60 })
+  })
+})
+
+describe('createPressGesture', () => {
+  it('a short press reports short and never fires the long action', () => {
+    vi.useFakeTimers()
+    try {
+      const long = vi.fn()
+      const g = createPressGesture(long, 500)
+      g.down()
+      vi.advanceTimersByTime(200)
+      expect(g.up()).toBe(true)
+      vi.advanceTimersByTime(1000)
+      expect(long).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('the long action fires at the threshold, and the release is then not short', () => {
+    vi.useFakeTimers()
+    try {
+      const long = vi.fn()
+      const g = createPressGesture(long, 500)
+      g.down()
+      vi.advanceTimersByTime(500)
+      expect(long).toHaveBeenCalledTimes(1)
+      expect(g.up()).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('rotating while pressed voids the gesture — nothing starts on release', () => {
+    vi.useFakeTimers()
+    try {
+      const long = vi.fn()
+      const g = createPressGesture(long, 500)
+      g.down()
+      vi.advanceTimersByTime(100)
+      g.cancel()
+      vi.advanceTimersByTime(1000)
+      expect(long).not.toHaveBeenCalled()
+      expect(g.up()).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('a fresh press after a long one is short again', () => {
+    vi.useFakeTimers()
+    try {
+      const long = vi.fn()
+      const g = createPressGesture(long, 500)
+      g.down()
+      vi.advanceTimersByTime(500)
+      g.up()
+      g.down()
+      vi.advanceTimersByTime(100)
+      expect(g.up()).toBe(true)
+      expect(long).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/streamdeck-plugin/src/dialModel.ts
+++ b/streamdeck-plugin/src/dialModel.ts
@@ -1,0 +1,210 @@
+/**
+ * Pure model behind the "Timer dial" encoder action (#186).
+ *
+ * Everything here is free of the SDK, of `net` and of timers-as-globals, so
+ * the whole interaction — which entry the wheel lands on, what a long press
+ * targets, when a press counts as short — is testable without a Stream Deck
+ * attached. The action module (`actions/timer-dial.ts`) only wires these
+ * functions to events.
+ */
+import type { RunningTimer, TargetClient } from './bridge'
+
+/** One position on the wheel. */
+export interface DialTarget {
+  /** Stable identity used to re-find the selection after the list changed. */
+  key: string
+  clientId: number
+  projectId: number | null
+  clientName: string
+  projectName: string | null
+  /** Raw client colour from the DB; normalized at render time. */
+  color: string
+}
+
+export function targetKey(clientId: number, projectId: number | null): string {
+  return `${clientId}:${projectId ?? ''}`
+}
+
+/**
+ * Flattens the bridge's client/project tree into the wheel's list.
+ *
+ * A client **with** projects contributes one entry per project and does NOT
+ * appear on its own — its project-less timer is reachable through the long
+ * press instead (see {@link clientOnly}). A client **without** projects
+ * contributes itself. Order is the bridge's order (clients alphabetical, each
+ * client's projects alphabetical): a list that reorders itself by usage would
+ * move under the user's fingers between two rotations.
+ */
+export function buildTargets(clients: TargetClient[]): DialTarget[] {
+  const out: DialTarget[] = []
+  for (const c of clients) {
+    if (c.projects.length === 0) {
+      out.push({
+        key: targetKey(c.id, null),
+        clientId: c.id,
+        projectId: null,
+        clientName: c.name,
+        projectName: null,
+        color: c.color
+      })
+      continue
+    }
+    for (const p of c.projects) {
+      out.push({
+        key: targetKey(c.id, p.id),
+        clientId: c.id,
+        projectId: p.id,
+        clientName: c.name,
+        projectName: p.name,
+        color: c.color
+      })
+    }
+  }
+  return out
+}
+
+/**
+ * The same client, but without a project — what a long press starts.
+ * On an entry that is already project-less this is the identity, so a long
+ * press there is simply the short press.
+ */
+export function clientOnly(target: DialTarget): DialTarget {
+  if (target.projectId === null) return target
+  return {
+    key: targetKey(target.clientId, null),
+    clientId: target.clientId,
+    projectId: null,
+    clientName: target.clientName,
+    projectName: null,
+    color: target.color
+  }
+}
+
+/**
+ * Re-find the selection by key, not by index: when a project is added or
+ * archived somewhere above it, the selected entry stays selected instead of
+ * silently sliding onto a neighbour. Unknown key ⇒ 0 (top of the list).
+ */
+export function indexOfKey(targets: DialTarget[], key: string | undefined): number {
+  if (!key) return 0
+  const at = targets.findIndex((t) => t.key === key)
+  return at >= 0 ? at : 0
+}
+
+/** Wrap-around step; `length <= 0` stays at 0. */
+export function step(index: number, ticks: number, length: number): number {
+  if (length <= 0) return 0
+  return (((index + ticks) % length) + length) % length
+}
+
+/** Does the running timer point at exactly this target? */
+export function isRunning(target: DialTarget, running: RunningTimer | null): boolean {
+  return (
+    running !== null &&
+    running.client_id === target.clientId &&
+    (running.project_id ?? null) === target.projectId
+  )
+}
+
+/**
+ * What the stats face puts on screen.
+ *
+ * The app rounds durations before showing them (`pdf_round_minutes`, ceiling),
+ * so the raw seconds disagree with the app window by up to one step — that is
+ * how this went wrong the first time: 6:24 on the strip against 6:30 in the
+ * app. The rounded values come from the bridge.
+ *
+ * Plugin and app ship separately and can be out of step: an older app answers
+ * `get_summary` without the display fields. Falling back to the raw seconds
+ * keeps that combination at "slightly off" instead of "NaN:NaN".
+ */
+export interface SummaryTotals {
+  today_seconds: number
+  week_seconds: number
+  today_display_seconds?: number
+  week_display_seconds?: number
+}
+
+export function displayTotals(s: SummaryTotals): { today: number; week: number } {
+  const pick = (display: number | undefined, raw: number): number => {
+    if (typeof display === 'number' && Number.isFinite(display)) return display
+    return Number.isFinite(raw) ? raw : 0
+  }
+  return {
+    today: pick(s.today_display_seconds, s.today_seconds),
+    week: pick(s.week_display_seconds, s.week_seconds)
+  }
+}
+
+/** h:mm — the minute is the unit on the faces; the ring carries the seconds. */
+export function formatHm(seconds: number): string {
+  const s = Math.max(0, Math.floor(seconds))
+  return `${Math.floor(s / 3600)}:${String(Math.floor(s / 60) % 60).padStart(2, '0')}`
+}
+
+/** Seconds a timer started at `startedAt` has been running at `nowMs`. */
+export function elapsedSeconds(startedAt: string, nowMs: number): number {
+  const t = Date.parse(startedAt)
+  if (Number.isNaN(t)) return 0
+  return Math.max(0, (nowMs - t) / 1000)
+}
+
+/**
+ * Short vs. long press on the wheel.
+ *
+ * The touch strip reports `hold` on `touchTap`, but the wheel does not — for
+ * `dialDown`/`dialUp` the distinction has to be measured here. The long action
+ * fires when the threshold is reached, not on release: the confirmation
+ * appears in the moment you have held long enough, which is the only feedback
+ * that tells you the gesture registered.
+ *
+ * Timer functions are injected so a test can drive the clock.
+ */
+export interface PressGesture {
+  down(): void
+  /** @returns true when this was a short press — the caller starts the timer. */
+  up(): boolean
+  /** Rotating (or leaving) while pressed voids the gesture. */
+  cancel(): void
+}
+
+export function createPressGesture(
+  onLong: () => void,
+  thresholdMs = 500,
+  clock: {
+    setTimeout: (fn: () => void, ms: number) => unknown
+    clearTimeout: (handle: unknown) => void
+  } = globalThis as never
+): PressGesture {
+  let handle: unknown = null
+  let consumed = false
+
+  function stop(): void {
+    if (handle !== null) {
+      clock.clearTimeout(handle)
+      handle = null
+    }
+  }
+
+  return {
+    down(): void {
+      stop()
+      consumed = false
+      handle = clock.setTimeout(() => {
+        handle = null
+        consumed = true
+        onLong()
+      }, thresholdMs)
+    },
+    up(): boolean {
+      stop()
+      const short = !consumed
+      consumed = false
+      return short
+    },
+    cancel(): void {
+      stop()
+      consumed = true
+    }
+  }
+}

--- a/streamdeck-plugin/src/keyImage.ts
+++ b/streamdeck-plugin/src/keyImage.ts
@@ -74,8 +74,8 @@ export function normalizeKeyColor(hex?: string): string {
   return oklabToHex([0.65, a * k, b * k])
 }
 
-/** Lightness skalieren, Hue/Chroma behalten. */
-function scaleL(hex: string, f: number): string {
+/** Lightness skalieren, Hue/Chroma behalten. Geteilt mit dialImage.ts (#186). */
+export function scaleL(hex: string, f: number): string {
   const [L, a, b] = rgbToOklab(hexToRgb(hex))
   return oklabToHex([Math.max(0.05, Math.min(0.92, L * f)), a, b])
 }
@@ -84,8 +84,8 @@ function scaleL(hex: string, f: number): string {
 // Im Key-SVG ist keine Font eingebettet — daher nur systemsichere Stacks.
 // Inter (App-Font) ist hier NICHT verfügbar.
 
-const FONT = 'Segoe UI, Helvetica, Arial, sans-serif'
-const MONO = 'Consolas, Menlo, monospace'
+export const FONT = 'Segoe UI, Helvetica, Arial, sans-serif'
+export const MONO = 'Consolas, Menlo, monospace'
 
 // ── Bausteine ──────────────────────────────────────────────────────────────
 
@@ -96,7 +96,7 @@ const SHELL = (fill: string): string =>
 const HAIRLINE = (opacity = 0.14): string =>
   `<rect x="5.5" y="5.5" width="133" height="133" rx="20.5" fill="none" stroke="#ffffff" stroke-opacity="${opacity}"/>`
 
-function escapeXml(s: string): string {
+export function escapeXml(s: string): string {
   return s
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')

--- a/streamdeck-plugin/src/plugin.ts
+++ b/streamdeck-plugin/src/plugin.ts
@@ -1,5 +1,7 @@
 import streamDeck from '@elgato/streamdeck'
 import { ToggleTimer } from './actions/toggle-timer'
+import { TimerDial } from './actions/timer-dial'
 
 streamDeck.actions.registerAction(new ToggleTimer())
+streamDeck.actions.registerAction(new TimerDial())
 await streamDeck.connect()

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,6 +23,18 @@ export default defineConfig({
         }
       },
       {
+        // The Stream Deck plugin is its own package (own node_modules, own
+        // tsconfig, not part of the app build), but its pure modules — dial
+        // model, touch-strip faces, layout contract — are testable here and
+        // would otherwise have no suite at all.
+        extends: true,
+        test: {
+          name: 'streamdeck',
+          environment: 'node',
+          include: ['streamdeck-plugin/src/**/*.test.ts']
+        }
+      },
+      {
         extends: true,
         test: {
           name: 'jsdom',


### PR DESCRIPTION
Closes #186.

One dial reaches every timer target, without configuring anything. The keypad action from #133 stays as it is; this adds a second action for the Stream Deck +'s wheel and touch strip.

| Gesture | Effect |
| --- | --- |
| idle | today + this week, the same numbers the app's *Heute* page shows, plus the entry a press would start |
| turn | walks the projects, and the clients that have none |
| press (on release) | starts the shown target — or stops it, if it is the one running |
| press and hold (0.5 s) | starts the same **client without a project** |
| tap / long-tap the strip | same as short / long press |
| while a timer runs | client, project, elapsed time, minute ring and pulse — the running key face on the strip |

A client that *has* projects never appears on its own in the list: its project-less timer is what the long press is for. That keeps the list as short as the number of things you actually book on. After a rotation the selection stays up for 4 s, then the ambient face returns; the selection is remembered per dial, anchored by client/project id rather than by position.

## App side

`readTotals()` in the new `src/main/dashboardTotals.ts` is now the **single** definition of "hours today / this week". The `dashboard:summary` IPC handler (the app's *Heute* page) and the new controller op `get_summary` both call it, so the strip cannot drift away from the app window. `get_summary` answers the running timer plus both totals in one round trip, and it is read-only: no backup, no audit, no broadcast (pinned by a test).

## Two things the hardware taught us

**Rounding.** The stat cards round with `pdf_round_minutes` (ceiling) before display. The first version rendered the raw seconds and read **6:24 against the app's 6:30** — one rounding step apart, on the device, with nothing failing. `get_summary` now sends raw *and* display seconds, rounded with the app's own `roundDuration`, and the strip shows the display ones. The setting is re-read per request, so changing it in Settings reaches the dial on the next 2-second poll.

**Version skew.** Plugin and app are installed separately and can be out of step. A probe against the running app confirmed it answers `get_summary` without the display fields, which would have put `NaN:NaN` on the strip. `displayTotals()` falls back to the raw seconds instead.

## Notes

- The strip is one full-bleed SVG in the layout's single `canvas` pixmap. The four faces place their text differently per state and a layout cannot switch geometry; one key also keeps the layout contract minimal — a feedback key the layout does not know is **dropped silently**, which on the device looks exactly like a broken plugin. `dialImage.test.ts` checks both sides against each other.
- Same hardware rules as the keys: one static frame, no SMIL, no `pathLength`. Ring and pulse advance frame-by-frame on a 1 Hz tick; `setFeedback` only fires when the rendered frame actually changed.
- The plugin's pure modules now run in the app's suite as the `streamdeck` vitest project. That package had no test at all before.
- **Drive-by finding, not fixed here:** the comment above the week window claimed "ISO week — Monday as first day", but `weekday 0, -7 days` lands on the most recent **Sunday**. The SQL is carried over verbatim — correcting it would move a number the app has shown since v1.2, which is a product decision. The comment now says what the code does.
- No VERSION bump and no CHANGELOG entry: per repo convention those land in the release PR.

## Verification

- `pnpm test` — **51 files, 950 passed, 0 skipped** (39 of them new)
- `pnpm typecheck`, `pnpm lint` (11 pre-existing warnings, none new), plugin `pnpm typecheck` + `pnpm build` — all clean
- **On hardware** (Stream Deck +, plugin junction + installed app): long press → client without project ✅, short press ✅, roll-through shows only projects ✅, return to idle ✅, TODAY/WEEK identical to the app after the rounding fix ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
