### PR TITLE
chore(#190): close two verification gaps — test-file coverage guard, plugin build in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,3 +67,27 @@ jobs:
       # Electron, which is how the cached poison above came to exist.
       - name: Test
         run: pnpm test
+
+      # #190: The Stream Deck plugin is its own package (own lockfile, own
+      # toolchain) and is NOT part of the app build. Its pure modules already
+      # run inside `pnpm test` as the `streamdeck` Vitest project — but nothing
+      # checked that the plugin still compiles or bundles. That gap matters
+      # more than usual here: a plugin crash leaves no trace (Elgato logs only
+      # "Plugin connected"; stdout goes nowhere), so a broken build would first
+      # show up as a key that silently does nothing.
+      #
+      # Order matters: the plugin's tsconfig also typechecks its test files,
+      # which import `vitest` — that resolves upwards into the root
+      # node_modules installed above. Do not move these steps before the root
+      # install.
+      - name: Stream Deck plugin — install
+        working-directory: streamdeck-plugin
+        run: pnpm install --frozen-lockfile --ignore-workspace
+
+      - name: Stream Deck plugin — typecheck
+        working-directory: streamdeck-plugin
+        run: pnpm typecheck
+
+      - name: Stream Deck plugin — build
+        working-directory: streamdeck-plugin
+        run: pnpm build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,13 @@ und **kein** Kommando meldet einen Fehler. Der Marker lügt.
 
 - Tests laufen mit `pnpm test`. Das startet Vitest über `scripts/run-vitest.mjs` auf der
   Electron-Binary im Node-Modus — dieselbe Lösung wie beim MCP-Server
-  (`src/main/mcpLaunch.ts`). Ein grüner Lauf ist **596 passed, 0 skipped**.
+  (`src/main/mcpLaunch.ts`). Ein grüner Lauf ist **0 skipped** über alle Vitest-Projekte.
+- Hier steht bewusst **keine absolute Testzahl** mehr. Sie war ein Proxy für die
+  Bedingung und veraltete mit jedem PR (zuletzt „596" gegen tatsächlich 969) — eine
+  falsche Zahl liest sich wie ein Defekt und lädt zum „Reparieren" ein. Was die Zahl
+  nebenbei absicherte — eine still schrumpfende Suite —, prüft jetzt
+  `src/test/vitestProjects.test.ts`: jede `*.test.ts(x)` im Repo muss von einem
+  Vitest-Projekt eingeschlossen sein, und jedes Projekt muss noch etwas finden.
 - `pnpm exec vitest` direkt aufzurufen kann nicht funktionieren und scheitert mit einer
   Anleitung. Das ist kein Umgebungsproblem, das du „reparieren" sollst.
 - Dreistellige Skip-Zahlen bedeuten kaputte Umgebung, nie „grün". Melde das, statt

--- a/src/test/vitestProjects.test.ts
+++ b/src/test/vitestProjects.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Guard: every test file in the repo is actually run by some Vitest project.
+ *
+ * This replaces the absolute test count that used to sit in CLAUDE.md ("a
+ * green run is 596 passed"). That number was a proxy for the real condition,
+ * and it rotted within three releases — 596 against an actual 969 reads as
+ * "something is broken" to whoever compares them next.
+ *
+ * But the number did cover one thing the "0 skipped" rule does not: a suite
+ * that silently *shrinks*. Vitest runs the files its projects include and says
+ * nothing about the ones they do not — a test file in an uncovered directory
+ * never runs, reports no skip, and leaves the run green. That risk grew when
+ * the `streamdeck` project was added for the plugin's modules (#186): had the
+ * registration been wrong, 32 tests would have quietly stopped existing.
+ *
+ * So the condition moves out of prose and into a check that can go red:
+ *   - every `*.test.ts(x)` in the repo matches at least one project's include
+ *   - every project's include still matches at least one file
+ *
+ * The config is imported, not parsed — the assertion is about the object
+ * Vitest actually runs on, not about the text of the file.
+ */
+import { describe, it, expect } from 'vitest'
+import { readdirSync } from 'node:fs'
+import { join, relative, resolve, sep } from 'node:path'
+import config from '../../vitest.config'
+
+const REPO_ROOT = resolve(__dirname, '..', '..')
+
+/** Directories that never hold source tests (build output, deps, tooling). */
+const SKIP_DIRS = new Set([
+  'node_modules',
+  'dist',
+  'out',
+  'build',
+  'coverage',
+  'release',
+  'templates',
+  'resources'
+])
+
+function findTestFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.')) continue
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue
+      findTestFiles(join(dir, entry.name), acc)
+    } else if (/\.test\.tsx?$/.test(entry.name)) {
+      acc.push(relative(REPO_ROOT, join(dir, entry.name)).split(sep).join('/'))
+    }
+  }
+  return acc
+}
+
+/**
+ * Minimal glob → RegExp for the shapes these Vitest configs actually use: a
+ * double star plus slash (any depth), a single star (one path segment), and
+ * `{ts,tsx}` alternation. Not a general glob implementation — the assertions
+ * below pin exactly what it claims to handle.
+ */
+export function globToRegExp(glob: string): RegExp {
+  let out = ''
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i]
+    if (c === '*' && glob[i + 1] === '*' && glob[i + 2] === '/') {
+      out += '(?:[^/]+/)*'
+      i += 2
+    } else if (c === '*' && glob[i + 1] === '*') {
+      out += '.*'
+      i += 1
+    } else if (c === '*') {
+      out += '[^/]*'
+    } else if (c === '{') {
+      const end = glob.indexOf('}', i)
+      out += `(?:${glob
+        .slice(i + 1, end)
+        .split(',')
+        .map((alt) => alt.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+        .join('|')})`
+      i = end
+    } else if ('.+?^$()[]|\\'.includes(c)) {
+      out += `\\${c}`
+    } else {
+      out += c
+    }
+  }
+  return new RegExp(`^${out}$`)
+}
+
+interface ProjectShape {
+  test?: { name?: string; include?: string[] }
+}
+
+const projects = ((config as { test?: { projects?: ProjectShape[] } }).test?.projects ??
+  []) as ProjectShape[]
+
+const declared = projects.map((p) => ({
+  name: p.test?.name ?? '(unnamed)',
+  patterns: (p.test?.include ?? []).map((g) => ({ glob: g, re: globToRegExp(g) }))
+}))
+
+describe('vitest projects cover every test file', () => {
+  const files = findTestFiles(REPO_ROOT)
+
+  it('finds test files at all — a broken walker would make this vacuous', () => {
+    expect(files.length).toBeGreaterThan(20)
+  })
+
+  it('declares at least one project, each with includes', () => {
+    expect(declared.length).toBeGreaterThan(0)
+    for (const p of declared) {
+      expect(p.patterns.length, `project "${p.name}" has no include patterns`).toBeGreaterThan(0)
+    }
+  })
+
+  it('every test file is included by some project', () => {
+    const orphans = files.filter((f) => !declared.some((p) => p.patterns.some((x) => x.re.test(f))))
+    // A file listed here runs nowhere: green, zero skips, zero coverage.
+    expect(orphans, `test files no Vitest project runs:\n  ${orphans.join('\n  ')}`).toEqual([])
+  })
+
+  it('every project still matches at least one file', () => {
+    for (const p of declared) {
+      const matched = files.filter((f) => p.patterns.some((x) => x.re.test(f)))
+      expect(
+        matched.length,
+        `project "${p.name}" matches nothing — patterns: ${p.patterns.map((x) => x.glob).join(', ')}`
+      ).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('globToRegExp', () => {
+  it('handles the shapes used in the config', () => {
+    expect(globToRegExp('src/main/**/*.test.ts').test('src/main/ipc.test.ts')).toBe(true)
+    expect(globToRegExp('src/main/**/*.test.ts').test('src/main/migrations/x.test.ts')).toBe(true)
+    expect(globToRegExp('src/main/**/*.test.ts').test('src/mcp/x.test.ts')).toBe(false)
+    // Extension alternation.
+    const rx = globToRegExp('src/renderer/**/*.test.{ts,tsx}')
+    expect(rx.test('src/renderer/src/views/A.test.tsx')).toBe(true)
+    expect(rx.test('src/renderer/src/views/A.test.ts')).toBe(true)
+    expect(rx.test('src/renderer/src/views/A.test.js')).toBe(false)
+    // `*` stays within one segment.
+    expect(globToRegExp('a/*/b.test.ts').test('a/x/b.test.ts')).toBe(true)
+    expect(globToRegExp('a/*/b.test.ts').test('a/x/y/b.test.ts')).toBe(false)
+    // A dot is a literal, not "any character".
+    expect(globToRegExp('src/a.test.ts').test('src/aXtest.ts')).toBe(false)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,7 +19,14 @@ export default defineConfig({
         test: {
           name: 'node',
           environment: 'node',
-          include: ['src/main/**/*.test.ts', 'src/shared/**/*.test.ts', 'src/mcp/**/*.test.ts']
+          include: [
+            'src/main/**/*.test.ts',
+            'src/shared/**/*.test.ts',
+            'src/mcp/**/*.test.ts',
+            // src/test holds the shared test bootstrap and the meta-test that
+            // checks these very patterns still cover every test file.
+            'src/test/**/*.test.ts'
+          ]
         }
       },
       {


### PR DESCRIPTION
Closes #190.

## 1. The number in CLAUDE.md is gone, the condition stays

`CLAUDE.md` claimed "a green run is **596 passed, 0 skipped**". It is 969. A stale number is worse than none — whoever compares reads it as a defect and starts fixing.

The operative half (`0 skipped`) already stood one line below. But the number covered one case by accident that the skip rule does not: **a suite that silently shrinks**. Vitest runs what its projects include and says nothing about the rest — a test file in an uncovered directory never runs, reports no skip, leaves the run green. Adding the `streamdeck` project in #186 grew that risk: a wrong registration would have made 32 tests quietly stop existing, and nothing would have said so.

So the condition moved out of prose and into `src/test/vitestProjects.test.ts`:

- every `*.test.ts(x)` in the repo is included by some project
- every project still matches at least one file

It **imports** `vitest.config.ts` rather than parsing the text, so the assertion is about the object Vitest actually runs on.

**Verified red before being kept** — a guard that has never failed is a decoration:

| Sabotage | Result |
| --- | --- |
| `streamdeck` project removed from the config | `test files no Vitest project runs: streamdeck-plugin/src/dialImage.test.ts, .../dialModel.test.ts` |
| `src/preload/orphan.test.ts` dropped in | `test files no Vitest project runs: src/preload/orphan.test.ts` |

Both restored afterwards; the suite is green again.

`src/test/**/*.test.ts` joins the node project's includes — that directory held only helpers until now, which is why the meta-test would itself have been an orphan.

## 2. The Stream Deck plugin is typechecked and built in CI

Its pure modules already ran in CI through the `streamdeck` project. `tsc --noEmit` and the esbuild bundle ran nowhere. That gap matters more here than usual: **a plugin crash leaves no trace** — Elgato logs only `Plugin connected` and the plugin's stdout goes nowhere, so a broken build would first show up as a key that silently does nothing.

Three steps in `test.yml` (~1 min). Commands verified locally from a wiped `node_modules`. The step order is documented in the workflow: the plugin's tsconfig also typechecks its test files, which import `vitest` and resolve it from the root install — moving these steps above the root install would break them.

## Not in this PR, and worth a decision

**The plugin is not shipped at all.** It appears neither in `electron-builder.yml` nor in the release workflow; there is no `.streamDeckPlugin` artifact. Someone updating the app does not get the dial — they would have to build and link it from the repo. v1.17.0's changelog reads as if the plugin ships with the app; for v1.18 the changelog will say plainly that it does not. Packaging it is a separate decision (Elgato CLI in the runner, plugin-vs-app versioning) and belongs in its own issue.

## Verification

- `pnpm test` — **53 files, 974 passed, 0 skipped** (5 new)
- `pnpm typecheck` clean, `pnpm lint` 11 warnings, all pre-existing
- Plugin from a clean install: `pnpm install --frozen-lockfile --ignore-workspace`, `pnpm typecheck`, `pnpm build` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
