### PR TITLE
fix(#196): drop the typecheck from the release pack job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,10 +100,18 @@ jobs:
         working-directory: streamdeck-plugin
         run: pnpm install --frozen-lockfile --ignore-workspace
 
-      - name: Typecheck
-        working-directory: streamdeck-plugin
-        run: pnpm typecheck
-
+      # No typecheck here, on purpose (#196). The plugin's tsconfig also covers
+      # its test files, which import `vitest` — and vitest is a dependency of
+      # the ROOT package, not of the plugin. `test.yml` installs the root first
+      # and typechecks there on every pull request, which is the environment
+      # where the check means something. This job has no root install, so
+      # running it here fails on module resolution, not on a type error: that
+      # is what broke the v1.18.0 release run.
+      #
+      # This job's purpose is to produce the artifact. Verification belongs to
+      # the gate that every commit passes before it reaches main — and `pack`
+      # still validates the manifest below, which is the part that can only
+      # fail here.
       - name: Build bundle
         working-directory: streamdeck-plugin
         run: pnpm build

--- a/streamdeck-plugin/README.md
+++ b/streamdeck-plugin/README.md
@@ -75,6 +75,13 @@ hardware before it is merged.
 `pnpm run pack`, not `pnpm pack` — the latter is pnpm's own npm-tarball command
 and shadows the script.
 
+**`pnpm typecheck` needs the repo root installed first.** This tsconfig also
+covers `src/**/*.test.ts`, and those import `vitest`, which is a dependency of
+the root package (the tests run there, as the `streamdeck` Vitest project).
+Without `pnpm install` at the root, the typecheck fails on module resolution
+rather than on a type error. Build, validate and pack are self-contained and do
+not need it — which is why the release job runs only those (#196).
+
 For iterating on the plugin, link the directory instead of installing a package:
 
 ```


### PR DESCRIPTION
Closes #196. **The v1.18.0 release never published** — this unblocks it.

## What happened

The tag ran the workflow, `pack-streamdeck` failed, and since `publish-release` needs it, the entire release was skipped. The Windows installer and the macOS artifacts had built successfully and were thrown away with it.

```
error TS2307: Cannot find module 'vitest' or its corresponding type declarations.
  src/dialImage.test.ts(9,38)
  src/dialModel.test.ts(5,42)
```

## Root cause

The plugin's tsconfig covers `src/**/*.ts` — tests included — and those import `vitest`, which belongs to the **root** package, not the plugin (the tests run there, as the `streamdeck` Vitest project):

```
$ cd streamdeck-plugin && node -p "require.resolve('vitest')"
E:\...\time-tracking\node_modules\vitest\index.cjs        ← root, not plugin
```

`test.yml` installs the root first, so the typecheck passes there. The job added in #193 installs only the plugin, so it fails on **module resolution, not on a type error**.

Worth naming plainly: the assumption was already written down — a comment in `test.yml` warning not to move those steps above the root install — and I did not carry it over when adding the isolated job. And #194, which exists precisely to prove the artifact path on every PR, could not catch this: it proves the path *in an environment the release does not have*. A gate only covers what it actually reproduces.

## Fix

Drop the typecheck from the release job. It produces the artifact; verification belongs to the gate every commit passes before reaching main, where the plugin typecheck keeps running in the environment where it means something. `pack` still validates the manifest — the part that can only fail here.

## Verification

From a wiped `node_modules`, plugin install only — exactly the job's sequence:

```
pnpm install --frozen-lockfile --ignore-workspace   ✔
pnpm build                                          ✔
pnpm run validate                                   ✔ Validation successful
pnpm run pack                                       ✔ 140.844 B
```

The cross-package dependency is now documented in the plugin README rather than living only in a workflow comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
