### PR TITLE
chore(#192): prove the plugin package on every PR, not only at release time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,12 @@ jobs:
       # `pack` refuses to package a manifest that would not install (icons must
       # be PNG, layouts must resolve). Running validate first makes that failure
       # say what is wrong instead of just aborting the pack.
+      #
+      # Both steps run with pinned validation rules (--no-update-check, see
+      # package.json). A release must not fail because Elgato published a rule
+      # change while the job was running; the same commands ran green on the PR
+      # that produced this commit. `pnpm run validate:rules` is where new rules
+      # are picked up, deliberately.
       - name: Validate manifest
         working-directory: streamdeck-plugin
         run: pnpm run validate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,12 +69,18 @@ jobs:
   # willing to build and link a plugin themselves — the feature shipped, the
   # function did not.
   #
-  # Its own job on Linux: the package is platform-neutral (JS + manifest + PNGs)
-  # and has nothing to do with the Electron build, so it neither slows the two
+  # Its own job, because the package is platform-neutral (JS + manifest + PNGs)
+  # and has nothing to do with the Electron build — it neither slows the two
   # installer jobs down nor fails with them.
+  #
+  # windows-latest, not ubuntu, although the work is OS-agnostic: `test.yml`
+  # packs on Windows for every PR, so that is the environment with evidence
+  # behind it. Shipping from an environment no gate exercises would be a claim
+  # rather than a verification. (The archive itself is portable either way — a
+  # plain ZIP with POSIX separators, checked on a Windows-packed file.)
   pack-streamdeck:
     needs: prepare
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     permissions:
       contents: read
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,3 +91,31 @@ jobs:
       - name: Stream Deck plugin — build
         working-directory: streamdeck-plugin
         run: pnpm build
+
+      # #192 follow-up: the release job packs the plugin, but release.yml only
+      # triggers on tags — so until now the artifact path was first exercised
+      # while cutting a release, which is the worst moment to discover that the
+      # manifest does not validate. Producing the package here proves it on
+      # every PR instead.
+      #
+      # Both commands carry --no-update-check (see package.json): the CLI
+      # otherwise fetches its validation rules at run time, which would let a
+      # server-side rule change turn an unrelated PR red. The pinned CLI plus
+      # pinned rules make this reproducible; `pnpm run validate:rules` is the
+      # deliberate check for whether Elgato changed anything.
+      - name: Stream Deck plugin — validate manifest
+        working-directory: streamdeck-plugin
+        run: pnpm run validate
+
+      - name: Stream Deck plugin — pack
+        working-directory: streamdeck-plugin
+        run: pnpm run pack
+
+      # Side benefit worth the five lines: the packed plugin of any PR can be
+      # downloaded from the run and installed on real hardware before merging.
+      - name: Upload packed plugin
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: timetrack-streamdeck-plugin-${{ github.sha }}
+          path: streamdeck-plugin/dist/*.streamDeckPlugin
+          if-no-files-found: error

--- a/streamdeck-plugin/README.md
+++ b/streamdeck-plugin/README.md
@@ -58,6 +58,20 @@ pnpm run validate     # what CI runs before packing — manifest + icon rules
 pnpm run pack         # dist/com.timetrack.streamdeck.streamDeckPlugin
 ```
 
+Both run with `--no-update-check`: the Elgato CLI otherwise fetches its
+validation rules at run time, which would let a server-side rule change turn an
+unrelated PR red. The CLI is pinned in the lockfile, so the rules move only
+when the dependency is bumped on purpose. To ask whether Elgato changed
+anything:
+
+```
+pnpm run validate:rules
+```
+
+Every PR builds, validates and packs the plugin (`test.yml`), and the packed
+file is attached to the run — so a plugin change can be installed on real
+hardware before it is merged.
+
 `pnpm run pack`, not `pnpm pack` — the latter is pnpm's own npm-tarball command
 and shadows the script.
 

--- a/streamdeck-plugin/package.json
+++ b/streamdeck-plugin/package.json
@@ -7,8 +7,9 @@
   "scripts": {
     "build": "node build.mjs",
     "typecheck": "tsc --noEmit",
-    "validate": "streamdeck validate com.timetrack.streamdeck.sdPlugin",
-    "pack": "streamdeck pack com.timetrack.streamdeck.sdPlugin --output dist --force"
+    "validate": "streamdeck validate com.timetrack.streamdeck.sdPlugin --no-update-check",
+    "validate:rules": "streamdeck validate com.timetrack.streamdeck.sdPlugin --force-update-check",
+    "pack": "streamdeck pack com.timetrack.streamdeck.sdPlugin --output dist --force --no-update-check"
   },
   "dependencies": {
     "@elgato/streamdeck": "^2.1.0"


### PR DESCRIPTION
Follow-up to #193, closing the open point stated in its description.

## The gap

#193 added a `pack-streamdeck` job — to `release.yml`, which triggers on tags. So the artifact path was first exercised **while cutting a release**. That is the worst moment to discover that the manifest does not validate, and it is precisely the failure that kept the plugin unshipped through two releases.

## What changed

- **`test.yml` validates and packs on every PR**, right after the plugin build steps from #190. If packing breaks, it breaks on the PR that broke it.
- **The packed file is attached to the run.** A plugin change can now be installed on real hardware *before* merging, instead of after — which matters here, because the plugin's own failure mode is silence (Elgato logs only `Plugin connected`; a crashed plugin is a key that does nothing).
- **Validation rules are pinned.** Both scripts now carry `--no-update-check`. The Elgato CLI otherwise fetches its rules at run time, so a server-side rule change could turn an unrelated PR red — or fail a release mid-flight. The CLI is pinned in the lockfile, so the rules move only when the dependency is bumped on purpose.
- **`pnpm run validate:rules`** is the deliberate counterpart: force a rules update and find out whether Elgato changed anything. Documented in the README, not wired into any gate.

## Verification

- `pnpm run validate` + `pnpm run pack` with pinned rules — green, artifact produced from a clean `dist/`
- `pnpm run validate:rules` against Elgato's current rules — also green, so pinning is not hiding a live failure today
- `pnpm test` — 53 files, 974 passed, 0 skipped; `pnpm lint` 11 warnings, all pre-existing
- Both workflow files parse; the new steps appear in the expected order

🤖 Generated with [Claude Code](https://claude.com/claude-code)
