### PR TITLE
feat(#188): configurable week start — one setting instead of two conventions

### DIFF
--- a/src/main/analyticsHandlers.ts
+++ b/src/main/analyticsHandlers.ts
@@ -200,7 +200,12 @@ export function buildAnalyticsSummary(
 
       // Map to labeled array; fill gaps for weeks with no entries
       const weekMap = new Map(weekRows.map((r) => [r.week_start, r]))
-      // Build a list of 12 Monday dates going backwards from anchor end
+      // Build a list of 12 Monday dates going backwards from anchor end.
+      //
+      // Deliberately NOT following the `week_start` setting (#188): these bars
+      // are labelled `KW##`, and ISO 8601 defines the calendar week as
+      // Monday-based. A Sunday-anchored bucket under a `KW` label would be a
+      // wrong number, not a preference.
       const anchorDate = new Date(year, month - 1, daysInMonth)
       // Find the Monday of the anchor-end's week
       const anchorDow = anchorDate.getDay() // 0=Sun..6=Sat

--- a/src/main/dashboardTotals.test.ts
+++ b/src/main/dashboardTotals.test.ts
@@ -10,7 +10,8 @@
 import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
 import type Database from 'better-sqlite3'
 import { applyMigrations, loadSqlite, type DatabaseCtor } from '../test/sqlite'
-import { readRoundMinutes, readTotals } from './dashboardTotals'
+import { readRoundMinutes, readTotals, readWeekStart } from './dashboardTotals'
+import { weekStartModifiers } from '../shared/weekStart'
 import { getDashboard, type SqliteDb } from '../mcp/queries'
 
 let DatabaseImpl: DatabaseCtor
@@ -21,6 +22,16 @@ beforeAll(async () => {
 
 function iso(msFromNow: number): string {
   return new Date(Date.now() + msFromNow).toISOString()
+}
+
+/**
+ * ISO timestamp for 12:00 **local** on a `YYYY-MM-DD` day. The queries compare
+ * `DATE(started_at,'localtime')`, so building the instant from local parts is
+ * what keeps the test honest in any timezone.
+ */
+function atLocalNoon(dayKey: string): string {
+  const [y, m, d] = dayKey.split('-').map(Number)
+  return new Date(y, m - 1, d, 12, 0, 0, 0).toISOString()
 }
 
 /** Local-midnight-safe: a date N days back at 10:00 local time. */
@@ -127,22 +138,80 @@ describe('readTotals', () => {
     expect(readRoundMinutes(db)).toBe(0)
   })
 
-  it('agrees with getDashboard() — the second copy of the same definition', () => {
-    addClosed(db, daysAgoAt10(0).toISOString(), 45)
-    addClosed(db, daysAgoAt10(2).toISOString(), 90)
-    addClosed(db, daysAgoAt10(20).toISOString(), 30)
+  it('readWeekStart: Monday unless the setting says sunday', () => {
+    expect(readWeekStart(db)).toBe('monday')
+    db.prepare(`INSERT OR REPLACE INTO settings (key, value) VALUES ('week_start','sunday')`).run()
+    expect(readWeekStart(db)).toBe('sunday')
     db.prepare(
-      `INSERT INTO entries (client_id, description, started_at, billable)
-       VALUES (1, 'running', ?, 1)`
-    ).run(iso(-120_000))
-
-    const mine = readTotals(db)
-    const theirs = getDashboard(
-      db as unknown as SqliteDb,
-      { exposeRates: false, exposePrivateNotes: false },
-      Date.now()
-    )
-    expect(mine.today_seconds).toBe(theirs.today_seconds)
-    expect(mine.week_seconds).toBe(theirs.week_seconds)
+      `INSERT OR REPLACE INTO settings (key, value) VALUES ('week_start','nonsense')`
+    ).run()
+    expect(readWeekStart(db)).toBe('monday')
   })
+
+  // The two settings pick different start days, so a fixed calendar date would
+  // only exercise one of them depending on when the suite runs. Instead: ask
+  // SQLite where the window starts for the configured setting, then place one
+  // entry exactly ON that day and one exactly the day BEFORE. That is
+  // deterministic on every weekday, which is the whole point — the bug this
+  // replaces was invisible on six days out of seven.
+  for (const week of ['monday', 'sunday'] as const) {
+    it(`week window follows the setting — ${week}`, () => {
+      db.prepare(`INSERT OR REPLACE INTO settings (key, value) VALUES ('week_start', ?)`).run(week)
+      const start = (
+        db.prepare(`SELECT DATE('now','localtime',${weekStartModifiers(week)}) AS d`).get() as {
+          d: string
+        }
+      ).d
+      const before = (db.prepare(`SELECT DATE(?, '-1 day') AS d`).get(start) as { d: string }).d
+
+      addClosed(db, atLocalNoon(start), 30)
+      addClosed(db, atLocalNoon(before), 60)
+
+      // Only the entry inside the window counts; the day before is out.
+      expect(readTotals(db).week_seconds).toBe(30 * 60)
+    })
+  }
+
+  it('the two settings disagree exactly on the days between them', () => {
+    // An entry on the most recent Sunday: inside a Sunday-anchored week
+    // always, inside a Monday-anchored week only when that Sunday is today.
+    const sunday = (
+      db.prepare(`SELECT DATE('now','localtime','-6 days','weekday 0') AS d`).get() as { d: string }
+    ).d
+    const todayIsSunday =
+      (db.prepare(`SELECT DATE('now','localtime') AS d`).get() as { d: string }).d === sunday
+    addClosed(db, atLocalNoon(sunday), 45)
+
+    db.prepare(`INSERT OR REPLACE INTO settings (key, value) VALUES ('week_start','sunday')`).run()
+    expect(readTotals(db).week_seconds).toBe(45 * 60)
+
+    db.prepare(`INSERT OR REPLACE INTO settings (key, value) VALUES ('week_start','monday')`).run()
+    expect(readTotals(db).week_seconds).toBe(todayIsSunday ? 45 * 60 : 0)
+  })
+
+  // Under BOTH settings: the MCP dashboard is the second copy of this
+  // definition, and a setting that reaches only one of them would be worse
+  // than no setting at all.
+  for (const week of ['monday', 'sunday'] as const) {
+    it(`agrees with getDashboard() — ${week}`, () => {
+      db.prepare(`INSERT OR REPLACE INTO settings (key, value) VALUES ('week_start', ?)`).run(week)
+      addClosed(db, daysAgoAt10(0).toISOString(), 45)
+      addClosed(db, daysAgoAt10(2).toISOString(), 90)
+      addClosed(db, daysAgoAt10(5).toISOString(), 75)
+      addClosed(db, daysAgoAt10(20).toISOString(), 30)
+      db.prepare(
+        `INSERT INTO entries (client_id, description, started_at, billable)
+         VALUES (1, 'running', ?, 1)`
+      ).run(iso(-120_000))
+
+      const mine = readTotals(db)
+      const theirs = getDashboard(
+        db as unknown as SqliteDb,
+        { exposeRates: false, exposePrivateNotes: false },
+        Date.now()
+      )
+      expect(mine.today_seconds).toBe(theirs.today_seconds)
+      expect(mine.week_seconds).toBe(theirs.week_seconds)
+    })
+  }
 })

--- a/src/main/dashboardTotals.ts
+++ b/src/main/dashboardTotals.ts
@@ -9,6 +9,12 @@
  * is then true by construction instead of by assertion.
  */
 import type Database from 'better-sqlite3'
+import {
+  parseWeekStart,
+  weekStartModifiers,
+  WEEK_START_SETTING_KEY,
+  type WeekStart
+} from '../shared/weekStart'
 
 type Db = Database.Database
 
@@ -20,15 +26,21 @@ const SECONDS = `CASE
      END`
 
 /**
- * Start of the week window, carried over verbatim from the IPC handler.
- *
- * NB: `weekday 0` advances to the *coming* Sunday, so minus seven days lands
- * on the most recent Sunday — the window therefore starts on SUNDAY, despite
- * the "ISO week — Monday as first day" comment that used to sit above it.
- * Kept unchanged on purpose: correcting it would move a number the app has
- * shown since v1.2, which is a product decision, not a refactor.
+ * Start of the week window, per the `week_start` setting (#188). Monday by
+ * default — see `src/shared/weekStart.ts` for why, and for why the modifier
+ * order is `'-6 days', 'weekday N'` and not the other way round.
  */
-const WEEK_START = `DATE('now', 'localtime', 'weekday 0', '-7 days')`
+function weekStartExpr(db: Db): string {
+  return `DATE('now', 'localtime', ${weekStartModifiers(readWeekStart(db))})`
+}
+
+/** The configured week start; absent or unreadable ⇒ the default (Monday). */
+export function readWeekStart(db: Db): WeekStart {
+  const row = db.prepare(`SELECT value FROM settings WHERE key = ?`).get(WEEK_START_SETTING_KEY) as
+    | { value: string }
+    | undefined
+  return parseWeekStart(row?.value)
+}
 
 export interface DayWeekTotals {
   today_seconds: number
@@ -73,7 +85,7 @@ export function readTotals(db: Db): DayWeekTotals {
       `SELECT COALESCE(SUM(${SECONDS}), 0) AS seconds
          FROM entries
         WHERE deleted_at IS NULL
-          AND (DATE(started_at, 'localtime') >= ${WEEK_START}
+          AND (DATE(started_at, 'localtime') >= ${weekStartExpr(db)}
                OR stopped_at IS NULL)`
     )
     .get() as { seconds: number }

--- a/src/main/migrations/026-v118-week-start.ts
+++ b/src/main/migrations/026-v118-week-start.ts
@@ -1,0 +1,21 @@
+import type { Migration } from './index'
+
+/**
+ * v1.18 #188 — configurable week start.
+ *
+ * One default for every installation: `monday`. The week card and the MCP
+ * dashboard counted from Sunday before this, while the export quick filters
+ * and the calendar grid already counted from Monday — so this migration does
+ * not preserve the old behaviour, it ends the disagreement. Existing
+ * installations see the week total move once; the setting puts it back.
+ *
+ * `INSERT OR IGNORE` keeps it idempotent and never overwrites a user choice.
+ */
+export const migration026: Migration = {
+  version: 26,
+  name: 'v1.18-week-start',
+  up: `
+    INSERT OR IGNORE INTO settings (key, value) VALUES
+      ('week_start', 'monday');
+  `
+}

--- a/src/main/migrations/index.ts
+++ b/src/main/migrations/index.ts
@@ -23,6 +23,7 @@ import { migration022 } from './022-v117-domain-project'
 import { migration023 } from './023-v117-hardware-keys'
 import { migration024 } from './024-v117-presence'
 import { migration025 } from './025-v117-ical-feed'
+import { migration026 } from './026-v118-week-start'
 
 export interface Migration {
   /** Monotonically increasing integer. Never reused, never reordered. */
@@ -62,5 +63,6 @@ export const migrations: Migration[] = [
   migration022,
   migration023,
   migration024,
-  migration025
+  migration025,
+  migration026
 ].sort((a, b) => a.version - b.version)

--- a/src/main/migrations/migrations.test.ts
+++ b/src/main/migrations/migrations.test.ts
@@ -133,7 +133,9 @@ describe('migration SQL execution', () => {
       // Migration 011 — Light/Dark/System theme (v1.8 #76)
       { key: 'theme_mode', value: 'system' },
       // Migration 020 — Outbound-Webhooks (v1.15 #134)
-      { key: 'webhook_targets', value: '[]' }
+      { key: 'webhook_targets', value: '[]' },
+      // #188 — one default for every installation, old and new.
+      { key: 'week_start', value: 'monday' }
       // rounding_mode and rounding_minutes removed by Migration 014
     ])
   })

--- a/src/mcp/queries.ts
+++ b/src/mcp/queries.ts
@@ -14,6 +14,7 @@
  * `rate = project.rate ?? client.rate` precedence.
  */
 import { deserializeTags } from '../shared/tags'
+import { parseWeekStart, weekStartModifiers, WEEK_START_SETTING_KEY } from '../shared/weekStart'
 import type { PrivacyConfig } from './privacy'
 
 // ── Minimal driver interface (better-sqlite3 compatible) ───────────────────
@@ -383,11 +384,15 @@ export function getDashboard(db: SqliteDb, privacy: PrivacyConfig, nowMs: number
     )
     .get() as { seconds: number }
 
+  // Week window per the `week_start` setting (#188) — the same expression the
+  // app's dashboard reads, so the MCP dashboard cannot answer a different week
+  // than the window shows.
+  const weekStart = parseWeekStart(getSetting(db, WEEK_START_SETTING_KEY))
   const week = db
     .prepare(
       `SELECT COALESCE(SUM(${SECS}), 0) AS seconds FROM entries
        WHERE deleted_at IS NULL
-         AND (DATE(started_at,'localtime') >= DATE('now','localtime','weekday 0','-7 days')
+         AND (DATE(started_at,'localtime') >= DATE('now','localtime',${weekStartModifiers(weekStart)})
               OR stopped_at IS NULL)`
     )
     .get() as { seconds: number }

--- a/src/renderer/src/hooks/useWeekStart.ts
+++ b/src/renderer/src/hooks/useWeekStart.ts
@@ -1,0 +1,11 @@
+import { useSettingsStore } from '../store/settingsStore'
+import { parseWeekStart, type WeekStart } from '../../../shared/weekStart'
+
+/**
+ * The configured week start (#188). Selector-scoped, so a view only re-renders
+ * when this key changes — same pattern as RoundingContext reads
+ * `pdf_round_minutes`.
+ */
+export function useWeekStart(): WeekStart {
+  return parseWeekStart(useSettingsStore((s) => s.settings?.week_start))
+}

--- a/src/renderer/src/views/CalendarView.tsx
+++ b/src/renderer/src/views/CalendarView.tsx
@@ -15,6 +15,8 @@ import type { Entry } from '../../../shared/types'
 import type { Client, Project } from '../../../shared/types'
 import { useProjectsStore } from '../store/projectsStore'
 import { localDateKey } from '../../../shared/dateRanges'
+import { weekStartsOn, type WeekStart } from '../../../shared/weekStart'
+import { useWeekStart } from '../hooks/useWeekStart'
 import { useEntriesStore } from '../store/entriesStore'
 import { useTimer } from '../hooks/useTimer'
 import { CalendarDrawer } from '../components/CalendarDrawer'
@@ -36,6 +38,7 @@ export default function CalendarView(): React.JSX.Element {
   const t = useT()
   const { clients } = useTimer()
   const { roundMinutes } = useRounding()
+  const weekStart = useWeekStart()
   const version = useEntriesStore((s) => s.version)
   const projectsVersion = useProjectsStore((s) => s.version)
 
@@ -95,7 +98,7 @@ export default function CalendarView(): React.JSX.Element {
   }, [entries])
 
   // Build the visible grid (Mon-anchored weeks covering the whole month).
-  const weeks = useMemo(() => buildMonthWeeks(cursor), [cursor])
+  const weeks = useMemo(() => buildMonthWeeks(cursor, weekStart), [cursor, weekStart])
 
   const onPrev = useCallback(() => setCursor((d) => addMonths(d, -1)), [])
   const onNext = useCallback(() => setCursor((d) => addMonths(d, 1)), [])
@@ -437,10 +440,12 @@ function DayBars({
 
 // --- helpers ---
 
-function buildMonthWeeks(cursor: Date): WeekData[] {
-  // Mon-anchored weeks covering the visible month.
-  const start = startOfWeek(startOfMonth(cursor), { weekStartsOn: 1 })
-  const end = endOfWeek(endOfMonth(cursor), { weekStartsOn: 1 })
+function buildMonthWeeks(cursor: Date, week: WeekStart): WeekData[] {
+  // Weeks covering the visible month, anchored per the week_start setting
+  // (#188) so the grid breaks where the week total does.
+  const opts = { weekStartsOn: weekStartsOn(week) } as const
+  const start = startOfWeek(startOfMonth(cursor), opts)
+  const end = endOfWeek(endOfMonth(cursor), opts)
   const weeks: WeekData[] = []
   let d = start
   while (d <= end) {

--- a/src/renderer/src/views/ExportView.tsx
+++ b/src/renderer/src/views/ExportView.tsx
@@ -4,6 +4,7 @@ import type { TranslationKey } from '../../../shared/locales/de'
 import { ExportModal } from '../components/ExportModal'
 import { PdfMergeModal } from '../components/PdfMergeModal'
 import { getQuickRange, localDateKey, type QuickRangeKind } from '../../../shared/dateRanges'
+import { useWeekStart } from '../hooks/useWeekStart'
 
 /**
  * Export view (#153).
@@ -27,16 +28,22 @@ import { getQuickRange, localDateKey, type QuickRangeKind } from '../../../share
  */
 export default function ExportView(): React.JSX.Element {
   const t = useT()
+  const weekStart = useWeekStart()
 
   // Range hand-off to ExportModal. `null` = closed; a range = open with that
   // range prefilled.
   const [pdfRange, setPdfRange] = useState<{ fromIso: string; toIso: string } | null>(null)
   const [mergeOpen, setMergeOpen] = useState(false)
 
-  const onQuickRange = useCallback((kind: QuickRangeKind) => {
-    const range = getQuickRange(kind, new Date())
-    setPdfRange({ fromIso: localDateKey(range.from), toIso: localDateKey(range.to) })
-  }, [])
+  // "Diese/Letzte Woche" follows the week_start setting (#188) — otherwise the
+  // quick filter would hand over a different week than the week total shows.
+  const onQuickRange = useCallback(
+    (kind: QuickRangeKind) => {
+      const range = getQuickRange(kind, new Date(), weekStart)
+      setPdfRange({ fromIso: localDateKey(range.from), toIso: localDateKey(range.to) })
+    },
+    [weekStart]
+  )
 
   return (
     <div className="mx-auto flex w-full max-w-[920px] flex-col gap-4">

--- a/src/renderer/src/views/SettingsView.tsx
+++ b/src/renderer/src/views/SettingsView.tsx
@@ -350,6 +350,16 @@ export default function SettingsView(): React.JSX.Element {
                 <option value="en">{t('settings.language.en')}</option>
               </select>
             </Row>
+            <Row label={t('settings.general.weekStart')} hint={t('settings.general.weekStartHint')}>
+              <SegmentedPicker
+                options={[
+                  { value: 'monday', label: t('settings.general.weekStartMonday') },
+                  { value: 'sunday', label: t('settings.general.weekStartSunday') }
+                ]}
+                value={settings.week_start === 'sunday' ? 'sunday' : 'monday'}
+                onChange={(v) => void update('week_start', v)}
+              />
+            </Row>
             <Row label={t('settings.general.onboarding')}>
               <button
                 type="button"

--- a/src/shared/dateRanges.test.ts
+++ b/src/shared/dateRanges.test.ts
@@ -121,3 +121,45 @@ describe('localDateKey', () => {
     expect(localDateKey(local(2025, 12, 31, 23, 59))).toBe('2025-12-31')
   })
 })
+
+describe('getQuickRange — week_start setting (#188)', () => {
+  it('defaults to Monday when no week start is passed', () => {
+    // 2026-04-24 is a Friday. Same expectation as the tests above, stated
+    // explicitly so the default cannot be changed unnoticed.
+    const r = getQuickRange('thisWeek', local(2026, 4, 24))
+    expect(dayKey(r.from)).toBe('2026-04-20') // Mon
+    expect(dayKey(r.to)).toBe('2026-04-26') // Sun
+  })
+
+  it('thisWeek anchors to Sunday when configured that way', () => {
+    const r = getQuickRange('thisWeek', local(2026, 4, 24), 'sunday')
+    expect(dayKey(r.from)).toBe('2026-04-19') // Sun
+    expect(dayKey(r.to)).toBe('2026-04-25') // Sat
+    expect(r.from.getHours()).toBe(0)
+    expect(r.to.getMilliseconds()).toBe(999)
+  })
+
+  it('on the boundary day itself the week starts that day', () => {
+    // 2026-04-19 is a Sunday.
+    const r = getQuickRange('thisWeek', local(2026, 4, 19), 'sunday')
+    expect(dayKey(r.from)).toBe('2026-04-19')
+    expect(dayKey(r.to)).toBe('2026-04-25')
+  })
+
+  it('lastWeek shifts by exactly seven days under both settings', () => {
+    const mon = getQuickRange('lastWeek', local(2026, 4, 24), 'monday')
+    expect(dayKey(mon.from)).toBe('2026-04-13')
+    expect(dayKey(mon.to)).toBe('2026-04-19')
+
+    const sun = getQuickRange('lastWeek', local(2026, 4, 24), 'sunday')
+    expect(dayKey(sun.from)).toBe('2026-04-12')
+    expect(dayKey(sun.to)).toBe('2026-04-18')
+  })
+
+  it('month ranges ignore the setting', () => {
+    const a = getQuickRange('thisMonth', local(2026, 4, 24), 'monday')
+    const b = getQuickRange('thisMonth', local(2026, 4, 24), 'sunday')
+    expect(dayKey(a.from)).toBe(dayKey(b.from))
+    expect(dayKey(a.to)).toBe(dayKey(b.to))
+  })
+})

--- a/src/shared/dateRanges.ts
+++ b/src/shared/dateRanges.ts
@@ -1,12 +1,13 @@
 import { endOfMonth, endOfWeek, startOfMonth, startOfWeek, subMonths, subWeeks } from 'date-fns'
+import { DEFAULT_WEEK_START, weekStartsOn, type WeekStart } from './weekStart'
 
 /**
  * Quick-filter ranges for the calendar / PDF export hero path (#21).
  *
  * Returned `from` is the inclusive start (00:00:00.000 local) and `to` is
  * the inclusive end (23:59:59.999 local). DST-safe because date-fns
- * normalises to local wall-clock and we anchor weeks to Monday for the
- * de-DE locale.
+ * normalises to local wall-clock. The week anchor follows the `week_start`
+ * setting (#188); callers that do not pass one get the default.
  */
 export type QuickRangeKind = 'thisWeek' | 'lastWeek' | 'thisMonth' | 'lastMonth'
 
@@ -15,15 +16,18 @@ export interface DateRange {
   to: Date
 }
 
-const WEEK_OPTS = { weekStartsOn: 1 } as const // Monday
-
-export function getQuickRange(kind: QuickRangeKind, now: Date): DateRange {
+export function getQuickRange(
+  kind: QuickRangeKind,
+  now: Date,
+  week: WeekStart = DEFAULT_WEEK_START
+): DateRange {
+  const opts = { weekStartsOn: weekStartsOn(week) } as const
   switch (kind) {
     case 'thisWeek':
-      return { from: startOfWeek(now, WEEK_OPTS), to: endOfWeek(now, WEEK_OPTS) }
+      return { from: startOfWeek(now, opts), to: endOfWeek(now, opts) }
     case 'lastWeek': {
       const ref = subWeeks(now, 1)
-      return { from: startOfWeek(ref, WEEK_OPTS), to: endOfWeek(ref, WEEK_OPTS) }
+      return { from: startOfWeek(ref, opts), to: endOfWeek(ref, opts) }
     }
     case 'thisMonth':
       return { from: startOfMonth(now), to: endOfMonth(now) }

--- a/src/shared/locales/de.ts
+++ b/src/shared/locales/de.ts
@@ -454,6 +454,11 @@ export const de = {
   'settings.general.showProjectNumber': 'Projektnummer anzeigen',
   'settings.general.showProjectNumberHint':
     'Externe Projektnummer in eckigen Klammern hinter dem Projektnamen anzeigen, falls vergeben.',
+  'settings.general.weekStart': 'Woche beginnt am',
+  'settings.general.weekStartHint':
+    'Gilt für die Wochensumme (Heute, Tray, Stream Deck), die Schnellfilter im Export und das Kalenderraster. Die KW-Achse in der Auswertung bleibt nach ISO 8601 immer montags.',
+  'settings.general.weekStartMonday': 'Montag',
+  'settings.general.weekStartSunday': 'Sonntag',
   'settings.general.company': 'Firma (für Exporte)',
   'settings.general.companyPlaceholder': 'z. B. Meine Firma GmbH',
   'settings.section.timer': 'Timer',

--- a/src/shared/locales/en.ts
+++ b/src/shared/locales/en.ts
@@ -449,6 +449,11 @@ export const en: Record<TranslationKey, string> = {
   'settings.general.showProjectNumber': 'Show project number',
   'settings.general.showProjectNumberHint':
     'Display the external project number in square brackets after the project name, if set.',
+  'settings.general.weekStart': 'Week starts on',
+  'settings.general.weekStartHint':
+    'Applies to the week total (Today, tray, Stream Deck), the export quick filters and the calendar grid. The KW axis in Auswertung stays Monday-based per ISO 8601.',
+  'settings.general.weekStartMonday': 'Monday',
+  'settings.general.weekStartSunday': 'Sunday',
   'settings.general.company': 'Company (for exports)',
   'settings.general.companyPlaceholder': 'e.g. My Company Ltd.',
   'settings.section.timer': 'Timer',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -181,6 +181,11 @@ export interface Settings {
   onboarding_completed: string
   // v1.8 #76 — Theme mode: 'light' | 'dark' | 'system'.
   theme_mode: string
+  // v1.18 #188 — Where the week begins: 'monday' (default) | 'sunday'.
+  // Drives the week total (Heute card, tray, Stream Deck dial, MCP dashboard),
+  // the export quick filters and the calendar grid. NOT the KW axis in
+  // Auswertung — the calendar week is ISO 8601, i.e. always Monday.
+  week_start?: string
   // v1.11 #94 — Show external project number in square brackets.
   // '0' (default) = hidden, '1' = shown.
   show_project_number?: string

--- a/src/shared/weekStart.test.ts
+++ b/src/shared/weekStart.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for the week-start helper (#188).
+ *
+ * The interesting one is the SQL modifier order. The week card shipped with
+ * `'weekday 0', '-7 days'`, which is correct on six days out of seven and
+ * silently wrong on the seventh: on the boundary day `weekday N` does not
+ * move, so the `-7 days` lands a week early and the "week" is eight days long.
+ * Every weekday is checked here, for both settings — that is the only way this
+ * class of bug shows up, because six of seven days look fine.
+ *
+ * SQLite evaluates the modifiers, not us: the test asserts against the real
+ * date arithmetic rather than a reimplementation of it.
+ */
+import { describe, it, expect, beforeAll } from 'vitest'
+import type Database from 'better-sqlite3'
+import { loadSqlite, type DatabaseCtor } from '../test/sqlite'
+import {
+  DEFAULT_WEEK_START,
+  parseWeekStart,
+  weekStartModifiers,
+  weekStartsOn,
+  type WeekStart
+} from './weekStart'
+
+let DatabaseImpl: DatabaseCtor
+let db: Database.Database
+
+beforeAll(async () => {
+  DatabaseImpl = await loadSqlite()
+  db = new DatabaseImpl(':memory:')
+})
+
+/** Run the modifier chain against a fixed anchor date. */
+function weekStartOf(date: string, week: WeekStart): string {
+  const row = db.prepare(`SELECT DATE(?, ${weekStartModifiers(week)}) AS d`).get(date) as {
+    d: string
+  }
+  return row.d
+}
+
+/** The old, subtly wrong expression — kept to demonstrate what changed. */
+function legacyWeekStart(date: string): string {
+  return (db.prepare(`SELECT DATE(?, 'weekday 0', '-7 days') AS d`).get(date) as { d: string }).d
+}
+
+// 2026-08-02 is a Sunday; 2026-08-03 a Monday; through 2026-08-08 (Saturday).
+const WEEK = {
+  sun: '2026-08-02',
+  mon: '2026-08-03',
+  tue: '2026-08-04',
+  wed: '2026-08-05',
+  thu: '2026-08-06',
+  fri: '2026-08-07',
+  sat: '2026-08-08'
+}
+
+describe('parseWeekStart', () => {
+  it('defaults to Monday for anything that is not exactly "sunday"', () => {
+    expect(DEFAULT_WEEK_START).toBe('monday')
+    expect(parseWeekStart('sunday')).toBe('sunday')
+    expect(parseWeekStart('monday')).toBe('monday')
+    expect(parseWeekStart(undefined)).toBe('monday')
+    expect(parseWeekStart(null)).toBe('monday')
+    expect(parseWeekStart('')).toBe('monday')
+    expect(parseWeekStart('Sunday')).toBe('monday') // exact match only
+    expect(parseWeekStart('garbage')).toBe('monday')
+  })
+
+  it('maps to date-fns weekStartsOn', () => {
+    expect(weekStartsOn('monday')).toBe(1)
+    expect(weekStartsOn('sunday')).toBe(0)
+  })
+})
+
+describe('weekStartModifiers — Monday', () => {
+  it('every day of a week resolves to the same Monday', () => {
+    // Monday through Sunday all belong to the week starting 2026-08-03.
+    for (const day of [WEEK.mon, WEEK.tue, WEEK.wed, WEEK.thu, WEEK.fri, WEEK.sat]) {
+      expect(weekStartOf(day, 'monday'), `for ${day}`).toBe(WEEK.mon)
+    }
+    // The Sunday BEFORE that Monday belongs to the previous week (ISO).
+    expect(weekStartOf(WEEK.sun, 'monday')).toBe('2026-07-27')
+  })
+
+  it('the boundary day maps to itself, not a week back', () => {
+    expect(weekStartOf(WEEK.mon, 'monday')).toBe(WEEK.mon)
+  })
+})
+
+describe('weekStartModifiers — Sunday', () => {
+  it('every day of a week resolves to the same Sunday', () => {
+    for (const day of [WEEK.mon, WEEK.tue, WEEK.wed, WEEK.thu, WEEK.fri, WEEK.sat]) {
+      expect(weekStartOf(day, 'sunday'), `for ${day}`).toBe(WEEK.sun)
+    }
+  })
+
+  it('the boundary day maps to itself, not a week back', () => {
+    expect(weekStartOf(WEEK.sun, 'sunday')).toBe(WEEK.sun)
+  })
+})
+
+describe('the bug the old expression had', () => {
+  it('agreed with the new one on six days …', () => {
+    for (const day of [WEEK.mon, WEEK.tue, WEEK.wed, WEEK.thu, WEEK.fri, WEEK.sat]) {
+      expect(legacyWeekStart(day), `for ${day}`).toBe(weekStartOf(day, 'sunday'))
+    }
+  })
+
+  it('… and produced an eight-day week on the seventh', () => {
+    // On a Sunday the old chain stepped back a full extra week: the window
+    // started 2026-07-26 and therefore counted eight days.
+    expect(legacyWeekStart(WEEK.sun)).toBe('2026-07-26')
+    expect(weekStartOf(WEEK.sun, 'sunday')).toBe(WEEK.sun)
+  })
+})
+
+describe('window length', () => {
+  it('is exactly seven days from every day, for both settings', () => {
+    const days = Object.values(WEEK)
+    for (const week of ['monday', 'sunday'] as const) {
+      for (const day of days) {
+        const start = weekStartOf(day, week)
+        const spanned = db
+          .prepare(`SELECT CAST(julianday(?) - julianday(?) AS INTEGER) AS n`)
+          .get(day, start) as { n: number }
+        expect(spanned.n, `${week} / ${day}`).toBeGreaterThanOrEqual(0)
+        expect(spanned.n, `${week} / ${day}`).toBeLessThan(7)
+      }
+    }
+  })
+})

--- a/src/shared/weekStart.ts
+++ b/src/shared/weekStart.ts
@@ -1,0 +1,52 @@
+/**
+ * Where the week begins (#188).
+ *
+ * Until v1.17 the app disagreed with itself: the "Heute" week card and the MCP
+ * dashboard counted from Sunday, while the export quick filters and the
+ * calendar grid counted from Monday. One setting now decides, and every
+ * surface that shows a *week* reads it from here.
+ *
+ * The one exception is the 12-week chart in Auswertung: its bars are labelled
+ * `KW##`, and the calendar week is defined by ISO 8601 as Monday-based. That
+ * is not a matter of taste, so those buckets stay Monday no matter what this
+ * setting says.
+ */
+
+export type WeekStart = 'monday' | 'sunday'
+
+/**
+ * Monday — what three of the app's five week computations already did, and
+ * what ISO 8601 and the de-DE locale expect. Installations that ran the old
+ * Sunday-based week card see that one number change once (release note), and
+ * can set it back here.
+ */
+export const DEFAULT_WEEK_START: WeekStart = 'monday'
+
+export const WEEK_START_SETTING_KEY = 'week_start'
+
+/** Anything that is not exactly `sunday` is the default — settings are text. */
+export function parseWeekStart(value: string | null | undefined): WeekStart {
+  return value === 'sunday' ? 'sunday' : DEFAULT_WEEK_START
+}
+
+/** date-fns `weekStartsOn`: 0 = Sunday, 1 = Monday. */
+export function weekStartsOn(week: WeekStart): 0 | 1 {
+  return week === 'sunday' ? 0 : 1
+}
+
+/**
+ * SQLite modifiers that move a date to the start of *its own* week.
+ *
+ * Order matters, and the obvious order is wrong. `'weekday N', '-7 days'`
+ * (what the week card shipped with) advances to the *coming* weekday first —
+ * so on the boundary day itself it stays put, and the `-7 days` then lands a
+ * whole week early: an eight-day "week" every Sunday.
+ *
+ * `'-6 days', 'weekday N'` has no such day. Step back six days, then forward
+ * to the next boundary: for every weekday including the boundary itself, that
+ * is the start of the current week. `weekStart.test.ts` pins all seven days
+ * for both settings.
+ */
+export function weekStartModifiers(week: WeekStart): string {
+  return `'-6 days', 'weekday ${weekStartsOn(week)}'`
+}


### PR DESCRIPTION
Closes #188. **Stacked on #187** — base is `feat/186-timer-dial`, because the file this touches first (`dashboardTotals.ts`) is created there. Merge #187 first; GitHub then retargets this to `main`. Since the repo squash-merges, I rebase this branch onto `main` before it goes in rather than letting the two histories collide.

## What changed

The app had two week conventions at once. Three of five computations already counted from Monday (export quick filters, calendar grid, the KW chart); the week total and the MCP dashboard counted from Sunday. Now one setting decides.

- **`week_start`** (Einstellungen → Allgemein), `monday` | `sunday`, **default Monday for every installation** — old and new. Migration 026 seeds it. Existing installs see the week total move once; the setting puts it back. No two-defaults split: the same app showing a different week depending on install date would make support questions unanswerable.
- **Reaches** the week total (Heute card, tray, Stream Deck dial, MCP dashboard), the export quick filters and the calendar grid. Takes effect without a restart — the setting is read per query.
- **Does not reach** the `KW##` axis in Auswertung, on purpose: ISO 8601 defines the calendar week as Monday-based, so a Sunday-anchored `KW32` bar would be a wrong number rather than a preference. A comment sits there now so it does not get "fixed" later.
- `src/shared/weekStart.ts` is the single definition, shared by the SQL windows (main + mcp) and the date-fns callers (renderer).

## The bug underneath

The window expression was `'weekday N', '-7 days'`. That is correct on six days out of seven. On the boundary day itself `weekday N` does not move the date, so the `-7 days` lands a full week early — **an eight-day week every Sunday**, which is what today happens to be.

`'-6 days', 'weekday N'` has no such day: step back six, then forward to the next boundary. `weekStart.test.ts` checks all seven weekdays for both settings, asserts the window is always exactly seven days, and keeps the old expression around to show precisely where it broke:

```
legacyWeekStart('2026-08-02')  → '2026-07-26'   (8 days)
weekStartOf('2026-08-02', 'sunday') → '2026-08-02'
```

## Why the parity test earned its keep

`dashboardTotals.test.ts` pins `readTotals()` against `getDashboard()` in the MCP layer — the second copy of the same definition. Changing only the app side turned it red immediately, which is how the MCP dashboard came along instead of being forgotten. It now runs under **both** settings.

## Verification

- `pnpm test` — **52 files, 969 passed, 0 skipped** (19 new)
- `pnpm typecheck` clean, `pnpm lint` 11 warnings, all pre-existing
- The migration test pins the full seeded settings table and went red until the new key was declared — kept as-is

## Release note (for the release PR)

> **Die Woche beginnt jetzt am Montag** — einstellbar unter Einstellungen → Allgemein. Bisher zählte die Wochensumme ab Sonntag, während Export-Schnellfilter und Kalender bereits ab Montag rechneten. Die Wochensumme ändert sich dadurch einmalig. Wer die alte Zählung will, stellt sie dort auf Sonntag zurück.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
